### PR TITLE
feat(pipeline): issue → proposal automation

### DIFF
--- a/.github/workflows/issue-to-proposal.yml
+++ b/.github/workflows/issue-to-proposal.yml
@@ -1,0 +1,133 @@
+name: Issue → Proposal
+
+on:
+  issues:
+    types: [opened, labeled]
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  convert:
+    if: contains(github.event.issue.labels.*.name, 'new-rule')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install deps
+        run: npm ci
+
+      - name: Write issue body to file
+        env:
+          BODY: ${{ github.event.issue.body }}
+        run: printf '%s' "$BODY" > /tmp/issue-body.txt
+
+      - name: Convert issue to proposal
+        id: convert
+        env:
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          TITLE: ${{ github.event.issue.title }}
+          AUTHOR: ${{ github.event.issue.user.login }}
+        run: |
+          set -e
+          npx tsx scripts/issue-to-proposal.ts \
+            --issue "$ISSUE_NUMBER" \
+            --title "$TITLE" \
+            --body-file /tmp/issue-body.txt \
+            --author "$AUTHOR" \
+            --write | tee /tmp/convert.out
+          # Extract the proposal file path from output marker
+          PROPOSAL_FILE=$(grep "::proposal-file::" /tmp/convert.out | sed 's/::proposal-file:://')
+          echo "proposal_file=$PROPOSAL_FILE" >> "$GITHUB_OUTPUT"
+          echo "Proposal file: $PROPOSAL_FILE"
+
+      - name: Configure git
+        run: |
+          git config user.name "ATR Issue Bot"
+          git config user.email "issues@agentthreatrule.org"
+
+      - name: Create branch + commit + push
+        id: push
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -e
+          BRANCH="proposal/issue-${{ github.event.issue.number }}-$(echo '${{ github.event.issue.title }}' | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/-/g' | sed 's/-\+/-/g' | cut -c1-50)"
+          git push origin --delete "$BRANCH" 2>/dev/null || true
+          git checkout -b "$BRANCH"
+          git add proposals/community/
+          git commit -m "feat(proposals): community issue #${{ github.event.issue.number }} — ${{ github.event.issue.title }}"
+          git push origin "$BRANCH"
+          echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
+
+      - name: Open draft PR
+        id: pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -e
+          PR_URL=$(gh pr create \
+            --title "feat(proposals): community issue #${{ github.event.issue.number }} — ${{ github.event.issue.title }}" \
+            --body "$(cat <<'EOF'
+          Community rule proposal from GitHub Issue #${{ github.event.issue.number }}.
+
+          Submitted by @${{ github.event.issue.user.login }}.
+
+          ## What to do next
+
+          1. Open `${{ steps.convert.outputs.proposal_file }}` in this PR
+          2. Author a detection regex in `detection.conditions`
+          3. Fill in `test_cases.true_positives` from the `_triage.example_payload`
+          4. Run locally: `npx tsx scripts/check-rules-safety.ts ${{ steps.convert.outputs.proposal_file }}`
+          5. Once 0 FP — remove the `needs-regex` label and request review
+
+          The proposal will not auto-merge until detection conditions are filled in and pass the safety gate.
+
+          Closes #${{ github.event.issue.number }}
+          EOF
+          )" \
+            --label "cve-collector,auto-generated" \
+            --draft \
+            --base main \
+            --head "${{ steps.push.outputs.branch }}" 2>&1)
+          echo "pr_url=$PR_URL" >> "$GITHUB_OUTPUT"
+          echo "PR: $PR_URL"
+
+      - name: Comment on issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh issue comment ${{ github.event.issue.number }} --body "$(cat <<'EOF'
+          Thanks @${{ github.event.issue.user.login }}! A draft proposal has been created from this issue.
+
+          **Next step:** A maintainer (or you!) needs to author a detection regex. Draft PR: ${{ steps.pr.outputs.pr_url }}
+
+          To contribute the regex yourself:
+          1. Clone the repo and check out the branch in the PR above
+          2. Open the proposal file and fill in `detection.conditions`
+          3. Run `npx tsx scripts/check-rules-safety.ts <proposal-file>` — must pass 0 FP
+          4. Push and mark the PR ready for review
+
+          See [how-to-write-a-rule.md](https://github.com/Agent-Threat-Rule/agent-threat-rules/blob/main/examples/how-to-write-a-rule.md) for a walkthrough.
+          EOF
+          )"
+
+      - name: Failure comment
+        if: failure()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh issue comment ${{ github.event.issue.number }} --body "$(cat <<'EOF'
+          The bot failed to convert this issue into a proposal automatically. A maintainer will review manually.
+
+          If you filed this issue, make sure the **Attack Type**, **Description**, and **Example Attack Payload** fields are filled in — they are required.
+          EOF
+          )"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,39 +1,50 @@
 # Contributing to ATR
 
