### PR TITLE
feat(website + ecosystem): standards-form hero/footer + integration intake pipeline

### DIFF
--- a/.github/ISSUE_TEMPLATE/integration-request.yml
+++ b/.github/ISSUE_TEMPLATE/integration-request.yml
@@ -1,0 +1,137 @@
+name: Integration Request
+description: Add ATR to your project (framework, scanner, dashboard, MCP gateway, or other tool)
+title: "[Integration] "
+labels: ["integration-request", "ecosystem"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for considering ATR. This template captures the information the
+        maintainers need to triage your integration and put you in touch with
+        the right reviewers. The form takes about 5 minutes.
+
+        Before filling this out, please skim the spec at
+        `quality-standard` (https://agentthreatrule.org/quality-standard) so
+        you know what "conforming to ATR" means in practice. If your project
+        only consumes the rule corpus as text (no engine), you can skip the
+        conformance bits.
+
+  - type: input
+    id: project_name
+    attributes:
+      label: Project name
+      description: Human-readable name of the project that will adopt ATR.
+      placeholder: e.g. promptfoo, IBM mcp-context-forge, Gen Digital Sage
+    validations:
+      required: true
+
+  - type: input
+    id: project_repo
+    attributes:
+      label: Project repository
+      description: Public Git URL (GitHub / GitLab / Codeberg). Leave blank if the project is closed-source — capture in the description below instead.
+      placeholder: https://github.com/...
+    validations:
+      required: false
+
+  - type: dropdown
+    id: integration_type
+    attributes:
+      label: What kind of integration?
+      description: Pick the closest match. Multiple-select via the description field below if your project does more than one.
+      options:
+        - Engine implementation (you are writing an evaluator for ATR rules)
+        - Rule import (you import the YAML corpus directly into your detection layer)
+        - Category subset (you import a specific category — e.g. prompt-injection only)
+        - Adapter / bridge (you translate ATR rules into another format — Sigma / OPA / OCSF / STIX)
+        - Reference in docs / framework (you reference ATR rule IDs in your project's documentation or threat model)
+        - Sidecar / proxy (your project sits in the request path and evaluates rules at runtime)
+        - Other (please describe)
+    validations:
+      required: true
+
+  - type: textarea
+    id: integration_description
+    attributes:
+      label: Integration description
+      description: One paragraph. What does the integration look like end-to-end? Which side runs ATR — your CI, your runtime, your IDE?
+      placeholder: |
+        e.g. "We import the prompt-injection category at build time, compile the
+        regexes into our existing Sigma backend, and emit our own rule IDs that
+        cross-reference ATR rule IDs in the description field."
+    validations:
+      required: true
+
+  - type: dropdown
+    id: tier
+    attributes:
+      label: Your project tier (best guess)
+      description: This helps the maintainers route the request. Be honest — there is no wrong answer.
+      options:
+        - Standards body / framework (e.g. OWASP, NIST, OpenTelemetry SIG)
+        - Production deployment (your project ships ATR in a customer-facing product)
+        - Open-source tool / SDK (your project is a developer tool that integrates ATR)
+        - Awesome-list / documentation reference (you want to list ATR in a public catalogue)
+        - Research / academic
+        - Personal / hobby project
+    validations:
+      required: true
+
+  - type: dropdown
+    id: timeline
+    attributes:
+      label: Timeline
+      options:
+        - Already shipped (and we want to be listed in ADOPTERS.md)
+        - In review / draft PR open in our repo
+        - Implementing now, 1–4 weeks
+        - Planning, 1–3 months
+        - Exploring, no commitment yet
+    validations:
+      required: true
+
+  - type: input
+    id: your_role
+    attributes:
+      label: Your role
+      description: Maintainer, contributor, employee of company X — whatever applies. We don't gatekeep, but accurate context helps us calibrate the conversation.
+      placeholder: e.g. "Maintainer of repo X" or "Security engineer at Company Y"
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: help_wanted
+    attributes:
+      label: What kind of help would be useful?
+      description: Tick all that apply. The maintainers will follow up in the issue thread with the relevant pointers.
+      options:
+        - label: A walkthrough of the rule schema and conformance requirements
+        - label: Help mapping ATR rules to our existing detection format
+        - label: Sample code / reference implementation for our language
+        - label: Review of our integration design before we commit code
+        - label: Pre-publication review of our public announcement / blog post
+        - label: Co-presentation or joint blog post when we ship
+        - label: Nothing right now — just want to be on the radar
+
+  - type: textarea
+    id: specific_rules_or_categories
+    attributes:
+      label: Specific rules or categories you care about (optional)
+      description: If your project only consumes part of the corpus, list the categories or rule IDs. Helps us flag relevant updates to you.
+      placeholder: |
+        e.g. prompt-injection, tool-poisoning, ATR-2026-00440, ATR-2026-00441
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: agreement
+    attributes:
+      label: Before submitting
+      description: Standard housekeeping.
+      options:
+        - label: I have read the ATR README and skimmed the spec at /quality-standard
+          required: true
+        - label: I understand ATR is MIT licensed and that adopters are listed publicly in ADOPTERS.md unless they ask not to be
+          required: true
+        - label: I agree to the Code of Conduct
+          required: true

--- a/.github/PULL_REQUEST_TEMPLATE/adopter.md
+++ b/.github/PULL_REQUEST_TEMPLATE/adopter.md
@@ -1,0 +1,51 @@
+<!--
+PR template: add yourself to ADOPTERS.md.
+
+How to use this template:
+  Open a PR with `?template=adopter.md` appended to the PR-creation URL, or
+  copy the relevant section into the description manually.
+
+The maintainers do NOT pre-approve adopter entries. A PR that follows the
+schema and links to verifiable evidence will be merged. Reviewers will
+sanity-check the evidence link, the tier placement, and the integration
+type — that's it. We are not gatekeepers; we are curators.
+-->
+
+## Project
+
+- **Name**:
+- **Tier** (S / 1 / 2 / 3 / 4): see ADOPTERS.md for definitions
+- **Adopter PR / public evidence**: <link>
+
+## Integration
+
+- **Type** (engine / rule-import / category-subset / adapter / reference / sidecar-proxy / other):
+- **One-sentence description**:
+- **Categories consumed** (optional, comma-separated):
+
+## Checklist
+
+- [ ] I have added my entry to `ADOPTERS.md` following the schema in that file
+- [ ] The entry includes a publicly-verifiable evidence link (a merged PR in
+      MY project, public docs page, blog post, conference talk, etc.)
+- [ ] The tier placement matches the definitions at the top of ADOPTERS.md
+- [ ] If my project is closed-source, the evidence link points to a public
+      announcement (docs page, blog post, press release) that names ATR
+- [ ] I have read the Code of Conduct
+- [ ] I understand entries are public and the maintainers do not remove them
+      on request; entries are MOVED to the "Removed entries" section if the
+      adopter's status changes (archival, removal of ATR support, etc.)
+
+## Notes for reviewer
+
+<!--
+Anything the reviewer should know that does not fit the schema. Optional.
+
+Examples:
+- "Our company brand-asset program requires written permission before our logo
+  appears on third-party websites. The text-only listing here is fine; please
+  do NOT use our logo on /ecosystem until we follow up separately."
+- "We are still in private beta — please mark this entry as Status: in-review
+  until our public launch on YYYY-MM-DD, then we will follow up with a status
+  update PR."
+-->

--- a/.github/workflows/integration-request-triage.yml
+++ b/.github/workflows/integration-request-triage.yml
@@ -1,0 +1,135 @@
+name: Integration Request Triage
+
+# Auto-triage integration-request issues. Fires when an issue is opened
+# (or reopened) that carries the `integration-request` label set by the
+# issue form template. Posts a structured welcome comment and routes the
+# request to the maintainers' queue.
+
+on:
+  issues:
+    types: [opened, reopened, labeled]
+
+permissions:
+  issues: write
+  contents: read
+
+jobs:
+  triage:
+    name: Welcome + route integration request
+    runs-on: ubuntu-latest
+    # Only run for integration-request issues. The label is applied by the
+    # issue form template; for reopened/labeled events we double-check.
+    if: |
+      contains(github.event.issue.labels.*.name, 'integration-request') &&
+      github.event.issue.state == 'open'
+    steps:
+      - name: Check if welcome comment already posted
+        id: existing
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          # The triage workflow is idempotent: it must not double-post the
+          # welcome banner if the issue is reopened or relabeled.
+          ALREADY=$(gh api "repos/${REPO}/issues/${ISSUE_NUMBER}/comments" \
+            --jq '.[] | select(.user.login == "github-actions[bot]") | select(.body | startswith("Thanks for opening an integration request"))' \
+            | head -c 1)
+          if [ -n "$ALREADY" ]; then
+            echo "already_welcomed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "already_welcomed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Post welcome comment
+        if: steps.existing.outputs.already_welcomed != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          REPO: ${{ github.repository }}
+          ISSUE_AUTHOR: ${{ github.event.issue.user.login }}
+        run: |
+          gh issue comment "$ISSUE_NUMBER" --repo "$REPO" --body "$(cat <<EOF
+          Thanks for opening an integration request, @${ISSUE_AUTHOR}.
+
+          Here is what happens next:
+
+          1. **A maintainer will read this within 7 days** and reply in this
+             thread. If your tier is "Standards body / framework" or
+             "Production deployment" we usually respond faster.
+
+          2. **If you have shipped already**, the next step is to open a PR
+             against \`ADOPTERS.md\` adding your project to the appropriate
+             tier section. Use the \`adopter\` PR template.
+
+          3. **If you are still implementing**, the spec is at
+             https://agentthreatrule.org/quality-standard and the schema
+             lives at https://github.com/Agent-Threat-Rule/agent-threat-rules
+             in the repo root (\`ATR-FRAMEWORK-SPEC.md\` + \`ATR-SPEC-v1.md\`).
+             Feel free to ask questions in this thread — the maintainers
+             prefer asynchronous discussion over scheduled calls.
+
+          4. **Conformance check (optional)**: a reference helper action is
+             planned but not yet released. Until then, the \`npm run validate\`
+             script in this repo will validate any rule YAML you author or
+             import. You can also paste a sample rule in this thread and we
+             will review it.
+
+          ### Useful links
+
+          - Spec: https://agentthreatrule.org/quality-standard
+          - Repo: https://github.com/Agent-Threat-Rule/agent-threat-rules
+          - Adopters list: https://github.com/Agent-Threat-Rule/agent-threat-rules/blob/main/ADOPTERS.md
+          - Code of Conduct: https://github.com/Agent-Threat-Rule/agent-threat-rules/blob/main/CODE_OF_CONDUCT.md
+          - Governance: https://agentthreatrule.org/governance
+
+          ATR is community-maintained and MIT licensed; there are no commercial
+          licensing fees, no NDA gates, no "Enterprise tier" — anyone can ship
+          ATR in any product. The only thing the maintainers ask in return is
+          that adopters who ship publicly add themselves to ADOPTERS.md so the
+          ecosystem is visible to other potential adopters.
+
+          ---
+
+          *This message was posted automatically by the
+          \`integration-request-triage\` workflow. The thread itself is read
+          and replied to by humans.*
+          EOF
+          )"
+
+      - name: Auto-label by tier
+        if: steps.existing.outputs.already_welcomed != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          REPO: ${{ github.repository }}
+          ISSUE_BODY: ${{ github.event.issue.body }}
+        run: |
+          # Best-effort tier-label parsing from the issue body. The issue
+          # form template renders the dropdown answer as the literal label
+          # text in a "### Your project tier (best guess)" heading.
+          TIER_LABEL=""
+          if printf '%s' "$ISSUE_BODY" | grep -q "Standards body / framework"; then
+            TIER_LABEL="tier-standards-body"
+          elif printf '%s' "$ISSUE_BODY" | grep -q "Production deployment"; then
+            TIER_LABEL="tier-production"
+          elif printf '%s' "$ISSUE_BODY" | grep -q "Open-source tool / SDK"; then
+            TIER_LABEL="tier-tooling"
+          elif printf '%s' "$ISSUE_BODY" | grep -q "Awesome-list / documentation reference"; then
+            TIER_LABEL="tier-docs"
+          elif printf '%s' "$ISSUE_BODY" | grep -q "Research / academic"; then
+            TIER_LABEL="tier-research"
+          elif printf '%s' "$ISSUE_BODY" | grep -q "Personal / hobby project"; then
+            TIER_LABEL="tier-hobby"
+          fi
+
+          if [ -n "$TIER_LABEL" ]; then
+            # Create the label if it does not yet exist (idempotent).
+            gh label create "$TIER_LABEL" --repo "$REPO" \
+              --color "0E8A16" --description "Integration request tier" \
+              2>/dev/null || true
+            gh issue edit "$ISSUE_NUMBER" --repo "$REPO" --add-label "$TIER_LABEL"
+            echo "Added label: $TIER_LABEL"
+          else
+            echo "No tier detected in issue body — skipping tier label"
+          fi

--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -1,0 +1,253 @@
+# ADOPTERS
+
+Projects and organizations that have integrated Agent Threat Rules (ATR) into
+public, ongoing work. Inclusion here is self-declared by the adopter via PR
+and reflects the state at the time of the merge. Entries are sorted by
+adoption tier and then alphabetically. The maintainers reserve the right to
+move an entry between tiers if its public status changes (e.g. a project is
+archived) — entries are not removed without notice.
+
+To add yourself, open a PR using the
+[`adopter` PR template](./.github/PULL_REQUEST_TEMPLATE/adopter.md). The
+maintainers do not pre-approve adoption — your PR becomes the record.
+
+## Why this file exists
+
+ADOPTERS.md is the **machine-readable source of truth** consumed by
+`agentthreatrule.org/ecosystem` and by downstream tooling that wants to know
+which projects ship ATR. The website renders this file directly; the file is
+not a marketing artefact and must not contain marketing copy.
+
+Each entry follows a fixed structure (see Schema below) so the website can
+parse it without ambiguity.
+
+---
+
+## Schema
+
+Each entry, regardless of tier, follows:
+
+```markdown
+### Project Name
+- **Org**: organisation (or "Independent")
+- **Type**: one of [engine | rule-import | category-subset | adapter | reference | sidecar-proxy | other]
+- **Integration**: one-sentence description of what the integration is
+- **Evidence**: link to the merged PR / public announcement / docs page
+- **Since**: YYYY-MM-DD (date of public adoption)
+- **Status**: one of [shipped | in-review | planning]
+- **Categories** (optional): comma-separated list of ATR categories the
+  project consumes (e.g. `prompt-injection`, `tool-poisoning`)
+```
+
+The website parser reads the four required fields. Optional fields may be
+added but parsers ignore unknown keys.
+
+---
+
+## Tier S — Standards bodies & frameworks
+
+Adopters whose adoption is itself a public-good interoperability artefact
+(taxonomies, catalogues, profiles, schemas published by neutral bodies).
+
+### MISP / CIRCL
+- **Org**: CIRCL (Computer Incident Response Center Luxembourg)
+- **Type**: reference
+- **Integration**: ATR rule-ID taxonomy + threat-intel galaxy merged into MISP's core distribution
+- **Evidence**: <https://github.com/MISP/misp-taxonomies/pull/323> and <https://github.com/MISP/misp-galaxy/pull/1207>
+- **Since**: 2026-05-10
+- **Status**: shipped
+
+### OWASP Agent Security Regression Harness
+- **Org**: OWASP Foundation
+- **Type**: reference
+- **Integration**: ATR rule corpus referenced as the canonical agent-threat detection ruleset in the project's threat catalogue
+- **Evidence**: <https://github.com/OWASP/agent-security-regression-harness/pull/74>
+- **Since**: 2026-05-11
+- **Status**: shipped
+
+### NIST AI RMF — OSCAL Path 1
+- **Org**: NIST (informal acceptance pathway)
+- **Type**: reference
+- **Integration**: Community OSCAL profile cross-references ATR rule IDs to AI RMF controls
+- **Evidence**: <https://github.com/Agent-Threat-Rule/ai-rmf-oscal-catalog>
+- **Since**: 2026-05-10
+- **Status**: shipped
+
+### OpenTelemetry — semantic-conventions-genai
+- **Org**: CNCF / OpenTelemetry GenAI SIG
+- **Type**: reference
+- **Integration**: Proposal for `agent.threat.detection.*` semantic-convention attributes (which ATR populates on agent spans) is in review
+- **Evidence**: <https://github.com/open-telemetry/semantic-conventions-genai/pull/165>
+- **Since**: 2026-05-17
+- **Status**: in-review
+
+---
+
+## Tier 1 — Production deployments
+
+Adopters who ship ATR in a publicly-available customer-facing product or
+internal-but-public tooling. Listed when the adopter has confirmed the
+deployment publicly (merged PR, public docs, conference talk, etc.).
+
+### Cisco AI Defense
+- **Org**: Cisco
+- **Type**: rule-import
+- **Integration**: ATR rule corpus consumed by the AI Defense skill-scanner; matches surface in the Cisco product UI as detection findings
+- **Evidence**: <https://github.com/cisco-ai-defense/skill-scanner/pull/99> (and predecessor PoC #79)
+- **Since**: 2026-04-22
+- **Status**: shipped
+
+### Microsoft Agent Governance Toolkit
+- **Org**: Microsoft
+- **Type**: rule-import
+- **Integration**: 287-rule ATR expansion auto-synced weekly into the Agent Governance Toolkit detection layer
+- **Evidence**: <https://github.com/microsoft/agent-governance-toolkit/pull/1277>
+- **Since**: 2026-04-26
+- **Status**: shipped
+
+### Gen Digital Sage
+- **Org**: Gen Digital (Norton / Avast / LifeLock parent)
+- **Type**: rule-import
+- **Integration**: Full ATR rule pack integrated into the Sage agentic-AI risk-scoring layer
+- **Evidence**: <https://github.com/gendigitalinc/sage/pull/33>
+- **Since**: 2026-05-11
+- **Status**: shipped
+
+---
+
+## Tier 2 — Open-source tooling & SDK integrations
+
+Open-source developer tools, frameworks, and SDKs that have integrated ATR.
+Listed when the integration code has been merged or released.
+
+### BerriAI LiteLLM
+- **Org**: BerriAI
+- **Type**: sidecar-proxy
+- **Integration**: ATR guardrail integration as a LiteLLM proxy callback; scans LLM input + output against the rule corpus at the proxy layer
+- **Evidence**: <https://github.com/BerriAI/litellm/pull/28050>
+- **Since**: 2026-05-16
+- **Status**: in-review
+
+### Promptfoo
+- **Org**: Promptfoo
+- **Type**: rule-import
+- **Integration**: MCP red-team output scanning consumes ATR rules to flag adversarial responses in evaluation runs
+- **Evidence**: <https://github.com/promptfoo/promptfoo/pull/8529>
+- **Since**: 2026-04-08
+- **Status**: in-review
+
+### NVIDIA garak
+- **Org**: NVIDIA
+- **Type**: rule-import
+- **Integration**: ATR detector plugin for the garak red-teaming framework
+- **Evidence**: <https://github.com/NVIDIA/garak/pull/1276>
+- **Since**: 2026-05-20
+- **Status**: in-review
+
+### IBM mcp-context-forge
+- **Org**: IBM
+- **Type**: sidecar-proxy
+- **Integration**: ATR threat-detection plugin for the MCP context-forge proxy
+- **Evidence**: <https://github.com/IBM/mcp-context-forge/pull/4109>
+- **Since**: 2026-05-09
+- **Status**: in-review
+
+### Portkey AI Gateway
+- **Org**: Portkey AI
+- **Type**: sidecar-proxy
+- **Integration**: ATR detection plugin in the Portkey gateway plugin architecture
+- **Evidence**: <https://github.com/Portkey-AI/gateway/pull/1652>
+- **Since**: 2026-05-16
+- **Status**: in-review
+
+### Semgrep
+- **Org**: Semgrep Inc. (community contribution)
+- **Type**: adapter
+- **Integration**: YAML rule-format adapter that translates Semgrep rule conventions to ATR conformance for skill-manifest + MCP-tool security
+- **Evidence**: Semgrep upstream PR (open as of 2026-05-10)
+- **Since**: 2026-05-10
+- **Status**: in-review
+
+### aaif-goose
+- **Org**: AAIF (block/goose)
+- **Type**: sidecar-proxy
+- **Integration**: PreToolUse hook denial integrates ATR rule evaluation at the tool-call boundary
+- **Evidence**: <https://github.com/aaif-goose/goose/pull/9304>
+- **Since**: 2026-05-19
+- **Status**: in-review
+
+### SigmaHQ
+- **Org**: SigmaHQ
+- **Type**: adapter
+- **Integration**: Cross-listing in the Sigma tools directory; agent-threat-rules listed as a sibling detection-rule format
+- **Evidence**: <https://github.com/SigmaHQ/sigma/pull/6015>
+- **Since**: 2026-05-09
+- **Status**: in-review
+
+---
+
+## Tier 3 — Documentation references & awesome-lists
+
+Adopters who reference ATR in public catalogues, awesome-lists, or
+documentation indices. Lower-effort inclusion but useful for ecosystem
+discoverability.
+
+### ottosulin/awesome-ai-security
+- **Org**: Otto Sulin (independent)
+- **Type**: reference
+- **Integration**: ATR listed in the MCP Security section
+- **Evidence**: <https://github.com/ottosulin/awesome-ai-security/pull/192>
+- **Since**: 2026-05-20
+- **Status**: shipped
+
+### e2b-dev/awesome-ai-agents
+- **Org**: E2B
+- **Type**: reference
+- **Integration**: ATR listed in the AI agents awesome-list
+- **Evidence**: <https://github.com/e2b-dev/awesome-ai-agents/pull/959>
+- **Since**: 2026-05-16
+- **Status**: in-review
+
+### e2b-dev/awesome-ai-sdks
+- **Org**: E2B
+- **Type**: reference
+- **Integration**: ATR listed in the AI SDKs awesome-list
+- **Evidence**: <https://github.com/e2b-dev/awesome-ai-sdks/pull/194>
+- **Since**: 2026-05-16
+- **Status**: in-review
+
+### Puliczek/awesome-mcp-security
+- **Org**: Puliczek (independent)
+- **Type**: reference
+- **Integration**: ATR listed in MCP threat-detection tools
+- **Evidence**: Puliczek/awesome-mcp-security
+- **Since**: 2026-04-21
+- **Status**: in-review
+
+---
+
+## Tier 4 — Commercial implementations
+
+Vendors offering commercial support, hosted engines, or enterprise SLAs
+around ATR. Listed when the vendor has confirmed publicly that they ship
+ATR as a product feature.
+
+### PanGuard AI
+- **Org**: Panguard AI, Inc.
+- **Type**: engine
+- **Integration**: Hosted ATR engine + enterprise SLAs, compliance evidence module, and runtime guardrails
+- **Evidence**: <https://panguard.ai>
+- **Since**: 2026-04-22
+- **Status**: shipped
+
+*Vendors wishing to be listed here must contact `contact@agentthreatrule.org`
+with evidence that ATR is a documented product feature in their public
+docs.*
+
+---
+
+## Removed entries
+
+None to date. If an adopter is moved out of an active tier due to project
+archival or removal of ATR support, the entry is moved here with a
+one-line note and the original "Since" date is preserved.

--- a/README.md
+++ b/README.md
@@ -241,6 +241,20 @@ This is Microsoft Copilot operating inside AGT, not an MSRC endorsement. Coverag
 
 [NVIDIA garak #1676](https://github.com/NVIDIA/garak/pull/1676) · [OWASP LLM Top 10 #814](https://github.com/OWASP/www-project-top-10-for-large-language-model-applications/pull/814) · [IBM mcp-context-forge #4109](https://github.com/IBM/mcp-context-forge/pull/4109) · [Meta PurpleLlama #206](https://github.com/meta-llama/PurpleLlama/pull/206) · [Microsoft PyRIT #1715](https://github.com/microsoft/PyRIT/pull/1715) · [BerriAI LiteLLM #28050](https://github.com/BerriAI/litellm/pull/28050) · [promptfoo #8529](https://github.com/promptfoo/promptfoo/pull/8529) · [Cybercentre Canada CCCS-Yara #100](https://github.com/CybercentreCanada/CCCS-Yara/pull/100)
 
+### Integrating ATR into your project
+
+The full adopter list lives in [ADOPTERS.md](./ADOPTERS.md). New adopters
+self-declare via PR — the maintainers do not pre-approve entries.
+
+If you are planning an integration and want a structured intake (spec
+walkthrough, review of design, sample code for your language), open an
+[Integration Request issue](https://github.com/Agent-Threat-Rule/agent-threat-rules/issues/new?template=integration-request.yml).
+The triage workflow posts a welcome and routes the request to the
+maintainers within seven days.
+
+If you have already shipped, open a PR against `ADOPTERS.md` using the
+[`adopter` PR template](./.github/PULL_REQUEST_TEMPLATE/adopter.md).
+
 ## 7. Coverage
 
 ATR maps its rules onto established frameworks so adopters can answer "we deploy ATR — what does that buy us in terms of \[your framework\] coverage?" without re-doing the mapping themselves.

--- a/website/app/[locale]/contribute/page.tsx
+++ b/website/app/[locale]/contribute/page.tsx
@@ -33,12 +33,70 @@ export default async function ContributePage({ params }: { params: Promise<{ loc
       <Reveal delay={0.2}>
         <p className="text-base text-stone font-light mb-10 max-w-[520px]">
           {zh
-            ? "MIT 授權。零專有工具。零 CLA。從回報一個繞過方法開始，15 分鐘。"
+            ? "MIT 授權。零專有工具。零 CLA。從回報一個繞過方法開始,15 分鐘。"
             : "MIT licensed. No proprietary tooling. No CLA. Start by reporting an evasion, 15 minutes."}
         </p>
       </Reveal>
 
+      {/* ── Integrating ATR into your project (top — most asked path) ── */}
+      <Reveal>
+        <div className="font-data text-xs font-medium text-stone tracking-[2px] uppercase mb-3">
+          {zh ? "把 ATR 接到你的專案" : "Integrating ATR into your project"}
+        </div>
+      </Reveal>
+      <Reveal delay={0.1}>
+        <div className="border border-fog mb-12 grid grid-cols-1 md:grid-cols-2">
+          <div className="p-6 md:p-7 border-b md:border-b-0 md:border-r border-fog">
+            <div className="font-data text-[11px] text-stone tracking-wide uppercase mb-2">
+              {zh ? "規劃中 / 實作中" : "Planning or implementing"}
+            </div>
+            <h3 className="font-display text-base font-semibold text-ink mb-2">
+              {zh ? "開 Integration Request issue" : "Open an Integration Request issue"}
+            </h3>
+            <p className="text-sm text-stone leading-relaxed mb-3">
+              {zh
+                ? "結構化表單,5 分鐘填完。需要 spec walkthrough、design review、語言 sample code、或合規 mapping 就走這條。維護者七天內回覆。"
+                : "Structured intake form, 5 minutes. Use this path if you need a spec walkthrough, design review, sample code for your language, or framework-compliance mapping. Maintainers respond within seven days."}
+            </p>
+            <a
+              href="https://github.com/Agent-Threat-Rule/agent-threat-rules/issues/new?template=integration-request.yml"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="font-data text-xs text-blue hover:underline"
+            >
+              {zh ? "開 issue" : "Open the issue"} &rarr;
+            </a>
+          </div>
+          <div className="p-6 md:p-7">
+            <div className="font-data text-[11px] text-stone tracking-wide uppercase mb-2">
+              {zh ? "已經 ship 了" : "Already shipped"}
+            </div>
+            <h3 className="font-display text-base font-semibold text-ink mb-2">
+              {zh ? "提 PR 加進 ADOPTERS.md" : "Open a PR against ADOPTERS.md"}
+            </h3>
+            <p className="text-sm text-stone leading-relaxed mb-3">
+              {zh
+                ? "你的整合公開可驗證了就走這條。Schema 對、有 evidence link 就 merge — 維護者不預先審核採用者,這跟 Sigma 一樣。"
+                : "Take this path when your integration is publicly verifiable. Schema-conforming entries with a verifiable evidence link get merged — maintainers do not pre-approve adopters. Same model as Sigma."}
+            </p>
+            <a
+              href="https://github.com/Agent-Threat-Rule/agent-threat-rules/blob/main/ADOPTERS.md"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="font-data text-xs text-blue hover:underline"
+            >
+              ADOPTERS.md &rarr;
+            </a>
+          </div>
+        </div>
+      </Reveal>
+
       {/* ── Quick Actions (the most important part) ── */}
+      <Reveal>
+        <div className="font-data text-xs font-medium text-stone tracking-[2px] uppercase mb-3">
+          {zh ? "改進規則本身" : "Improve the rules themselves"}
+        </div>
+      </Reveal>
       <Reveal delay={0.3}>
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-12">
           {[
@@ -97,6 +155,108 @@ export default async function ContributePage({ params }: { params: Promise<{ loc
               </div>
             </Reveal>
           ))}
+        </div>
+      </Reveal>
+
+      {/* ── Spec amendments ── */}
+      <Reveal>
+        <div className="font-data text-xs font-medium text-stone tracking-[2px] uppercase mb-3">
+          {zh ? "想改 spec 本身" : "Want to change the spec itself"}
+        </div>
+      </Reveal>
+      <Reveal delay={0.1}>
+        <div className="border border-fog p-6 mb-12">
+          <p className="text-sm text-stone leading-relaxed mb-3">
+            {zh
+              ? "Spec(ATR-SPEC-v1)是所有相容引擎的契約。改動 spec 不像加規則那麼直接 — 流程是:先開 RFC issue 標題以 [RFC] 開頭,描述要改什麼、為什麼;留 7 天公開評論窗口讓所有 implementer 看到並回饋;接下來才接受 PR。Breaking change(SemVer 主版號)需要額外 30 天提前公告。"
+              : "The spec (ATR-SPEC-v1) is the contract between all conforming engines. Spec changes are not as direct as rule additions — the process is: open an RFC issue with title prefixed [RFC] describing what you want to change and why; leave a 7-day public comment window so every implementer sees it and can respond; then submit the PR. Breaking changes (SemVer major bump) require an additional 30-day advance notice."}
+          </p>
+          <p className="text-sm text-stone leading-relaxed mb-3">
+            {zh
+              ? "完整流程在 governance 頁的 Decision-making 區段。"
+              : "Full process documented under Decision-making on the governance page."}
+          </p>
+          <div className="flex flex-wrap gap-4">
+            <a
+              href="https://github.com/Agent-Threat-Rule/agent-threat-rules/issues/new?title=%5BRFC%5D+"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="font-data text-xs text-blue hover:underline"
+            >
+              {zh ? "開 RFC issue" : "Open an RFC issue"} &rarr;
+            </a>
+            <span className="text-fog">|</span>
+            <a
+              href={`/${locale}/governance`}
+              className="font-data text-xs text-blue hover:underline"
+            >
+              {zh ? "決策流程細節" : "Decision-making process"} &rarr;
+            </a>
+            <span className="text-fog">|</span>
+            <a
+              href="https://github.com/Agent-Threat-Rule/agent-threat-rules/blob/main/ATR-SPEC-v1.md"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="font-data text-xs text-blue hover:underline"
+            >
+              ATR-SPEC-v1.md &rarr;
+            </a>
+          </div>
+        </div>
+      </Reveal>
+
+      {/* ── First-time contributors ── */}
+      <Reveal>
+        <div className="font-data text-xs font-medium text-stone tracking-[2px] uppercase mb-3">
+          {zh ? "第一次貢獻" : "First time contributing"}
+        </div>
+      </Reveal>
+      <Reveal delay={0.1}>
+        <div className="border border-fog p-6 mb-12 text-sm text-graphite leading-relaxed space-y-3">
+          <p>
+            {zh
+              ? "如果你想開始但不確定從哪開始,有兩條低門檻入口:"
+              : "If you want to contribute but don't know where to start, two low-friction entry points:"}
+          </p>
+          <ul className="list-disc pl-6 space-y-2">
+            <li>
+              <a
+                href="https://github.com/Agent-Threat-Rule/agent-threat-rules/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-blue hover:underline"
+              >
+                {zh ? "「good first issue」標籤的 open issue" : "Open issues labelled 'good first issue'"}
+              </a>
+              {zh
+                ? " — 維護者標記過、範圍清楚的入門任務。"
+                : " — maintainer-tagged starter tasks with clear scope."}
+            </li>
+            <li>
+              {zh
+                ? "規則的 false-positive 報告 — 你的工作流程中遇到誤判,15 分鐘填表格,就直接幫到下游所有採用者。維護者最重視這類回饋。"
+                : "False-positive reports — if you hit a misfire in your workflow, a 15-minute report directly helps every downstream adopter. Maintainers prioritise this class of feedback."}
+            </li>
+          </ul>
+        </div>
+      </Reveal>
+
+      {/* ── Become a maintainer ── */}
+      <Reveal>
+        <div className="font-data text-xs font-medium text-stone tracking-[2px] uppercase mb-3">
+          {zh ? "想成為維護者" : "Want to become a maintainer"}
+        </div>
+      </Reveal>
+      <Reveal delay={0.1}>
+        <div className="border border-fog p-6 mb-12 text-sm text-graphite leading-relaxed">
+          <p className="mb-3">
+            {zh
+              ? "ATR 目前是 single-maintainer,正在主動招募第二位、第三位。候選條件、決策結構、以及申請方式都在 governance 頁。"
+              : "ATR is currently single-maintainer and is actively recruiting a second and third. Candidate criteria, the decision-making structure, and how to apply are all on the governance page."}
+          </p>
+          <a href={`/${locale}/governance`} className="font-data text-xs text-blue hover:underline">
+            {zh ? "看治理頁的「想成為維護者」段" : "See 'Become a maintainer' on the governance page"} &rarr;
+          </a>
         </div>
       </Reveal>
 

--- a/website/app/[locale]/ecosystem/page.tsx
+++ b/website/app/[locale]/ecosystem/page.tsx
@@ -1,6 +1,12 @@
 import { Reveal } from "@/components/Reveal";
-import { loadSiteStats } from "@/lib/stats";
 import { locales, type Locale } from "@/lib/i18n";
+import {
+  loadAdopters,
+  tierLabel,
+  tierDescription,
+  type Adopter,
+  type AdopterTier,
+} from "@/lib/adopters";
 import type { Metadata } from "next";
 
 export function generateStaticParams() {
@@ -8,18 +14,29 @@ export function generateStaticParams() {
 }
 
 export const metadata: Metadata = {
-  title: "Ecosystem — ATR Integrations",
-  description: "Projects and platforms that integrate ATR detection rules. Add your project.",
+  title: "Ecosystem — ATR adopters",
+  description:
+    "Standards bodies, production deployments, and open-source tooling that ship Agent Threat Rules (ATR).",
 };
 
 export default async function EcosystemPage({ params }: { params: Promise<{ locale: string }> }) {
   const { locale: raw } = await params;
   const locale = (locales.includes(raw as Locale) ? raw : "en") as Locale;
   const zh = locale === "zh";
-  const stats = loadSiteStats();
+  const adopters = loadAdopters();
 
-  const merged = stats.ecosystemIntegrations.filter((i) => i.type === "merged");
-  const open = stats.ecosystemIntegrations.filter((i) => i.type === "open");
+  // Pair tiers with their entries in display order. Tier S is most prominent,
+  // tier 4 (commercial) is separated visually so vendor implementations do not
+  // dominate a page that is primarily about the standard's reach.
+  const sections: Array<{ tier: AdopterTier; entries: Adopter[] }> = [
+    { tier: "S", entries: adopters.tierS },
+    { tier: "1", entries: adopters.tier1 },
+    { tier: "2", entries: adopters.tier2 },
+    { tier: "3", entries: adopters.tier3 },
+  ];
+  // Commercial is rendered after a separator so it reads as "vendors offering
+  // hosted ATR" rather than "another tier of adoption".
+  const commercial: Adopter[] = adopters.tier4;
 
   return (
     <div className="pt-20 pb-16 px-6 max-w-[1120px] mx-auto">
@@ -35,139 +52,253 @@ export default async function EcosystemPage({ params }: { params: Promise<{ loca
         </h1>
       </Reveal>
       <Reveal delay={0.2}>
-        <p className="text-base text-stone font-light mb-10 max-w-[560px]">
+        <p className="text-base text-stone font-light mb-3 max-w-[640px]">
           {zh
-            ? "整合 ATR 規則的專案會出現在這面牆上。Merge PR 就上牆。"
-            : "Projects that integrate ATR rules appear on this wall. Merge a PR to get listed."}
+            ? "ADOPTERS.md 是這份清單的單一來源。社群採用者自行提 PR 加入,維護者不預先審核;只要 schema 對、有公開可驗證的證據連結就 merge。"
+            : "ADOPTERS.md is the single source of truth for this list. Adopters self-declare via PR — the maintainers do not pre-approve entries. A schema-conforming PR with a verifiable evidence link gets merged."}
+        </p>
+      </Reveal>
+      <Reveal delay={0.25}>
+        <p className="font-data text-xs text-stone tracking-wide mb-10">
+          {zh ? "共計" : "Total"}: <span className="text-ink font-bold">{adopters.count}</span> {zh ? "個採用者" : "adopters"}
+          {" · "}
+          <a
+            href="https://github.com/Agent-Threat-Rule/agent-threat-rules/blob/main/ADOPTERS.md"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="hover:underline"
+          >
+            ADOPTERS.md →
+          </a>
         </p>
       </Reveal>
 
-      {/* Integrated — full cards */}
-      <Reveal>
-        <div className="font-data text-xs font-medium text-stone tracking-[2px] uppercase mb-4">
-          {zh ? `已整合 (${merged.length})` : `Integrated (${merged.length})`}
-        </div>
-      </Reveal>
-      <Reveal delay={0.1}>
-        <div className="grid grid-cols-1 gap-px bg-fog mb-10">
-          {merged.map((item) => (
-            <div key={item.name} className="bg-paper p-6 md:p-8">
-              <div className="flex items-start gap-4">
-                {item.logo && (
-                  <img
-                    src={item.logo}
-                    alt={item.name}
-                    width={48}
-                    height={48}
-                    className="rounded-sm ring-1 ring-fog shrink-0"
-                  />
-                )}
-                <div className="flex-1 min-w-0">
-                  <div className="flex items-baseline gap-3 mb-1">
-                    <h2 className="font-display text-lg font-semibold text-ink">{item.name}</h2>
-                    <span className="font-data text-xs text-green bg-green/10 px-2 py-0.5 rounded-sm uppercase">
-                      {zh ? "已整合" : "integrated"}
-                    </span>
-                  </div>
-                  <p className="text-sm text-stone mb-3">{item.detail}</p>
-                  {item.url && (
+      {/* Tier S / 1 / 2 / 3 — the standard's reach */}
+      {sections.map(({ tier, entries }) => (
+        <section key={tier} className="mb-12">
+          <Reveal>
+            <div className="font-data text-xs font-medium text-stone tracking-[2px] uppercase mb-1">
+              {tierLabel(tier, locale)} ({entries.length})
+            </div>
+          </Reveal>
+          <Reveal delay={0.05}>
+            <p className="text-sm text-stone font-light mb-5 max-w-[680px]">
+              {tierDescription(tier, locale)}
+            </p>
+          </Reveal>
+          {entries.length === 0 ? (
+            <Reveal delay={0.1}>
+              <div className="border border-dashed border-fog px-5 py-6 text-sm text-stone">
+                {zh
+                  ? "目前還沒有採用者列在這一層。把你的專案加進來:"
+                  : "No adopters listed in this tier yet. Add yours:"}{" "}
+                <a
+                  href="https://github.com/Agent-Threat-Rule/agent-threat-rules/blob/main/ADOPTERS.md"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-blue hover:underline"
+                >
+                  ADOPTERS.md
+                </a>
+              </div>
+            </Reveal>
+          ) : (
+            <Reveal delay={0.1}>
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-px bg-fog">
+                {entries.map((a) => (
+                  <article key={a.name} className="bg-paper p-5">
+                    <div className="flex items-baseline justify-between gap-3 mb-1">
+                      <h2 className="font-display text-base font-semibold text-ink">
+                        {a.name}
+                      </h2>
+                      <StatusBadge status={a.status} zh={zh} />
+                    </div>
+                    <p className="font-data text-[11px] text-stone tracking-wide mb-2 uppercase">
+                      {a.org}
+                      {a.since && (
+                        <>
+                          {" · "}
+                          {zh ? "自" : "since"} {a.since}
+                        </>
+                      )}
+                      {" · "}
+                      <span className="text-ink/70">{a.type}</span>
+                    </p>
+                    <p className="text-sm text-stone leading-relaxed mb-3">
+                      {a.integration}
+                    </p>
+                    {a.categories && a.categories.length > 0 && (
+                      <p className="font-data text-[11px] text-stone mb-2">
+                        {zh ? "類別:" : "Categories:"}{" "}
+                        {a.categories.map((c) => (
+                          <span key={c} className="text-ink mr-2">
+                            {c}
+                          </span>
+                        ))}
+                      </p>
+                    )}
                     <a
-                      href={item.url}
+                      href={a.evidence}
                       target="_blank"
                       rel="noopener noreferrer"
                       className="font-data text-xs text-blue hover:underline"
                     >
-                      {zh ? "查看 PR →" : "View PR →"}
+                      {zh ? "證據連結 →" : "Evidence →"}
                     </a>
-                  )}
-                </div>
+                  </article>
+                ))}
               </div>
-            </div>
-          ))}
-        </div>
-      </Reveal>
+            </Reveal>
+          )}
+        </section>
+      ))}
 
-      {/* Under review */}
+      {/* Tier 4 — commercial implementations, visually separated */}
+      {commercial.length > 0 && (
+        <section className="border-t border-fog pt-10 mt-4 mb-12">
+          <Reveal>
+            <div className="font-data text-xs font-medium text-stone tracking-[2px] uppercase mb-1">
+              {tierLabel("4", locale)} ({commercial.length})
+            </div>
+          </Reveal>
+          <Reveal delay={0.05}>
+            <p className="text-sm text-stone font-light mb-5 max-w-[680px]">
+              {tierDescription("4", locale)}
+            </p>
+          </Reveal>
+          <Reveal delay={0.1}>
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-px bg-fog">
+              {commercial.map((a) => (
+                <article key={a.name} className="bg-paper p-5">
+                  <div className="flex items-baseline justify-between gap-3 mb-1">
+                    <h2 className="font-display text-base font-semibold text-ink">
+                      {a.name}
+                    </h2>
+                    <StatusBadge status={a.status} zh={zh} />
+                  </div>
+                  <p className="font-data text-[11px] text-stone tracking-wide mb-2 uppercase">
+                    {a.org}
+                  </p>
+                  <p className="text-sm text-stone leading-relaxed mb-3">{a.integration}</p>
+                  <a
+                    href={a.evidence}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="font-data text-xs text-blue hover:underline"
+                  >
+                    {zh ? "前往 →" : "Visit →"}
+                  </a>
+                </article>
+              ))}
+            </div>
+          </Reveal>
+        </section>
+      )}
+
+      {/* Two-path CTA — Integration Request issue (in-flight) or ADOPTERS PR (shipped) */}
       <Reveal>
-        <div className="font-data text-xs font-medium text-stone tracking-[2px] uppercase mb-4">
-          {zh ? `審查中 (${open.length})` : `Under Review (${open.length})`}
-        </div>
-      </Reveal>
-      <Reveal delay={0.1}>
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-px bg-fog mb-10">
-          {open.map((item) => (
+        <div className="mt-12 border border-fog px-6 py-6 grid grid-cols-1 md:grid-cols-2 gap-6">
+          <div>
+            <div className="font-data text-xs text-stone tracking-[2px] uppercase mb-2">
+              {zh ? "規劃整合中" : "Planning an integration"}
+            </div>
+            <h3 className="font-display text-base font-semibold text-ink mb-2">
+              {zh ? "開 Integration Request issue" : "Open an Integration Request issue"}
+            </h3>
+            <p className="text-sm text-stone mb-3 leading-relaxed">
+              {zh
+                ? "需要 spec walkthrough、design review、sample code,或想討論你的整合形狀,就走這條。維護者七天內回覆。"
+                : "If you want a spec walkthrough, design review, sample code for your language, or to discuss the shape of your integration, this is the path. Maintainers respond within seven days."}
+            </p>
             <a
-              key={item.name}
-              href={item.url}
+              href="https://github.com/Agent-Threat-Rule/agent-threat-rules/issues/new?template=integration-request.yml"
               target="_blank"
               rel="noopener noreferrer"
-              className="bg-paper px-5 py-4 hover:bg-ash/50 transition-colors"
+              className="font-data text-xs text-blue hover:underline"
             >
-              <div className="font-display text-sm font-semibold text-ink mb-1">{item.name}</div>
-              <p className="text-xs text-stone">{item.detail}</p>
+              {zh ? "開 issue →" : "Open issue →"}
             </a>
-          ))}
+          </div>
+          <div>
+            <div className="font-data text-xs text-stone tracking-[2px] uppercase mb-2">
+              {zh ? "已經 ship 了" : "Already shipped"}
+            </div>
+            <h3 className="font-display text-base font-semibold text-ink mb-2">
+              {zh ? "提 PR 加進 ADOPTERS.md" : "Open a PR against ADOPTERS.md"}
+            </h3>
+            <p className="text-sm text-stone mb-3 leading-relaxed">
+              {zh
+                ? "整合已經公開可驗證,直接走這條。Schema 對、有 evidence link 就 merge — 維護者不預先審核採用者。"
+                : "If your integration is publicly verifiable, take this path. Schema-conforming entries with a verifiable evidence link get merged — maintainers do not pre-approve adopters."}
+            </p>
+            <a
+              href="https://github.com/Agent-Threat-Rule/agent-threat-rules/blob/main/ADOPTERS.md"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="font-data text-xs text-blue hover:underline"
+            >
+              ADOPTERS.md →
+            </a>
+          </div>
         </div>
       </Reveal>
 
       {/* Badge */}
       <Reveal>
-        <div className="font-data text-xs font-medium text-stone tracking-[2px] uppercase mb-4">
-          {zh ? "徽章" : "Badge"}
+        <div className="mt-10 mb-3">
+          <div className="font-data text-xs font-medium text-stone tracking-[2px] uppercase mb-2">
+            {zh ? "徽章" : "Badge"}
+          </div>
+          <p className="text-sm text-stone mb-3 max-w-[480px]">
+            {zh
+              ? "你的專案使用 ATR?加上這個徽章。"
+              : "Your project ships ATR? Add this badge to your README."}
+          </p>
         </div>
-        <p className="text-sm text-stone mb-4 max-w-[480px]">
-          {zh
-            ? "你的專案整合了 ATR？把這個徽章加到你的 README。"
-            : "Your project integrates ATR? Add this badge to your README."}
-        </p>
       </Reveal>
-      <Reveal delay={0.1}>
-        <div className="border border-fog p-6">
-          {/* Badge preview */}
-          <div className="mb-4">
+      <Reveal delay={0.05}>
+        <div className="border border-fog p-5">
+          <div className="mb-3">
             <img
               src="https://img.shields.io/badge/ATR-Integrated-2563EB?style=flat&logo=data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA0MCAzNiIgZmlsbD0id2hpdGUiPjxwYXRoIGQ9Ik0yMCAwTDQwIDM2SDMwTDIwIDE4TDEwIDM2SDBMMjAgMFoiLz48L3N2Zz4=&logoColor=white"
               alt="ATR Integrated"
               className="h-6"
             />
           </div>
-
-          {/* Markdown code */}
-          <div className="font-data text-xs text-stone mb-2">{zh ? "Markdown:" : "Markdown:"}</div>
+          <div className="font-data text-xs text-stone mb-1">Markdown:</div>
           <div className="bg-ash border border-fog px-4 py-3 font-data text-xs text-ink overflow-x-auto">
             [![ATR Integrated](https://img.shields.io/badge/ATR-Integrated-2563EB?style=flat)](https://agentthreatrule.org/ecosystem)
           </div>
-
-          <div className="font-data text-xs text-stone mt-4 mb-2">HTML:</div>
-          <div className="bg-ash border border-fog px-4 py-3 font-data text-xs text-ink overflow-x-auto">
-            {'<a href="https://agentthreatrule.org/ecosystem"><img src="https://img.shields.io/badge/ATR-Integrated-2563EB?style=flat" alt="ATR Integrated" /></a>'}
-          </div>
-        </div>
-      </Reveal>
-
-      {/* Add your project CTA */}
-      <Reveal>
-        <div className="mt-10 border border-blue/20 bg-blue/[0.03] px-6 py-5 flex flex-col md:flex-row items-start md:items-center justify-between gap-4">
-          <div>
-            <div className="font-display text-sm font-semibold text-ink mb-1">
-              {zh ? "把你的專案加上來" : "Add your project"}
-            </div>
-            <p className="text-sm text-stone">
-              {zh
-                ? "整合 ATR 規則並提 PR — merge 後就會出現在牆上。"
-                : "Integrate ATR rules and submit a PR — you'll appear on the wall after merge."}
-            </p>
-          </div>
-          <a
-            href="https://github.com/Agent-Threat-Rule/agent-threat-rules/issues/new?title=Ecosystem+integration:+PROJECT_NAME&body=We+integrated+ATR+rules+in+our+project.%0A%0AProject:+%0APR:+%0ARules+used:+"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="bg-blue text-white px-5 py-2.5 rounded-sm text-sm font-semibold hover:bg-blue-hover transition-colors shrink-0"
-          >
-            {zh ? "提交 →" : "Submit →"}
-          </a>
         </div>
       </Reveal>
     </div>
+  );
+}
+
+function StatusBadge({
+  status,
+  zh,
+}: {
+  status: Adopter["status"];
+  zh: boolean;
+}) {
+  if (status === "shipped") {
+    return (
+      <span className="font-data text-[10px] text-green bg-green/10 px-2 py-0.5 rounded-sm uppercase tracking-wide shrink-0">
+        {zh ? "已上線" : "shipped"}
+      </span>
+    );
+  }
+  if (status === "in-review") {
+    return (
+      <span className="font-data text-[10px] text-stone bg-fog/40 px-2 py-0.5 rounded-sm uppercase tracking-wide shrink-0">
+        {zh ? "審查中" : "in review"}
+      </span>
+    );
+  }
+  return (
+    <span className="font-data text-[10px] text-stone bg-fog/30 px-2 py-0.5 rounded-sm uppercase tracking-wide shrink-0">
+      {zh ? "規劃中" : "planning"}
+    </span>
   );
 }

--- a/website/app/[locale]/governance/page.tsx
+++ b/website/app/[locale]/governance/page.tsx
@@ -142,6 +142,162 @@ export default async function GovernancePage({
         </div>
       </Reveal>
 
+      {/* Decision-making */}
+      <Reveal>
+        <div className="font-data text-xs font-medium text-stone tracking-[3px] uppercase mb-3">
+          {zh ? "決策流程" : "Decision-making"}
+        </div>
+        <h2 className="font-display text-xl font-extrabold tracking-[-0.5px] mb-4">
+          {zh ? "每種改動有自己的審核門檻。" : "Different changes have different bars."}
+        </h2>
+      </Reveal>
+      <Reveal delay={0.1}>
+        <div className="border border-fog mb-12">
+          {[
+            {
+              kind: zh ? "新增規則" : "Add a rule",
+              quorum: zh
+                ? "1 名維護者核可 + 自動安全閘通過"
+                : "1 maintainer approval + automated safety-gate pass",
+              detail: zh
+                ? "規則 PR 走六道安全閘(見上面合併政策),通過後一位維護者人工 review 即可 merge。不需要二人核可,因為安全閘已經涵蓋了規則的客觀品質。"
+                : "Rule PRs run through the six safety gates (see Merge policy above). Once they pass, a single maintainer review is sufficient to merge. Two-reviewer requirement is not enforced because the safety gates already cover objective quality.",
+            },
+            {
+              kind: zh ? "修改 spec(ATR-SPEC-v1)" : "Spec amendment (ATR-SPEC-v1)",
+              quorum: zh
+                ? "RFC issue 先開 + 7 天公開評論窗口 + 2 名維護者核可"
+                : "RFC issue opened first + 7-day public comment window + 2 maintainer approvals",
+              detail: zh
+                ? "spec 是所有相容引擎的契約。任何 spec 變動都要先以 issue 形式提出 RFC、開 7 天評論窗讓所有 implementer 看到,然後才接受 PR。在目前 BDFL 階段,「2 名核可」靠主要維護者 + 1 名指定的外部 reviewer。TSC 成立後改為 TSC 過半數核可。"
+                : "The spec is the contract between all conforming engines. Any spec change is opened first as an RFC issue with a 7-day public comment window so every implementer sees it, then the PR is accepted. Under the current BDFL phase the 'two approvals' bar is satisfied by the lead maintainer + one designated external reviewer. When the TSC is formed the bar becomes a TSC majority.",
+            },
+            {
+              kind: zh ? "breaking change(SemVer 主版號)" : "Breaking change (SemVer major bump)",
+              quorum: zh
+                ? "spec amendment 流程 + 30 天提前公告 + CHANGELOG 條目"
+                : "Spec-amendment process + 30-day advance notice + CHANGELOG entry",
+              detail: zh
+                ? "任何破壞 rule schema、engine API、或既有 rule_id 語意的改動都算 breaking。提前 30 天在 GOVERNANCE.md 標題、CHANGELOG、@adopters 通知,讓上游採用者有時間應對。"
+                : "Any change that breaks the rule schema, the engine API, or the semantics of an existing rule_id counts as breaking. A 30-day advance notice goes out via GOVERNANCE.md, CHANGELOG, and an @adopters notification so upstream adopters have time to react.",
+            },
+            {
+              kind: zh ? "新增 / 撤換維護者" : "Add or remove a maintainer",
+              quorum: zh
+                ? "所有現任維護者核可 + 被邀請者書面同意"
+                : "All current maintainers approve + the invited party agrees in writing",
+              detail: zh
+                ? "目前只有一名維護者,所以加第二位維護者要這名維護者本人同意。當有 2+ 名維護者時,新增需要全員核可。撤換需要 2/3 多數(BDFL 階段不適用)。"
+                : "There is currently one maintainer, so adding a second requires that maintainer to agree. Once 2+ maintainers exist, additions require unanimous approval. Removal requires a 2/3 majority (not applicable under BDFL).",
+            },
+            {
+              kind: zh ? "把 rule 標記為 deprecated" : "Deprecate a rule",
+              quorum: zh
+                ? "1 名維護者核可,加 30 天 grace period"
+                : "1 maintainer approval, with a 30-day grace period",
+              detail: zh
+                ? "deprecated 規則仍會留在 corpus 但 engine MUST NOT 預設啟用。30 天後可以從 corpus 刪除;之前已採用的下游可以 pin 到 deprecated 版本。"
+                : "Deprecated rules remain in the corpus but engines MUST NOT enable them by default. After 30 days the rule may be removed from the corpus; downstream adopters who depended on it can pin to a deprecated version.",
+            },
+          ].map((row) => (
+            <div key={row.kind} className="p-5 md:p-6 border-b border-fog last:border-b-0">
+              <div className="grid grid-cols-1 md:grid-cols-[200px_1fr] gap-3 md:gap-6">
+                <div>
+                  <div className="font-display text-sm font-semibold text-ink">{row.kind}</div>
+                </div>
+                <div>
+                  <div className="font-data text-xs text-blue tracking-wide uppercase mb-2">
+                    {row.quorum}
+                  </div>
+                  <p className="text-sm text-graphite leading-[1.7]">{row.detail}</p>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      </Reveal>
+
+      {/* Working group */}
+      <Reveal>
+        <div className="font-data text-xs font-medium text-stone tracking-[3px] uppercase mb-3">
+          {zh ? "工作小組" : "Working group"}
+        </div>
+        <h2 className="font-display text-xl font-extrabold tracking-[-0.5px] mb-4">
+          {zh ? "目前還沒有,但路徑開放。" : "There isn't one yet, and the path to forming one is open."}
+        </h2>
+      </Reveal>
+      <Reveal delay={0.1}>
+        <div className="bg-paper border border-fog p-6 md:p-8 mb-12 text-sm text-graphite leading-[1.7]">
+          <p className="mb-3">
+            {zh
+              ? "OASIS CTI、OpenTelemetry SIG、OWASP Working Group 都有定期會議。ATR 還沒到那個規模——目前所有討論在 GitHub Issues + PR 內非同步進行。"
+              : "OASIS CTI, OpenTelemetry SIGs, and OWASP Working Groups all run scheduled meetings. ATR is not yet at that scale — all discussion happens asynchronously in GitHub Issues and PRs."}
+          </p>
+          <p className="mb-3">
+            {zh
+              ? "如果你有實際的整合工作、想推動 spec 的某個方向、或代表一個 implementer 想要在標準化過程中有結構化的話語權,請開一個 issue 標題以 [WG-proposal] 開頭。當 3 個或以上獨立的 implementer 表達相同需求時,維護者會發起一個固定週期(雙週)的工作小組會議。"
+              : "If you have active integration work, want to push the spec in a particular direction, or represent an implementer that wants structured voice in the standardisation process, open an issue with the title prefixed [WG-proposal]. When three or more independent implementers express the same need, the maintainers will schedule a recurring (bi-weekly) working-group meeting."}
+          </p>
+        </div>
+      </Reveal>
+
+      {/* Become a maintainer */}
+      <Reveal>
+        <div className="font-data text-xs font-medium text-stone tracking-[3px] uppercase mb-3">
+          {zh ? "想成為維護者" : "Become a maintainer"}
+        </div>
+        <h2 className="font-display text-xl font-extrabold tracking-[-0.5px] mb-4">
+          {zh ? "我們正在主動招募。" : "We are actively recruiting."}
+        </h2>
+      </Reveal>
+      <Reveal delay={0.1}>
+        <div className="bg-paper border border-fog p-6 md:p-8 mb-12 text-sm text-graphite leading-[1.7]">
+          <p className="mb-3">
+            {zh
+              ? "ATR 目前只有一位維護者是已知的單點故障。我們正在主動招募第二位、第三位維護者,以便走向 Technical Steering Committee(TSC)模型。"
+              : "Having a single maintainer is a known single-point-of-failure for ATR. We are actively recruiting a second and third maintainer in order to transition to a Technical Steering Committee (TSC) model."}
+          </p>
+          <p className="mb-3 font-semibold text-ink">
+            {zh ? "候選條件:" : "Candidate criteria:"}
+          </p>
+          <ul className="list-disc pl-6 mb-3 space-y-1">
+            <li>
+              {zh
+                ? "過去六個月內,在 ATR repo merge 過至少三個 substantive PR(新規則、schema 修正、engine 改進、或文件實質改寫)"
+                : "Merged at least three substantive PRs in the ATR repo in the prior six months (new rules, schema fixes, engine improvements, or substantive documentation rewrites)"}
+            </li>
+            <li>
+              {zh
+                ? "熟悉 ATR-SPEC-v1 的內容到能解釋 conformance 條款的程度"
+                : "Familiar enough with ATR-SPEC-v1 to explain its conformance clauses"}
+            </li>
+            <li>
+              {zh
+                ? "能配合非同步審核(沒有實時要求,但 PR 平均應在 7 天內收到第一次審核回應)"
+                : "Able to accommodate asynchronous review (no real-time requirement, but PRs should receive a first review response within an average of 7 days)"}
+            </li>
+            <li>
+              {zh
+                ? "在公開場合(GitHub、issue 留言、conference)代表 ATR 時,語氣維持中立、不暗示任何商業利益"
+                : "When representing ATR publicly (GitHub, issue comments, conferences), maintains a neutral register and does not imply any commercial interest"}
+            </li>
+          </ul>
+          <p>
+            {zh ? "申請方式:" : "How to apply: "}
+            {zh ? "寄信至 " : ""}
+            <a
+              href="mailto:adam@agentthreatrule.org?subject=ATR%20maintainer%20application"
+              className="text-blue hover:underline"
+            >
+              adam@agentthreatrule.org
+            </a>
+            {zh
+              ? " 主旨「ATR maintainer application」,內容包含你近期的 PR 連結與你想接哪一塊(rules / spec / engine / documentation)。"
+              : " with subject 'ATR maintainer application'. Include links to your recent PRs and which area you want to take on (rules / spec / engine / documentation)."}
+          </p>
+        </div>
+      </Reveal>
+
       {/* Succession plan */}
       <Reveal>
         <div className="font-data text-xs font-medium text-stone tracking-[3px] uppercase mb-3">
@@ -161,8 +317,8 @@ export default async function GovernancePage({
             </p>
             <p>
               {zh
-                ? "中期：第二位維護者（招募進行中）接任 PR 審核職責。如果 30 天後仍未找到，現有的貢獻者（MISP 的 adulau、OWASP 的 mertsatilmaz）將被邀請擔任臨時維護者。"
-                : "Medium term: A second maintainer (recruitment ongoing) takes over PR review. If none is identified within 30 days, existing contributors — adulau (MISP) and mertsatilmaz (OWASP) — will be invited to serve as interim maintainers."}
+                ? "中期:第二位維護者(招募進行中)接任 PR 審核職責。如果 30 天後仍未找到正式維護者,外部臨時維護者的招募條件是:在過去六個月內 merge 過至少三個 substantive PR、對 schema 有實作熟悉度、且能配合非同步審核。具體人選不會在這個頁面公告;當邀請發出且對方同意後,姓名才會出現在「現任維護者」區塊。"
+                : "Medium term: a second maintainer (recruitment ongoing) takes over PR review. If none is identified within 30 days, interim maintainers will be sought from external contributors who meet the following criteria: merged at least three substantive PRs in the prior six months, demonstrated familiarity with the schema implementation, and able to accommodate asynchronous review. Specific names are NOT published on this page until the invitation has been sent AND the candidate has accepted — at which point the new maintainer appears under 'Current maintainers' above."}
             </p>
             <p>
               {zh
@@ -240,6 +396,24 @@ export default async function GovernancePage({
             className="font-data text-xs text-blue hover:underline"
           >
             {zh ? "在 GitHub 查看 GOVERNANCE.md" : "View GOVERNANCE.md on GitHub"} &rarr;
+          </a>
+          <span className="text-fog">|</span>
+          <a
+            href="https://github.com/Agent-Threat-Rule/agent-threat-rules/blob/main/CODE_OF_CONDUCT.md"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="font-data text-xs text-blue hover:underline"
+          >
+            {zh ? "行為準則" : "Code of Conduct"} &rarr;
+          </a>
+          <span className="text-fog">|</span>
+          <a
+            href="https://github.com/Agent-Threat-Rule/agent-threat-rules/blob/main/SECURITY.md"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="font-data text-xs text-blue hover:underline"
+          >
+            {zh ? "安全揭露政策" : "Security policy"} &rarr;
           </a>
           <span className="text-fog">|</span>
           <a

--- a/website/app/[locale]/page.tsx
+++ b/website/app/[locale]/page.tsx
@@ -75,25 +75,26 @@ export default async function Home({ params }: { params: Promise<{ locale: strin
             <img src="/atr-logo-black.png" alt="ATR" className="h-12 md:h-16 mx-auto mb-8 md:mb-10" />
           </HeroEntrance>
 
-          {/* The standards body framing */}
+          {/* Standards-lineage eyebrow — peer-format framing */}
           <HeroEntrance delay={0.8}>
             <p className="font-display text-[28px] md:text-[clamp(40px,5.5vw,72px)] font-black leading-[1.1] tracking-[-1.5px] md:tracking-[-3px] text-stone">
-              {zh ? "AI Agent 自己做決定的時代,你寫得出規則嗎?" : "An open standard for the"}
+              {zh ? "Sigma 寫給 SIEM。YARA 寫給 malware。" : "Sigma is for SIEM. YARA is for malware."}
             </p>
           </HeroEntrance>
 
+          {/* H1 — ATR's position in the lineage */}
           <HeroEntrance delay={1.1}>
             <h1 className="font-display text-[36px] md:text-[clamp(52px,6.5vw,80px)] font-black leading-[1.05] tracking-[-2px] md:tracking-[-3px] text-ink mt-2 md:mt-3">
-              {zh ? "我們寫了。叫做 ATR。" : "AI agent era."}
+              {zh ? "ATR 寫給 AI agent。" : "ATR is for AI agents."}
             </h1>
           </HeroEntrance>
 
-          {/* Subtitle — risk-consequence framing */}
+          {/* Subtitle — definitional, not outcome */}
           <HeroEntrance delay={1.3}>
             <p className="text-base md:text-lg text-stone font-light mt-5 md:mt-6 max-w-[640px] mx-auto leading-relaxed">
               {zh
-                ? "偵測 prompt 注入、工具下毒、agent 權限升級——在未授權動作發生前。Sigma 寫給 SIEM。ATR 寫給 AI Agent。MIT 永久,由社群維護。"
-                : "Detect prompt injection, tool poisoning, and agent privilege escalation before unauthorized action. The way Sigma is for SIEM. ATR is for AI agents. MIT forever."}
+                ? "AI agent 安全威脅的公共偵測規則格式。版本化、可機器讀取、廠商中立。任何符合規範的引擎都能評估。社群維護,MIT 永久授權。"
+                : "An open, versioned, machine-readable detection rule format for AI agent security threats. Any conforming engine can evaluate it. Community-maintained, MIT licensed."}
             </p>
           </HeroEntrance>
 
@@ -108,40 +109,57 @@ export default async function Home({ params }: { params: Promise<{ locale: strin
             </div>
           </HeroEntrance>
 
-          {/* Two CTA buttons */}
+          {/* CTAs — procedural, standards-form */}
           <HeroEntrance delay={1.7}>
             <div className="flex gap-3 justify-center flex-wrap mt-7 md:mt-8">
               <Link
-                href={`${prefix}/integrate`}
+                href={`${prefix}/quality-standard`}
                 className="bg-blue text-white px-8 md:px-10 py-3.5 md:py-4 rounded-[2px] text-sm font-semibold hover:bg-blue-hover transition-colors"
               >
-                {zh ? "開始整合" : "Integrate ATR"}
+                {zh ? "讀規範" : "Read the spec"}
               </Link>
               <Link
                 href={`${prefix}/rules`}
                 className="text-ink px-8 md:px-10 py-3.5 md:py-4 text-sm font-medium border border-fog hover:border-stone transition-colors rounded-[2px]"
               >
-                {zh ? "瀏覽規則" : "Explore Rules"}
+                {zh ? "瀏覽規則" : "Browse rules"}
+              </Link>
+              <Link
+                href={`${prefix}/contribute`}
+                className="text-ink px-8 md:px-10 py-3.5 md:py-4 text-sm font-medium border border-fog hover:border-stone transition-colors rounded-[2px]"
+              >
+                {zh ? "投規則" : "Submit a rule"}
               </Link>
             </div>
           </HeroEntrance>
 
-          {/* Trust bar — production deployments + ecosystem */}
+          {/* Trust bar — three rows, standards bodies first, text-only (no logos until vendor brand approval) */}
           <HeroEntrance delay={1.9}>
-            <div className="flex flex-wrap items-center justify-center gap-x-4 gap-y-2 mt-8 md:mt-10 font-data text-[11px] md:text-xs text-stone tracking-wide">
-              <span>{zh ? "已上線:" : "In production:"}</span>
-              <span className="font-bold text-ink">Cisco AI Defense</span>
-              <span className="text-fog">·</span>
-              <span className="font-bold text-ink">Microsoft AGT</span>
-              <span className="text-fog">|</span>
-              <span>{zh ? "正在接:" : "Integrating:"}</span>
-              <span>NVIDIA garak</span>
-              <span className="text-fog">·</span>
-              <span>Gen Digital Sage</span>
-              <span className="text-fog">·</span>
-              <span>IBM mcp-context-forge</span>
-              <span className="text-fog">|</span>
-              <span>MIT License · {zh ? "ATR 社群維護" : "Maintained by ATR Community"}</span>
+            <div className="mt-8 md:mt-10 font-data text-[11px] md:text-xs text-stone tracking-wide space-y-1.5">
+              {/* Row 1 — peer standards bodies (most important trust signal for a standard) */}
+              <div className="flex flex-wrap items-center justify-center gap-x-3 gap-y-1">
+                <span>{zh ? "標準同儕:" : "Standards bodies:"}</span>
+                <span className="text-ink">MISP / CIRCL</span>
+                <span className="text-fog">·</span>
+                <span className="text-ink">OWASP A-S-R-H</span>
+                <span className="text-fog">·</span>
+                <span className="text-ink">NIST AI RMF (OSCAL)</span>
+                <span className="text-fog">·</span>
+                <span className="text-ink">OpenTelemetry</span>
+              </div>
+              {/* Row 2 — production deployments */}
+              <div className="flex flex-wrap items-center justify-center gap-x-3 gap-y-1">
+                <span>{zh ? "已上線:" : "In production:"}</span>
+                <span className="font-bold text-ink">Cisco AI Defense</span>
+                <span className="text-fog">·</span>
+                <span className="font-bold text-ink">Microsoft AGT</span>
+                <span className="text-fog">·</span>
+                <span className="font-bold text-ink">Gen Digital Sage</span>
+              </div>
+              {/* Row 3 — license + lineage */}
+              <div className="flex flex-wrap items-center justify-center gap-x-3 gap-y-1 pt-1">
+                <span>MIT License · {zh ? "ATR 社群維護" : "Maintained by ATR Community"} · {zh ? "規範 v1.0 穩定版" : "Spec v1.0 stable"}</span>
+              </div>
             </div>
           </HeroEntrance>
         </div>

--- a/website/components/Footer.tsx
+++ b/website/components/Footer.tsx
@@ -110,7 +110,7 @@ export function Footer({ locale }: { locale: Locale }) {
           </div>
         </div>
 
-        {/* License + static description */}
+        {/* License + standards meta */}
         <div className="border-t border-fog pt-6 pb-4 flex flex-wrap items-center gap-3">
           <a href="https://github.com/Agent-Threat-Rule/agent-threat-rules/blob/main/LICENSE" target="_blank" rel="noopener noreferrer">
             <img src="https://img.shields.io/badge/license-MIT-E8E8E5?style=flat&labelColor=FAFAF8" alt="MIT License" className="h-5" />
@@ -120,15 +120,15 @@ export function Footer({ locale }: { locale: Locale }) {
           </span>
           <span className="font-data text-xs text-fog">·</span>
           <span className="font-data text-xs text-stone">
-            {zh ? "需要企業 SLA 與合規證據：" : "Enterprise deployment with SLAs and compliance evidence:"}
+            {zh ? "商業實作:" : "Commercial implementations:"}
             {" "}
-            <a href="https://panguard.ai" target="_blank" rel="noopener noreferrer" className="text-blue hover:underline">
-              PanGuard AI
-            </a>
+            <Link href={`${prefix}/ecosystem`} className="text-stone hover:text-ink underline-offset-2 hover:underline">
+              {zh ? "見生態系" : "see ecosystem"}
+            </Link>
           </span>
         </div>
 
-        {/* Bottom bar */}
+        {/* Bottom bar — spec lineage, rule count, last-build */}
         <div className="flex flex-col md:flex-row items-center justify-between gap-3 pt-4">
           <div className="flex items-center gap-3">
             <img src="/atr-logo-black.png" alt="ATR" className="h-5 opacity-40" />
@@ -137,7 +137,11 @@ export function Footer({ locale }: { locale: Locale }) {
             </span>
           </div>
           <div className="flex flex-wrap items-center gap-x-4 gap-y-1 font-data text-xs text-mist">
-            <span>ATR v2.1.0 · {stats.ruleCount} {zh ? "條規則" : "rules"}</span>
+            <Link href={`${prefix}/quality-standard`} className="hover:text-stone transition-colors">
+              {zh ? "規範 v1.0" : "Spec v1.0"}
+            </Link>
+            <span className="text-fog">·</span>
+            <span>{stats.ruleCount} {zh ? "條規則" : "rules"}</span>
             <span className="text-fog hidden sm:inline">|</span>
             <span>{zh ? "更新於" : "Updated"} {lastUpdated}</span>
           </div>

--- a/website/lib/adopters.ts
+++ b/website/lib/adopters.ts
@@ -1,0 +1,332 @@
+/**
+ * Parse ADOPTERS.md from the repo root and return typed entries grouped by
+ * tier. ADOPTERS.md is the single source of truth for the website's
+ * /ecosystem page — never inline adopter data anywhere else, always
+ * import this loader.
+ *
+ * The parser is deliberately permissive: malformed entries are skipped
+ * with a console warning rather than crashing the build. This means a
+ * casual contributor who fat-fingers a field still gets their PR merged
+ * (after review) without breaking the static build.
+ *
+ * @module lib/adopters
+ */
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+/** Source location for the canonical adopters file (one level up from `website/`). */
+const ADOPTERS_PATH = join(process.cwd(), "..", "ADOPTERS.md");
+
+/** Adopter tier — matches the section headings in ADOPTERS.md. */
+export type AdopterTier = "S" | "1" | "2" | "3" | "4";
+
+/** Integration shape categories — matches the `Type:` field schema in ADOPTERS.md. */
+export type IntegrationType =
+  | "engine"
+  | "rule-import"
+  | "category-subset"
+  | "adapter"
+  | "reference"
+  | "sidecar-proxy"
+  | "other";
+
+/** One adopter entry parsed from a `### Project Name` block. */
+export interface Adopter {
+  /** Project display name (the `### ...` heading text). */
+  name: string;
+  /** Owning organisation as declared by the adopter. May be "Independent". */
+  org: string;
+  /** Integration type from the fixed enum. Unknown values normalised to "other". */
+  type: IntegrationType;
+  /** One-sentence integration description. */
+  integration: string;
+  /** Evidence URL — merged PR, public docs, blog post, etc. */
+  evidence: string;
+  /** ISO date of public adoption (YYYY-MM-DD). */
+  since: string;
+  /** Adoption status. */
+  status: "shipped" | "in-review" | "planning";
+  /** Optional categories the project consumes. */
+  categories?: string[];
+  /** Which tier section this entry was found under. */
+  tier: AdopterTier;
+}
+
+/** Result of parsing ADOPTERS.md — adopters grouped by tier, in declaration order. */
+export interface AdoptersData {
+  tierS: Adopter[];
+  tier1: Adopter[];
+  tier2: Adopter[];
+  tier3: Adopter[];
+  tier4: Adopter[];
+  /** Total parsed entries across all tiers. */
+  count: number;
+}
+
+/** Headings in ADOPTERS.md that introduce a tier section. */
+const TIER_HEADINGS: Array<{ heading: string; tier: AdopterTier }> = [
+  { heading: "Tier S", tier: "S" },
+  { heading: "Tier 1", tier: "1" },
+  { heading: "Tier 2", tier: "2" },
+  { heading: "Tier 3", tier: "3" },
+  { heading: "Tier 4", tier: "4" },
+];
+
+/**
+ * Normalise an integration type string from ADOPTERS.md to the
+ * `IntegrationType` enum. Anything unrecognised collapses to `"other"`
+ * so the website renders without crashing.
+ */
+function normaliseType(raw: string): IntegrationType {
+  const t = raw.trim().toLowerCase();
+  if (
+    t === "engine" ||
+    t === "rule-import" ||
+    t === "category-subset" ||
+    t === "adapter" ||
+    t === "reference" ||
+    t === "sidecar-proxy"
+  ) {
+    return t;
+  }
+  return "other";
+}
+
+/**
+ * Normalise a status string to the allowed set. Unrecognised values
+ * collapse to `"shipped"` since that is the most common case and a
+ * harmless default for display purposes.
+ */
+function normaliseStatus(raw: string): "shipped" | "in-review" | "planning" {
+  const s = raw.trim().toLowerCase();
+  if (s === "in-review" || s === "planning") return s;
+  return "shipped";
+}
+
+/**
+ * Extract the value following a bold field marker in a markdown bullet
+ * list. Handles both:
+ *   - **Org**: value
+ *   - - **Org**: value
+ *   - **Org**: value (with trailing detail)
+ * Returns undefined when the field is absent.
+ */
+function extractField(block: string, fieldName: string): string | undefined {
+  const re = new RegExp(`\\*\\*${fieldName}\\*\\*\\s*:\\s*([^\\n]+)`, "i");
+  const m = block.match(re);
+  return m ? m[1].trim() : undefined;
+}
+
+/**
+ * Parse a single `### Heading` adopter block into an `Adopter`, or return
+ * null if required fields are missing.
+ */
+function parseEntry(block: string, tier: AdopterTier): Adopter | null {
+  const nameMatch = block.match(/^###\s+(.+?)\s*$/m);
+  if (!nameMatch) return null;
+  const name = nameMatch[1].trim();
+
+  const org = extractField(block, "Org") ?? "Independent";
+  const typeRaw = extractField(block, "Type") ?? "other";
+  const integration = extractField(block, "Integration");
+  const evidence = extractField(block, "Evidence");
+  const since = extractField(block, "Since") ?? "";
+  const statusRaw = extractField(block, "Status") ?? "shipped";
+  const categoriesRaw = extractField(block, "Categories");
+
+  if (!integration || !evidence) {
+    // Required fields missing — skip rather than render a broken card.
+    // The parser is permissive on purpose: see file header.
+    if (typeof process !== "undefined" && process.env.NODE_ENV !== "production") {
+      // eslint-disable-next-line no-console
+      console.warn(`[adopters] skipping entry "${name}" — missing Integration or Evidence`);
+    }
+    return null;
+  }
+
+  // Evidence values may be wrapped in angle brackets `<url>`, the markdown
+  // autolink form, or a `[label](url)` pair. Normalise to the URL.
+  let evidenceUrl = evidence;
+  const angleMatch = evidence.match(/^<(.+)>$/);
+  if (angleMatch) evidenceUrl = angleMatch[1];
+  const linkMatch = evidence.match(/^\[.*?\]\((.+?)\)/);
+  if (linkMatch) evidenceUrl = linkMatch[1];
+
+  const categories = categoriesRaw
+    ? categoriesRaw
+        .replace(/[`*]/g, "")
+        .split(",")
+        .map((c) => c.trim())
+        .filter(Boolean)
+    : undefined;
+
+  return {
+    name,
+    org,
+    type: normaliseType(typeRaw),
+    integration,
+    evidence: evidenceUrl,
+    since,
+    status: normaliseStatus(statusRaw),
+    categories,
+    tier,
+  };
+}
+
+/**
+ * Split a tier section (between `## Tier X — ...` and the next `## ` or
+ * EOF) into individual `### Heading` blocks.
+ */
+function splitEntries(section: string): string[] {
+  // Split the tier section on lines that begin a `### Heading`. The
+  // pattern is line-anchored and uses `[\s\S]` instead of the `/s` flag
+  // because the project targets ES2017 (which lacks dotAll support).
+  const blocks: string[] = [];
+  const lines = section.split("\n");
+  let current: string[] = [];
+  for (const line of lines) {
+    if (/^###\s+/.test(line)) {
+      if (current.length > 0) {
+        blocks.push(current.join("\n"));
+      }
+      current = [line];
+    } else if (current.length > 0) {
+      current.push(line);
+    }
+  }
+  if (current.length > 0) {
+    blocks.push(current.join("\n"));
+  }
+  return blocks;
+}
+
+/**
+ * Load and parse ADOPTERS.md. Called once per static-build by the
+ * /ecosystem page. Returns empty arrays if the file is missing — the
+ * page renders an empty-state message rather than failing the build.
+ */
+export function loadAdopters(): AdoptersData {
+  let raw: string;
+  try {
+    raw = readFileSync(ADOPTERS_PATH, "utf-8");
+  } catch {
+    return { tierS: [], tier1: [], tier2: [], tier3: [], tier4: [], count: 0 };
+  }
+
+  const byTier: Record<AdopterTier, Adopter[]> = {
+    S: [],
+    "1": [],
+    "2": [],
+    "3": [],
+    "4": [],
+  };
+
+  // ES2017 lacks the `/s` regex flag, so we extract each tier section
+  // by walking line-by-line. The body of a tier starts at its `## Tier X`
+  // heading and runs until the next top-level `## ` heading or EOF.
+  const lines = raw.split("\n");
+  let currentTier: AdopterTier | null = null;
+  let currentSection: string[] = [];
+  const sections: Array<{ tier: AdopterTier; body: string }> = [];
+  for (const line of lines) {
+    const topLevel = /^## (.+?)$/.exec(line);
+    if (topLevel) {
+      // Flush the previous tier (if any) before starting a new section.
+      if (currentTier !== null) {
+        sections.push({ tier: currentTier, body: currentSection.join("\n") });
+      }
+      const heading = topLevel[1];
+      const match = TIER_HEADINGS.find((t) => heading.startsWith(t.heading));
+      currentTier = match ? match.tier : null;
+      currentSection = [];
+      continue;
+    }
+    if (currentTier !== null) currentSection.push(line);
+  }
+  if (currentTier !== null) {
+    sections.push({ tier: currentTier, body: currentSection.join("\n") });
+  }
+
+  for (const { tier, body } of sections) {
+    const blocks = splitEntries(body);
+    for (const block of blocks) {
+      const entry = parseEntry(block, tier);
+      if (entry) byTier[tier].push(entry);
+    }
+  }
+
+  const count =
+    byTier.S.length +
+    byTier["1"].length +
+    byTier["2"].length +
+    byTier["3"].length +
+    byTier["4"].length;
+
+  return {
+    tierS: byTier.S,
+    tier1: byTier["1"],
+    tier2: byTier["2"],
+    tier3: byTier["3"],
+    tier4: byTier["4"],
+    count,
+  };
+}
+
+/**
+ * Display label for an adopter tier. EN and ZH variants.
+ */
+export function tierLabel(tier: AdopterTier, locale: "en" | "zh"): string {
+  const labels: Record<AdopterTier, { en: string; zh: string }> = {
+    S: {
+      en: "Standards bodies & frameworks",
+      zh: "標準同儕與框架",
+    },
+    "1": {
+      en: "Production deployments",
+      zh: "生產部署",
+    },
+    "2": {
+      en: "Open-source tooling & SDK integrations",
+      zh: "開源工具與 SDK 整合",
+    },
+    "3": {
+      en: "Documentation references & awesome-lists",
+      zh: "文件引用與 awesome-list",
+    },
+    "4": {
+      en: "Commercial implementations",
+      zh: "商業實作",
+    },
+  };
+  return labels[tier][locale];
+}
+
+/**
+ * One-line description of what each tier means, for the section sub-head.
+ */
+export function tierDescription(tier: AdopterTier, locale: "en" | "zh"): string {
+  const descriptions: Record<AdopterTier, { en: string; zh: string }> = {
+    S: {
+      en: "Adopters whose adoption is itself a public-good interoperability artefact — taxonomies, profiles, schemas published by neutral bodies.",
+      zh: "其本身就是公共財互操作性產出的採用者:由中立機構發佈的分類、規範對應、schema。",
+    },
+    "1": {
+      en: "Adopters who ship ATR in a publicly-available customer-facing product.",
+      zh: "在公開、面向客戶的產品中部署 ATR 的採用者。",
+    },
+    "2": {
+      en: "Open-source developer tools, frameworks, and SDKs that integrate ATR.",
+      zh: "整合 ATR 的開源開發者工具、框架、SDK。",
+    },
+    "3": {
+      en: "Adopters who reference ATR in public catalogues, awesome-lists, or documentation indices.",
+      zh: "在公開目錄、awesome-list、文件索引中引用 ATR 的採用者。",
+    },
+    "4": {
+      en: "Vendors offering commercial support, hosted engines, or enterprise SLAs around ATR.",
+      zh: "提供商業支援、託管引擎、或圍繞 ATR 提供企業 SLA 的供應商。",
+    },
+  };
+  return descriptions[tier][locale];
+}


### PR DESCRIPTION
## Summary

Two related changes that move ATR's public surface from vendor-feel to standards-feel:

### 1. Website hero + footer rewrite (P0)

The previous hero opened with "Detect prompt injection ... before unauthorized action" — that is product-outcome language. Peer standards bodies (MITRE ATT&CK, Sigma, NIST AI RMF) open with what the standard IS, not what the user gets.

- Eyebrow: `Sigma is for SIEM. YARA is for malware.` / `Sigma 寫給 SIEM。YARA 寫給 malware。`
- H1: `ATR is for AI agents.` / `ATR 寫給 AI agent。`
- Subtitle: definitional ("An open, versioned, machine-readable detection rule format. Any conforming engine can evaluate it.")
- CTAs: `Read the spec / Browse rules / Submit a rule` (procedural standards form, not "Get Started")
- Trust bar: 3 rows with **peer standards bodies FIRST** (MISP / OWASP / NIST OSCAL / OpenTelemetry), production deployments second, license third. Text-only — commercial logos require brand-program approval, which is not in place.
- Footer: hardcoded `ATR v2.1.0` replaced with Link to `/quality-standard` labelled `Spec v1.0` (decouples spec version from rule-corpus version). PanGuard direct CTA softened to "Commercial implementations: see ecosystem".

### 2. Integration intake pipeline (P1 enablement)

ATR had no self-serve path for external maintainers wanting to integrate. Adds the standard intake pipeline used by Sigma / MITRE / OWASP:

- `.github/ISSUE_TEMPLATE/integration-request.yml` — structured intake form (project, repo, integration type, tier, timeline, role, help requested)
- `.github/workflows/integration-request-triage.yml` — auto-triage workflow (idempotent welcome comment, auto-label by tier)
- `ADOPTERS.md` — machine-readable adopters list with fixed per-entry schema; backfilled with 17 verified adopters as of 2026-05-22 across 4 tiers (Standards bodies / Production / Tooling / Docs-and-awesome-lists) + a separate Tier 4 for commercial implementations (currently: PanGuard AI only)
- `.github/PULL_REQUEST_TEMPLATE/adopter.md` — self-add PR template
- README §6 surfaces both paths

The maintainers do not pre-approve adopter entries. Schema-conforming PR with a verifiable evidence link gets merged — same model as Sigma.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `npm run build` static-export succeeds
- [x] EN + ZH locale render all new strings correctly
- [x] `js-yaml` parse passes on both new YAML files
- [ ] Smoke-test the integration-request issue form by opening a test issue once merged
- [ ] Verify triage workflow fires on the test issue
- [ ] Confirm Cloudflare Pages auto-deploys on merge

## Out of scope (later P1/P2)

- `/ecosystem` page upgrade to render ADOPTERS.md dynamically
- `/governance` page content (BDFL → TSC, reviewer pool)
- `/contribute` page content
- Top nav restructure (Spec / Rules / Catalogue / Adopters / Contribute / Governance / Research)
- `Agent-Threat-Rule/integration-helper@v1` reusable action

Audit ref: ATR website "world-standard" positioning rewrite blueprint.