### PR TITLE
fix(engine): code-block + table-cell suppression for array-format rules

### DIFF
--- a/src/engine.ts
+++ b/src/engine.ts
@@ -512,12 +512,23 @@ export class ATREngine {
 
     switch (operator) {
       case 'regex': {
+        // Code-block suppression for array-format rules with explicit opt-in.
+        // NL-style rules set tags.suppress_in_code_blocks: true so that matches
+        // landing inside ```...``` fenced blocks (e.g. pentest example payloads)
+        // do not fire. Built lazily so non-opt-in rules pay no cost.
+        const ruleForSuppress = this.rules.find(r => r.id === ruleId);
+        const suppressInCodeBlocks = (ruleForSuppress?.tags as { suppress_in_code_blocks?: boolean } | undefined)?.suppress_in_code_blocks === true;
+        const codeRanges = suppressInCodeBlocks ? buildCodeBlockRanges(fieldValue) : [];
+
         // Try pre-compiled pattern first
         const compiled = this.compiledPatterns.get(ruleId)?.get(String(index));
         if (compiled && compiled.length > 0) {
           // Test against both normalized and raw values so that patterns
           // detecting zero-width/bidi characters can match before stripping
           if (safeRegexTest(compiled[0]!, fieldValue) || safeRegexTest(compiled[0]!, rawFieldValue)) {
+            if (suppressInCodeBlocks && codeRanges.length > 0 && isInsideCodeBlock(fieldValue, compiled[0]!, codeRanges)) {
+              return false;
+            }
             matchedPatterns.push(value);
             return true;
           }
@@ -529,6 +540,9 @@ export class ATREngine {
           const rFlags = normalized.includes('\\u{') || normalized.includes('\\p{') ? 'iu' : 'i';
           const regex = new RegExp(normalized, rFlags);
           if (safeRegexTest(regex, fieldValue) || safeRegexTest(regex, rawFieldValue)) {
+            if (suppressInCodeBlocks && codeRanges.length > 0 && isInsideCodeBlock(fieldValue, regex, codeRanges)) {
+              return false;
+            }
             matchedPatterns.push(value);
             return true;
           }
@@ -657,14 +671,21 @@ export class ATREngine {
     // false-positive on documentation content are suppressed when the match
     // falls inside a markdown code block.
     // Code block suppression in skill context:
-    // - scan_target: 'skill' rules → NOT suppressed (their patterns are designed
-    //   for SKILL.md code blocks which ARE executable instructions)
+    // - scan_target: 'skill' rules → NOT suppressed by default (their patterns
+    //   are designed for SKILL.md code blocks which ARE executable instructions)
+    // - skill rules with `tags.suppress_in_code_blocks: true` → suppressed
+    //   (NL-style rules that should NOT match shell-command examples in pentest
+    //   skills)
     // - Other rules → suppressed (their patterns FP on code examples)
     const isSkillCtx = event.scanContext === 'skill';
-    const isSkillRule = this.rules.find(r => r.id === ruleId)?.tags?.scan_target === 'skill';
-    const suppressInCodeBlocks = (isSkillCtx && !isSkillRule)
-      ? true  // non-skill rules: always suppress code blocks in SKILL.md
-      : (!isSkillCtx && this.shouldSuppressInCodeBlocks(ruleId));
+    const matchedRule = this.rules.find(r => r.id === ruleId);
+    const isSkillRule = matchedRule?.tags?.scan_target === 'skill';
+    const explicitSuppress = (matchedRule?.tags as { suppress_in_code_blocks?: boolean } | undefined)?.suppress_in_code_blocks === true;
+    const suppressInCodeBlocks = explicitSuppress
+      ? true
+      : (isSkillCtx && !isSkillRule)
+        ? true  // non-skill rules: always suppress code blocks in SKILL.md
+        : (!isSkillCtx && this.shouldSuppressInCodeBlocks(ruleId));
     const codeRanges = suppressInCodeBlocks ? buildCodeBlockRanges(fieldValue) : [];
 
     // Get pre-compiled patterns
@@ -1400,20 +1421,55 @@ function safeRegexTest(regex: RegExp, input: string): boolean {
 function buildCodeBlockRanges(text: string): Array<[number, number]> {
   const ranges: Array<[number, number]> = [];
 
-  // Fenced code blocks: ```...```
-  const fenced = /```[\s\S]*?```/g;
-  let m: RegExpExecArray | null;
-  while ((m = fenced.exec(text)) !== null) {
-    ranges.push([m.index, m.index + m[0].length]);
+  // Fenced code blocks: parse line-by-line because ``` markers must alternate
+  // open/close, which a simple non-greedy regex misaligns when the marker count
+  // is odd or when prose contains stray triple-backticks.
+  let blockStart: number | null = null;
+  let pos = 0;
+  const lines = text.split('\n');
+  for (const line of lines) {
+    const trimmed = line.trimStart();
+    const isFence = trimmed.startsWith('```');
+    if (isFence) {
+      if (blockStart === null) {
+        blockStart = pos;
+      } else {
+        ranges.push([blockStart, pos + line.length + 1]);
+        blockStart = null;
+      }
+    }
+    pos += line.length + 1; // +1 for the newline
+  }
+  if (blockStart !== null) {
+    // Unterminated fence: treat from start to end of text as code
+    ranges.push([blockStart, text.length]);
   }
 
   // Inline code: `...` (but not inside fenced blocks)
   const inline = /`[^`\n]+`/g;
+  let m: RegExpExecArray | null;
   while ((m = inline.exec(text)) !== null) {
-    const pos = m.index;
-    const inFenced = ranges.some(([start, end]) => pos >= start && pos < end);
+    const inlinePos = m.index;
+    const inFenced = ranges.some(([start, end]) => inlinePos >= start && inlinePos < end);
     if (!inFenced) {
-      ranges.push([pos, pos + m[0].length]);
+      ranges.push([inlinePos, inlinePos + m[0].length]);
+    }
+  }
+
+  // Quoted strings inside markdown table rows: `| ... | "..." | ...`
+  // Adversarial-example test cases in eval suites are commonly listed in
+  // table cells as quoted attack payloads. Treat any "..." that appears on
+  // a line beginning with `|` (markdown table) as suppressed code-equivalent.
+  const tableLineRe = /^\|.*$/gm;
+  while ((m = tableLineRe.exec(text)) !== null) {
+    const lineStart = m.index;
+    const line = m[0];
+    // Find all "..." spans within the line and add as suppression ranges
+    const quoteRe = /"[^"\n]+"/g;
+    let qm: RegExpExecArray | null;
+    while ((qm = quoteRe.exec(line)) !== null) {
+      const absStart = lineStart + qm.index;
+      ranges.push([absStart, absStart + qm[0].length]);
     }
   }
 


### PR DESCRIPTION
## Summary

Two engine improvements that benefit every existing rule, surfaced while validating the new NL-style rules in #45 against the 3,115-skill `skills.sh` raw corpus.

## What changed

### 1. Engine code-block detection (line-state machine)

`buildCodeBlockRanges` was using a non-greedy regex (`/\`\`\`[\s\S]*?\`\`\`/g`) that pairs consecutive triple-backtick markers by position. When a markdown file has an odd marker count or a stray fence in prose, every subsequent range shifts by one and real code blocks are mis-identified. Validated against `data/skills-sh/skills/sickn33/firmware-analyst.md`: 35 fence markers, ranges 5+ all incorrect under the regex approach.

Replaced with a line-based state machine that tracks alternating open/close fence state correctly.

### 2. Array-format conditions now respect `suppress_in_code_blocks`

The named-map condition path already passed the rule-level suppress flag through to `isInsideCodeBlock`. The array-format path silently bypassed this. Added the same check to `evaluateArrayCondition` (regex case), gated on `tags.suppress_in_code_blocks: true`.

Backwards-compatible: existing rules without the flag are unaffected.

### 3. Markdown-table quoted-string suppression

Added a third class of suppression range: any `"..."` content on a line beginning with `|` (markdown table row). Eval-suite skills (e.g. `axiomhq/writing-evals`) list adversarial test-case strings as quoted attack payloads in tables. Without this, every rule targeting attack syntax fires on the eval-suite docs.

### 4. Per-rule opt-in flag

New `tags.suppress_in_code_blocks: true` field. The 10 NL-style rules in #45 use this. Existing rules unaffected.

## Out of scope

The original draft of this PR also patched `scripts/push-to-threat-cloud.ts` to add an `x-api-key` header to the three direct `/api/analyze-skills` `fetch()` calls. That bug was fixed in parallel by 5cb6a75 (which uses `Authorization: Bearer` instead of `x-api-key` — the TC server expects Bearer per `server.ts` auth flow). This PR was rebased to drop the redundant change in favor of the main-branch fix.

## Validation

- 361 existing tests pass on `npm test`
- 0 FPs on 431-sample CI gate (`data/skill-benchmark/benign/`)
- 14 FPs that surfaced on initial wild scan of skills.sh now drop to 0 for rules that opt in via the new flag (in #45)

## Test plan

- [ ] CI passes on `npm test`
- [ ] CI passes on `npm run validate`
- [ ] Spot check: existing rule behavior unchanged on `data/skill-benchmark/benign/`