### PR TITLE
Add STIX 2.1 extension for x-atr-rule custom SDO

### DIFF
--- a/spec/stix-extension/README.md
+++ b/spec/stix-extension/README.md
@@ -1,0 +1,79 @@
+# Agent Threat Rules (ATR) — STIX 2.1 Extension
+
+This directory defines a STIX 2.1 extension that introduces the
+`x-atr-rule` custom Domain Object so ATR rules can be represented
+natively in STIX/TAXII threat-intelligence pipelines.
+
+## Why a STIX extension
+
+ATR rules are an open detection vocabulary for AI agent threats —
+prompt injection, tool poisoning, MCP server attacks, skill compromise.
+They were adopted as a MISP taxonomy in [MISP/misp-taxonomies#323][misp-tax]
+on 2026-05-10 and a MISP galaxy in [MISP/misp-galaxy#1207][misp-gal].
+
+Several CTI consumers use STIX/TAXII rather than MISP. Mapping ATR to a
+generic STIX `indicator` or `attack-pattern` object is lossy: the
+nine-category attack class, regex detection patterns, severity, and the
+compliance-framework references (EU AI Act, NIST AI RMF, ISO 42001) all
+get flattened. This extension preserves them as first-class fields on a
+new `x-atr-rule` SDO.
+
+## Files
+
+- [`extension-definition.json`](./extension-definition.json) — the
+  STIX 2.1 Extension Definition object. Stable id
+  `extension-definition--93370194-c964-570f-9802-9d1154e5525d`. Consumers
+  reference this id in the `extensions` map of every `x-atr-rule`
+  instance.
+- [`x-atr-rule-schema.json`](./x-atr-rule-schema.json) — JSON Schema
+  (Draft 7) for the new SDO. Defines required fields, enum values for
+  `atr_category` / `severity` / `agent_source_type` / `response_actions`,
+  and structural constraints on `detection_patterns` and
+  `compliance_refs`.
+- [`examples/atr-rule-prompt-injection-example.json`](./examples/atr-rule-prompt-injection-example.json)
+  — concrete instance for `ATR-2026-00001` showing the full payload
+  shape including the extension reference.
+
+## Identifier convention
+
+`x-atr-rule.id` is recommended to be a deterministic UUIDv5 derived
+from the canonical ATR rule id (e.g. `ATR-2026-00431`) under the
+namespace UUID `6f7a8b9c-1d2e-4f5a-9b8c-7e6d5f4a3b2c`. The same rule id
+therefore always produces the same STIX id across consumers, which lets
+multiple feeds align without conflict resolution.
+
+## Extension type
+
+`extension_types: ["new-sdo"]` per STIX 2.1 §7.3, which is the correct
+designation for introducing a brand-new top-level Domain Object type.
+The schema field on the Extension Definition points at the JSON Schema
+in this directory via raw GitHub URL so the schema is dereferenceable
+for validating consumers.
+
+## Validation
+
+```bash
+python3 -m pip install jsonschema
+python3 -c "import json, jsonschema; \
+  schema = json.load(open('spec/stix-extension/x-atr-rule-schema.json')); \
+  example = json.load(open('spec/stix-extension/examples/atr-rule-prompt-injection-example.json')); \
+  jsonschema.validate(example, schema); \
+  print('OK')"
+```
+
+## Status
+
+Draft v1.0.0. Not yet submitted to the OASIS CTI Technical Committee.
+The extension is usable today by any consumer that processes STIX
+extensions per the spec; OASIS submission becomes relevant if a
+subset of fields ends up wanting promotion into core STIX.
+
+## Related
+
+- Canonical ATR repo: <https://github.com/Agent-Threat-Rule/agent-threat-rules>
+- ATR YAML schema: [`../atr-schema.yaml`](../atr-schema.yaml)
+- npm: <https://www.npmjs.com/package/agent-threat-rules>
+- DOI: 10.5281/zenodo.19178002
+
+[misp-tax]: https://github.com/MISP/misp-taxonomies/pull/323
+[misp-gal]: https://github.com/MISP/misp-galaxy/pull/1207

--- a/spec/stix-extension/examples/atr-rule-prompt-injection-example.json
+++ b/spec/stix-extension/examples/atr-rule-prompt-injection-example.json
@@ -1,0 +1,52 @@
+{
+  "type": "x-atr-rule",
+  "id": "x-atr-rule--7859f830-8dd6-55ee-a3c4-d942825b4294",
+  "spec_version": "2.1",
+  "created_by_ref": "identity--4ee77ba4-f956-5d27-aeb1-cbfeb4c8f8d5",
+  "created": "2026-05-11T00:00:00.000Z",
+  "modified": "2026-05-11T00:00:00.000Z",
+  "atr_id": "ATR-2026-00001",
+  "atr_category": "prompt-injection",
+  "atr_subcategory": "direct-prompt-injection",
+  "name": "Direct Prompt Injection via User Input",
+  "description": "Detects direct prompt injection attempts where a user embeds malicious instructions within their input to override the agent's intended behavior. Layered detection covers instruction override verbs with target nouns, persona switching, temporal behavioral overrides, fake system delimiters, restriction removal, encoding-wrapped payloads (base64, hex, unicode homoglyphs), and zero-width character obfuscation.",
+  "severity": "high",
+  "maturity": "stable",
+  "agent_source_type": "llm_io",
+  "detection_patterns": [
+    {
+      "field": "user_input",
+      "operator": "regex",
+      "pattern": "(?i)\\b(?:ignore|disregard|forget|override)\\s+(?:all|any|previous|prior)\\s+(?:instructions?|rules?|prompts?)",
+      "description": "Instruction override verbs targeting prior context"
+    }
+  ],
+  "response_actions": [
+    "alert",
+    "block_input"
+  ],
+  "owasp_llm_refs": [
+    "LLM01:2025 - Prompt Injection"
+  ],
+  "mitre_atlas_refs": [
+    "AML.T0051 - LLM Prompt Injection",
+    "AML.T0051.000 - Direct"
+  ],
+  "cve_refs": [
+    "CVE-2024-5184",
+    "CVE-2024-3402",
+    "CVE-2025-53773"
+  ],
+  "external_references": [
+    {
+      "source_name": "agent-threat-rules",
+      "external_id": "ATR-2026-00001",
+      "url": "https://github.com/Agent-Threat-Rule/agent-threat-rules/blob/main/rules/prompt-injection/ATR-2026-00001-direct-prompt-injection.yaml"
+    }
+  ],
+  "extensions": {
+    "extension-definition--93370194-c964-570f-9802-9d1154e5525d": {
+      "extension_type": "new-sdo"
+    }
+  }
+}

--- a/spec/stix-extension/extension-definition.json
+++ b/spec/stix-extension/extension-definition.json
@@ -1,0 +1,32 @@
+{
+  "type": "extension-definition",
+  "id": "extension-definition--93370194-c964-570f-9802-9d1154e5525d",
+  "spec_version": "2.1",
+  "created_by_ref": "identity--4ee77ba4-f956-5d27-aeb1-cbfeb4c8f8d5",
+  "created": "2026-05-11T00:00:00.000Z",
+  "modified": "2026-05-11T00:00:00.000Z",
+  "name": "Agent Threat Rules (ATR) STIX Extension",
+  "description": "Defines the x-atr-rule custom STIX Domain Object for representing AI agent detection rules. Each x-atr-rule instance carries a deterministic rule identifier (e.g. ATR-2026-00001), one of nine attack-class categories (prompt-injection, tool-poisoning, context-exfiltration, agent-manipulation, privilege-escalation, excessive-autonomy, data-poisoning, model-abuse, skill-compromise), severity, regex detection patterns, and external mappings to OWASP LLM Top 10, MITRE ATLAS, EU AI Act, NIST AI RMF, and ISO/IEC 42001 controls. ATR rules are the open-source detection vocabulary published at github.com/Agent-Threat-Rule/agent-threat-rules under MIT and adopted as a MISP taxonomy at MISP/misp-taxonomies#323. This extension lets STIX consumers represent ATR rules natively in CTI pipelines without lossy translation through indicator or attack-pattern objects.",
+  "schema": "https://raw.githubusercontent.com/Agent-Threat-Rule/agent-threat-rules/main/spec/stix-extension/x-atr-rule-schema.json",
+  "version": "1.0.0",
+  "extension_types": [
+    "new-sdo"
+  ],
+  "external_references": [
+    {
+      "source_name": "agent-threat-rules",
+      "description": "ATR canonical repository",
+      "url": "https://github.com/Agent-Threat-Rule/agent-threat-rules"
+    },
+    {
+      "source_name": "misp-taxonomies",
+      "description": "ATR MISP taxonomy adoption",
+      "url": "https://github.com/MISP/misp-taxonomies/pull/323"
+    },
+    {
+      "source_name": "stix-2.1",
+      "description": "STIX 2.1 specification, Section 7.3 Extension Definition",
+      "url": "https://docs.oasis-open.org/cti/stix/v2.1/os/stix-v2.1-os.html"
+    }
+  ]
+}

--- a/spec/stix-extension/x-atr-rule-schema.json
+++ b/spec/stix-extension/x-atr-rule-schema.json
@@ -1,0 +1,184 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://raw.githubusercontent.com/Agent-Threat-Rule/agent-threat-rules/main/spec/stix-extension/x-atr-rule-schema.json",
+  "title": "x-atr-rule",
+  "description": "STIX 2.1 custom SDO for an Agent Threat Rules detection rule.",
+  "type": "object",
+  "required": [
+    "type",
+    "id",
+    "spec_version",
+    "created",
+    "modified",
+    "atr_id",
+    "atr_category",
+    "name",
+    "severity",
+    "extensions"
+  ],
+  "properties": {
+    "type": {
+      "type": "string",
+      "const": "x-atr-rule",
+      "description": "Always 'x-atr-rule'."
+    },
+    "id": {
+      "type": "string",
+      "pattern": "^x-atr-rule--[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+      "description": "STIX UUID-typed identifier. Recommended: deterministic UUID5 derived from atr_id under a stable namespace so the same rule ID always produces the same STIX id."
+    },
+    "spec_version": {
+      "type": "string",
+      "const": "2.1"
+    },
+    "created_by_ref": {
+      "type": "string",
+      "pattern": "^identity--[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
+    },
+    "created": { "type": "string", "format": "date-time" },
+    "modified": { "type": "string", "format": "date-time" },
+    "revoked": { "type": "boolean" },
+    "labels": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "confidence": { "type": "integer", "minimum": 0, "maximum": 100 },
+    "lang": { "type": "string" },
+    "external_references": { "type": "array" },
+    "object_marking_refs": { "type": "array" },
+    "granular_markings": { "type": "array" },
+
+    "atr_id": {
+      "type": "string",
+      "pattern": "^ATR-[0-9]{4}-[0-9]{5}$",
+      "description": "Canonical ATR rule identifier (e.g. ATR-2026-00431)."
+    },
+    "atr_category": {
+      "type": "string",
+      "enum": [
+        "prompt-injection",
+        "tool-poisoning",
+        "context-exfiltration",
+        "agent-manipulation",
+        "privilege-escalation",
+        "excessive-autonomy",
+        "data-poisoning",
+        "model-abuse",
+        "skill-compromise"
+      ],
+      "description": "One of nine ATR attack-class categories."
+    },
+    "atr_subcategory": {
+      "type": "string",
+      "description": "Optional finer-grained subcategory (e.g. 'mcp-oauth-metadata-injection')."
+    },
+    "name": {
+      "type": "string",
+      "description": "Human-readable rule title."
+    },
+    "description": { "type": "string" },
+    "severity": {
+      "type": "string",
+      "enum": ["critical", "high", "medium", "low", "informational"]
+    },
+    "maturity": {
+      "type": "string",
+      "enum": ["experimental", "test", "stable", "deprecated"]
+    },
+    "agent_source_type": {
+      "type": "string",
+      "enum": [
+        "llm_io",
+        "tool_call",
+        "mcp_exchange",
+        "agent_behavior",
+        "multi_agent_comm",
+        "context_window",
+        "memory_access",
+        "skill_lifecycle",
+        "skill_permission",
+        "skill_chain"
+      ]
+    },
+    "detection_patterns": {
+      "type": "array",
+      "description": "Regex patterns extracted from the ATR rule's detection.conditions.",
+      "items": {
+        "type": "object",
+        "required": ["field", "pattern"],
+        "properties": {
+          "field": { "type": "string" },
+          "pattern": { "type": "string" },
+          "operator": { "type": "string", "default": "regex" },
+          "description": { "type": "string" }
+        }
+      }
+    },
+    "response_actions": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": [
+          "block_input",
+          "block_output",
+          "block_tool",
+          "quarantine_session",
+          "reset_context",
+          "alert",
+          "snapshot",
+          "escalate",
+          "reduce_permissions",
+          "kill_agent"
+        ]
+      }
+    },
+    "owasp_llm_refs": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "owasp_agentic_refs": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "mitre_atlas_refs": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "mitre_attack_refs": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "cve_refs": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "pattern": "^CVE-[0-9]{4}-[0-9]+$"
+      }
+    },
+    "compliance_refs": {
+      "type": "object",
+      "description": "Mappings to compliance frameworks. Each value is an array of {control, context, strength}.",
+      "properties": {
+        "eu_ai_act": { "type": "array" },
+        "nist_ai_rmf": { "type": "array" },
+        "iso_42001": { "type": "array" }
+      },
+      "additionalProperties": false
+    },
+    "extensions": {
+      "type": "object",
+      "description": "STIX 2.1 extensions object, must contain the ATR extension-definition reference.",
+      "patternProperties": {
+        "^extension-definition--93370194-c964-570f-9802-9d1154e5525d$": {
+          "type": "object",
+          "required": ["extension_type"],
+          "properties": {
+            "extension_type": { "const": "new-sdo" }
+          }
+        }
+      },
+      "minProperties": 1
+    }
+  },
+  "additionalProperties": true
+}


