### PR TITLE
fix(cve-pipeline): remove jailbreak sources, fix non-fast-forward push

### DIFF
--- a/.github/workflows/cve-daily-sync.yml
+++ b/.github/workflows/cve-daily-sync.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       source:
-        description: "Run only one source (cisa-kev | avid-db | ghsa). Empty = all."
+        description: "Run only one source (cisa-kev | avid-db | ghsa | nvd). Empty = all."
         required: false
         default: ""
 
@@ -89,6 +89,8 @@ jobs:
           set -e
           DATE=$(date -u +%Y-%m-%d)
           BRANCH="cve-collect/$DATE"
+          # Delete the remote branch if it already exists (re-run idempotency).
+          git push origin --delete "$BRANCH" 2>/dev/null || true
           git checkout -b "$BRANCH"
           git commit -m "feat(proposals): daily CVE collector — ${{ steps.collect.outputs.new_proposals }} new proposals ($DATE)"
           git push origin "$BRANCH"
@@ -101,6 +103,12 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -e
+          DATE="${{ steps.push.outputs.date }}"
+          BRANCH="${{ steps.push.outputs.branch }}"
+
+          # If a PR already exists for this branch, update its body; otherwise create.
+          EXISTING_PR=$(gh pr list --head "$BRANCH" --json number -q '.[0].number' 2>/dev/null || true)
+
           REPORT=$(cat data/cve-collector/last-run.json)
           SUMMARY_TABLE=$(echo "$REPORT" | python3 -c "
           import sys, json
@@ -125,7 +133,7 @@ jobs:
           print(f\"- Proposals tracking-only: **{c['proposals_tracking_only']}**\")
           ")
           PR_BODY=$(cat <<EOF
-          Auto-generated batch PR from the daily CVE collector ($(date -u +%Y-%m-%d)).
+          Auto-generated batch PR from the daily CVE collector ($DATE).
 
           ## Per-source results
 
@@ -146,13 +154,19 @@ jobs:
           See \`data/cve-collector/last-run.json\` for the full JSON report.
           EOF
           )
-          gh pr create \
-            --title "feat(proposals): daily CVE collector — ${{ steps.push.outputs.date }}" \
-            --body "$PR_BODY" \
-            --label "cve-collector,auto-generated" \
-            --draft \
-            --base main \
-            --head "${{ steps.push.outputs.branch }}"
+
+          if [ -n "$EXISTING_PR" ]; then
+            gh pr edit "$EXISTING_PR" --body "$PR_BODY"
+            echo "Updated existing PR #$EXISTING_PR"
+          else
+            gh pr create \
+              --title "feat(proposals): daily CVE collector — $DATE" \
+              --body "$PR_BODY" \
+              --label "cve-collector,auto-generated" \
+              --draft \
+              --base main \
+              --head "$BRANCH"
+          fi
 
       - name: Failure summary
         if: failure()

--- a/scripts/cve-collect.ts
+++ b/scripts/cve-collect.ts
@@ -12,9 +12,8 @@
  *   2. AVID-DB          scripts/sync-avid-db.ts    -> proposals/avid/
  *   3. GHSA             scripts/sync-ghsa.ts        -> proposals/ghsa/
  *   4. NVD AI-filter    scripts/sync-nvd-ai.ts      -> proposals/nvd/
- *   5. Pliny corpus     scripts/sync-pliny.ts        -> proposals/pliny/
  *   (planned)
- *   6. Huntr.dev        scripts/sync-huntr.ts       -> proposals/huntr/
+ *   5. Huntr.dev        scripts/sync-huntr.ts       -> proposals/huntr/
  *
  * Output:
  *   - Writes per-source proposal files (delegated to each sync script).
@@ -108,26 +107,6 @@ const SOURCES: SourceDef[] = [
     proposalsDir: "nvd",
     summaryMarker: "::nvd-summary::",
     description: "NVD CVE feed (AI/agent/LLM keyword-filtered)",
-  },
-  {
-    id: "pliny",
-    script: "sync-pliny.ts",
-    proposalsDir: "pliny",
-    summaryMarker: "::pliny-summary::",
-    description: "Pliny L1B3RT4S community jailbreak corpus (MIT)",
-  },
-  {
-    // sync-advbench.ts processes 3 sub-corpora (AdvBench, HarmBench,
-    // JailbreakBench) in one pass; the proposalsDir counted below is the
-    // parent advbench/ folder, but the script writes into 3 sibling
-    // dirs (advbench/, harmbench/, jailbreakbench/) so the orchestrator
-    // reads combined totals via the summary marker.
-    id: "advbench",
-    script: "sync-advbench.ts",
-    proposalsDir: "advbench",
-    summaryMarker: "::advbench-summary::",
-    description:
-      "Academic adversarial-prompt benchmarks (AdvBench + HarmBench + JailbreakBench)",
   },
 ];
 


### PR DESCRIPTION
Two fixes to the daily CVE collector workflow that have been causing every run to fail.

## What broke

1. Non-fast-forward push rejection: `cve-daily-sync.yml` creates branch `cve-collect/YYYY-MM-DD` but if the workflow runs twice on the same day (re-trigger after a failed run), the second run hits:

```
! [rejected] cve-collect/2026-05-20 -> cve-collect/2026-05-20 (non-fast-forward)
```

2. Wrong data sources: `pliny` (jailbreak prompts) and `advbench`/`harmbench`/`jailbreakbench` (adversarial LLM benchmarks) were included as CVE sources. These are academic jailbreak datasets not AI agent security CVEs. They generated 500+ irrelevant proposals about bomb-making, terrorism, etc.

## Fixes

- `cve-daily-sync.yml`: delete remote branch before pushing so re-runs on the same day succeed cleanly
- `cve-daily-sync.yml`: detect existing PR for today's branch and update its body instead of failing on duplicate `gh pr create`
- `scripts/cve-collect.ts`: remove `pliny` and `advbench` from SOURCES — CVE pipeline should only pull from authoritative vulnerability databases (CISA KEV, AVID, GHSA, NVD)

## Test plan

- Trigger workflow twice on the same day — second run should succeed
- Verify proposals directory no longer receives pliny/advbench/harmbench output
- Confirm CISA KEV, AVID, GHSA, NVD sources still run normally