-ATR is MIT-licensed. Contributing requires a text editor, a YAML file,
-and `npx agent-threat-rules test`. Nothing else.
+ATR is MIT-licensed. No proprietary tooling. No telemetry. No CLA.
 
-No proprietary tooling. No telemetry. No CLA.
+---
 
-ATR is community-maintained and governed as an open standard.
-Rules contributed here are MIT-licensed and belong to the community.
+## Fastest path: open a GitHub Issue
+
+Spotted an attack pattern? File a **[New Rule Proposal](https://github.com/Agent-Threat-Rule/agent-threat-rules/issues/new?template=new-rule.yml)** issue. Fill in three fields — attack type, description, example payload. A bot converts it to a draft proposal within minutes and opens a PR. You don't need to clone the repo.
+
+A maintainer (or you) authors the detection regex from there.
 
 ---
 
 ## How to Contribute
 
-ATR accepts contributions through both traditional open source workflows
-and AI-native workflows. In the age of AI agents, contributing to a
-security standard should not be limited to writing regex by hand.
+#### A. Propose a New Rule via Issue (~5 minutes, no repo setup needed)
 
-### Traditional Contributions
+1. Open a **[New Rule Proposal](https://github.com/Agent-Threat-Rule/agent-threat-rules/issues/new?template=new-rule.yml)** issue.
+2. Fill in: attack type, description, and at least one example payload.
+3. A bot creates `proposals/community/ISSUE-{number}-{slug}.proposal.yaml` and opens a draft PR automatically.
+4. The proposal is queued for regex authoring. You can stop here, or continue to step 5.
+5. Optional: check out the PR branch, fill in `detection.conditions`, run `npx tsx scripts/check-rules-safety.ts <file>`, push.
 
-#### A. Report an Evasion (~15 minutes)
+Every filed issue becomes a tracked proposal. Your name appears in the `author` field of any rule that ships from it.
 
-Found a way to bypass an existing rule? This is the most valuable contribution.
+#### B. Write the Regex for an Existing Proposal (~30–60 minutes)
 
-1. Check the rule's existing `evasion_tests` section and [LIMITATIONS.md](./LIMITATIONS.md)
-   to verify the bypass is not already documented.
+The `proposals/` directory has CVE-sourced drafts that have payloads but no detection logic yet. These are the fastest contributions to ship.
+
+1. Browse `proposals/` for files with `_triage.detection_ready: true`
+2. Pick one, check out a branch, fill in `detection.conditions` based on the `_triage.example_payload`
+3. Run `npx agent-threat-rules test <file>` — must pass all test cases
+4. Run `npx tsx scripts/check-rules-safety.ts <file>` — must show 0 FP
+5. Submit a PR
+
+#### C. Report an Evasion (~15 minutes)
+
+Found a way to bypass an existing rule?
+
+1. Check the rule's `evasion_tests` section and [LIMITATIONS.md](./LIMITATIONS.md) — might already be documented.
 2. Open an issue using the **Evasion Report** template.
 3. Include: rule ID, bypass input, technique used, why it works.
 
-Every confirmed evasion becomes a new `evasion_tests` entry in the rule YAML.
-You get credited in [CONTRIBUTORS.md](./CONTRIBUTORS.md).
+Every confirmed evasion becomes a new `evasion_tests` entry. You get credited in [CONTRIBUTORS.md](./CONTRIBUTORS.md). We publish evasion tests openly — your bypass makes the project more honest.
 
-We already know regex has limits. We publish evasion tests openly.
-Your bypass makes the project more honest.
-
-#### B. Report a False Positive (~20 minutes)
+#### D. Report a False Positive (~20 minutes)
 
 A rule triggered on legitimate content?
 
@@ -42,9 +53,9 @@ A rule triggered on legitimate content?
 
 Confirmed false positives become new `true_negatives` test cases.
 
-#### C. Submit a New Rule (1-2 hours)
+#### E. Submit a New Rule Directly (~1 hour)
 
-Write a full detection rule for a new attack pattern.
+Write a full detection rule from scratch.
 
 1. Fork this repository
 2. Create a YAML file in the appropriate `rules/<category>/` subdirectory
@@ -58,7 +69,7 @@ Write a full detection rule for a new attack pattern.
 Security standards in the AI era need AI-era contribution workflows.
 You do not have to write YAML by hand to make ATR better.
 
-#### D. Scan and Report (~2 minutes)
+#### F. Scan and Report (~2 minutes)
 
 Run ATR against your MCP skills or any public skill. Findings go to
 Threat Cloud for aggregation (anonymized, opt-in via `--report-to-cloud`).
@@ -74,7 +85,7 @@ When TC aggregates enough signals for a new attack pattern, it
 crystallizes a draft rule, opens a PR to this repo, and a human
 reviewer merges it. Your scan data becomes part of the global defense.
 
-#### E. Add ATR to Your CI (~5 minutes)
+#### G. Add ATR to Your CI (~5 minutes)
 
 Add one file to your repo. Every PR gets scanned automatically.
 
@@ -95,7 +106,7 @@ jobs:
 
 Results appear in GitHub's Security tab as code scanning alerts.
 
-#### F. Contribute via LLM-Assisted Rule Generation
+#### H. Contribute via LLM-Assisted Rule Generation
 
 Use AI tools to draft ATR rules. The ATR MCP server lets any AI
 agent read, test, and propose new rules:

--- a/scripts/issue-to-proposal.ts
+++ b/scripts/issue-to-proposal.ts
@@ -1,0 +1,251 @@
+#!/usr/bin/env npx tsx
+/**
+ * issue-to-proposal.ts
+ *
+ * Converts a GitHub "New Rule Proposal" issue into a draft proposal YAML
+ * and writes it to proposals/community/.
+ *
+ * Called by .github/workflows/issue-to-proposal.yml. Can also be run
+ * locally for testing.
+ *
+ * Usage:
+ *   npx tsx scripts/issue-to-proposal.ts \
+ *     --issue 42 \
+ *     --title "[Rule] Prompt injection via tool description" \
+ *     --body-file /tmp/issue-body.txt \
+ *     --author octocat \
+ *     --write
+ *
+ * Exit codes:
+ *   0  proposal written (or dry-run succeeded)
+ *   1  fatal parse or IO error
+ *   2  issue body missing required fields (attack-type, description, payload)
+ */
+
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const REPO_ROOT = resolve(__dirname, "..");
+const PROPOSALS_DIR = resolve(REPO_ROOT, "proposals/community");
+
+const args = process.argv.slice(2);
+const flag = (n: string) => args.includes(n);
+const opt = (n: string): string | undefined => {
+  const i = args.indexOf(n);
+  return i >= 0 ? args[i + 1] : undefined;
+};
+
+const WRITE = flag("--write");
+const ISSUE_NUMBER = opt("--issue");
+const TITLE = opt("--title") ?? "";
+const BODY_FILE = opt("--body-file");
+const AUTHOR = opt("--author") ?? "anonymous";
+
+if (!ISSUE_NUMBER) {
+  console.error("error: --issue <number> is required");
+  process.exit(1);
+}
+if (!BODY_FILE || !existsSync(BODY_FILE)) {
+  console.error("error: --body-file <path> is required and must exist");
+  process.exit(1);
+}
+
+const issueBody = readFileSync(BODY_FILE, "utf8");
+
+// Parse GitHub issue form body: each section is "### Field Name\n\nvalue"
+function parseSection(body: string, heading: string): string {
+  const re = new RegExp(
+    `###\\s*${heading}\\s*\\n+([\\s\\S]*?)(?=\\n###|$)`,
+    "i"
+  );
+  const m = body.match(re);
+  if (!m) return "";
+  return m[1].trim();
+}
+
+const attackType = parseSection(issueBody, "Attack Type");
+const description = parseSection(issueBody, "Description");
+const references = parseSection(issueBody, "OWASP/MITRE/CVE References");
+const payload = parseSection(issueBody, "Example Attack Payload");
+const falsePosText = parseSection(issueBody, "Potential False Positives");
+
+const missing: string[] = [];
+if (!attackType) missing.push("Attack Type");
+if (!description) missing.push("Description");
+if (!payload) missing.push("Example Attack Payload");
+if (missing.length) {
+  console.error(`error: missing required fields: ${missing.join(", ")}`);
+  process.exit(2);
+}
+
+function slugify(s: string): string {
+  return s
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 60);
+}
+
+function inferCategory(type: string): string {
+  const t = type.toLowerCase();
+  if (/prompt.inject|hijack|jailbreak/.test(t)) return "prompt-injection";
+  if (/tool.poison|mcp|malicious.tool|tool.tamper/.test(t)) return "tool-poisoning";
+  if (/data.poison|train|finetun/.test(t)) return "data-poisoning";
+  if (/exfil|credential|secret|leak|disclosure/.test(t)) return "data-exfiltration";
+  if (/denial|dos|flood|rate.limit/.test(t)) return "resource-abuse";
+  if (/lateral|pivot|escalat/.test(t)) return "lateral-movement";
+  if (/supply.chain|package|dependen/.test(t)) return "supply-chain";
+  return "agent-manipulation";
+}
+
+function parseRefs(raw: string): string[] {
+  if (!raw) return [];
+  return raw
+    .split(/[\s,;]+/)
+    .map((r) => r.trim())
+    .filter((r) => r.length > 0);
+}
+
+const slug = slugify(attackType);
+const issueNum = parseInt(ISSUE_NUMBER, 10);
+const category = inferCategory(attackType);
+const today = new Date().toISOString().slice(0, 10).replace(/-/g, "/");
+
+const refs = parseRefs(references);
+const cveRefs = refs.filter((r) => /^CVE-/i.test(r));
+const owaspRefs = refs.filter((r) => /LLM\d|ASI\d/i.test(r));
+const atlasRefs = refs.filter((r) => /AML\./i.test(r));
+const attackRefs = refs.filter((r) => /T\d{4}/i.test(r));
+
+const falsePosLines = falsePosText
+  ? falsePosText
+      .split("\n")
+      .map((l) => l.replace(/^[-*]\s*/, "").trim())
+      .filter((l) => l.length > 0)
+  : [];
+
+// Indent a multi-line string for YAML block scalar
+function indent(s: string, spaces: number): string {
+  const pad = " ".repeat(spaces);
+  return s
+    .split("\n")
+    .map((l) => (l.trim() ? pad + l : l))
+    .join("\n");
+}
+
+function yamlStringList(items: string[], indentSpaces: number): string {
+  if (!items.length) return "[]";
+  const pad = " ".repeat(indentSpaces);
+  return "\n" + items.map((i) => `${pad}- "${i}"`).join("\n");
+}
+
+const fpBlock =
+  falsePosLines.length
+    ? falsePosLines.map((l) => `    - "${l.replace(/"/g, '\\"')}"`).join("\n")
+    : '    - "No false positives identified by submitter."';
+
+const cveBlock = cveRefs.length
+  ? `\n  cve:${yamlStringList(cveRefs, 4)}`
+  : "";
+const owaspBlock = owaspRefs.length
+  ? `\n  owasp_llm:${yamlStringList(owaspRefs, 4)}`
+  : "";
+const atlasBlock = atlasRefs.length
+  ? `\n  mitre_atlas:${yamlStringList(atlasRefs, 4)}`
+  : "";
+const attackBlock = attackRefs.length
+  ? `\n  mitre_attack:${yamlStringList(attackRefs, 4)}`
+  : "";
+const externalBlock = `\n  external:\n    - "https://github.com/Agent-Threat-Rule/agent-threat-rules/issues/${issueNum}"`;
+
+const refsSection = `references:${cveBlock}${owaspBlock}${atlasBlock}${attackBlock}${externalBlock}`;
+
+const payloadIndented = indent(payload, 2);
+
+const yaml = `# ATR rule proposal -- generated from GitHub Issue #${issueNum}
+# Submitted by: @${AUTHOR}
+# Source: https://github.com/Agent-Threat-Rule/agent-threat-rules/issues/${issueNum}
+# Status: DRAFT -- detection.conditions MUST be filled in before merge.
+title: "${attackType.replace(/"/g, '\\"')} — community proposal"
+id: ATR-COMMUNITY-ISSUE-${issueNum}
+rule_version: 1
+status: draft
+description: >
+${indent(description, 2)}
+author: "ATR Community (@${AUTHOR})"
+date: "${today}"
+schema_version: "0.1"
+detection_tier: pattern
+maturity: experimental
+severity: medium
+
+${refsSection}
+
+tags:
+  category: ${category}
+  scan_target: mcp
+  confidence: medium
+
+agent_source:
+  type: mcp_exchange
+  framework:
+    - any
+  provider:
+    - any
+
+detection:
+  condition: any
+  false_positives:
+${fpBlock}
+  conditions: []
+    # TODO: author a detection regex based on the example payload below.
+    # Run: npx tsx scripts/check-rules-safety.ts <this-file>
+    # Required: 0 FP on data/skill-benchmark/benign/ before PR merge.
+
+response:
+  actions:
+    - alert
+  auto_response_threshold: medium
+  message_template: >
+    [ATR-COMMUNITY-ISSUE-${issueNum}] MEDIUM: ${attackType} detected.
+
+confidence: 50
+
+test_cases:
+  true_positives: []
+    # TODO: derive from example payload once detection regex is written.
+  true_negatives: []
+
+_triage:
+  source: github-issue
+  issue_number: ${issueNum}
+  submitted_by: "@${AUTHOR}"
+  detection_ready: false
+  example_payload: |
+${payloadIndented}
+`;
+
+const filename = `ISSUE-${issueNum}-${slug}.proposal.yaml`;
+const outPath = resolve(PROPOSALS_DIR, filename);
+
+console.log(`\nProposal: proposals/community/${filename}`);
+console.log(`Category: ${category}`);
+console.log(`Issue:    #${issueNum} by @${AUTHOR}`);
+
+if (WRITE) {
+  if (!existsSync(PROPOSALS_DIR)) mkdirSync(PROPOSALS_DIR, { recursive: true });
+  writeFileSync(outPath, yaml, "utf8");
+  console.log(`Written:  ${outPath}`);
+  console.log(`::proposal-file::proposals/community/${filename}`);
+} else {
+  console.log("\n--- DRY RUN (pass --write to save) ---");
+  console.log(yaml);
+}


### PR DESCRIPTION
Closes the gap between external contributors and ATR proposals.

## Problem

External proposals were not flowing because the only path was: fork → write full YAML → validate → PR. No security researcher has 1-2 hours to do that.

The GitHub Issue `new-rule` template existed but was dead-end — nothing consumed it.

## What this adds

A bot that converts `new-rule` issues into `proposals/community/` YAML files automatically.

**New contributor flow:**
1. Open a [New Rule Proposal](https://github.com/Agent-Threat-Rule/agent-threat-rules/issues/new?template=new-rule.yml) issue — fill in attack type, description, example payload
2. Bot creates `proposals/community/ISSUE-{n}-{slug}.proposal.yaml` within minutes
3. Bot opens a draft PR and comments on the issue with next steps
4. Maintainer (or contributor) authors the regex, runs safety gate, merges

No repo clone needed for step 1-2.

## Files

- `scripts/issue-to-proposal.ts` — parses issue form body, infers category, emits proposal YAML
- `.github/workflows/issue-to-proposal.yml` — triggers on `issues.opened` + `issues.labeled[new-rule]`
- `CONTRIBUTING.md` — rewrite: issue-first path is now option A

## Test plan

- [ ] Open a test `new-rule` issue — verify draft PR opens with correct proposal YAML
- [ ] Open issue with missing required fields — verify bot comments with failure message
- [ ] Re-label an existing issue as `new-rule` — verify action re-triggers
- [ ] Confirm `proposals/community/` directory is created if it doesn't exist