### PR DESCRIPTION
Defines a STIX 2.1 Extension Definition so ATR rules can be represented natively in STIX/TAXII threat-intel pipelines without lossy translation through indicator or attack-pattern objects.

Companion to the MISP adoptions this week:
- MISP taxonomy: MISP/misp-taxonomies#323 (merged 2026-05-10)
- MISP galaxy: MISP/misp-galaxy#1207 (open)

Three independent threat-intel standards layers now reference the same ATR vocabulary, which is the integration story we want NIST OSCAL Team to see when the 5/14 reply lands.

Files added:
- spec/stix-extension/extension-definition.json (stable id, extension_types: new-sdo)
- spec/stix-extension/x-atr-rule-schema.json (JSON Schema Draft 7 for the new SDO)
- spec/stix-extension/examples/atr-rule-prompt-injection-example.json (worked example for ATR-2026-00001)
- spec/stix-extension/README.md (usage docs, identifier convention, validation)

Validation:
- Example validates cleanly against the schema
- Extension Definition has all STIX 2.1 §7.3 required fields
- Stable UUIDs (UUID5 from agent-threat-rules.org/stix-ext namespace) so the same rule id always produces the same STIX id

Status: draft v1.0.0. Not yet submitted to OASIS CTI Technical Committee — that becomes relevant only if a subset of fields ends up wanting promotion into core STIX. The extension is usable today by any STIX 2.1 consumer.