### PR TITLE
fix(ci): Rule Quality Gate comment best-effort for fork PRs

### DIFF
--- a/.github/workflows/rule-quality.yml
+++ b/.github/workflows/rule-quality.yml
@@ -119,7 +119,12 @@ jobs:
           echo "EOF" >> "$GITHUB_OUTPUT"
 
       - name: Post quality report comment
+        # External-fork PRs receive a read-only GITHUB_TOKEN, so this POST
+        # returns 403 "Resource not accessible by integration". Treat the
+        # comment as best-effort so benchmark + PINT gates still run and
+        # the job status reflects actual quality, not a permission quirk.
         if: steps.changed-rules.outputs.has_changes == 'true'
+        continue-on-error: true
         uses: actions/github-script@v7
         with:
           script: |


### PR DESCRIPTION
## Summary

- External-fork PRs run with a read-only `GITHUB_TOKEN`, so `github-script` 403s when the Rule Quality Gate tries to post a comment on the PR issue.
- The unhandled 403 fails the job before **Benchmark regression gate** and **PINT eval regression check** run, which means every external contribution shows the gate red even when validate + test + security scan are all green.
- One-line fix: add `continue-on-error: true` on the comment step. Own-repo PRs still post comments; fork PRs log the 403 but downstream gates execute.

## Test plan

- [x] PR #5 (external fork, 5 community rules) — all 26 test cases passed locally and in CI, but the gate showed red solely because of the 403.
- [ ] After merge, re-run Rule Quality Gate on PR #5 — expect it to go green (validate + test + benchmark + PINT gates).
- [ ] Next time a fork PR has a real regression, confirm the final `Fail if quality gate not met` step still enforces it (relies on `validate.outputs.validation_status` / `test.outputs.test_status` / `benchmark.outputs.benchmark_status`, not on the comment step).

## Root cause link

See full log on PR #5 run: [#24615430418](https://github.com/Agent-Threat-Rule/agent-threat-rules/actions/runs/24615430418) — "Post quality report comment" step throws `HttpError: Resource not accessible by integration` on `POST /repos/.../issues/5/comments`.