### PR TITLE
fix(cli): emit valid PreToolUse hook structure in `atr init`

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -692,7 +692,7 @@ function cmdInit(options: Record<string, string>): void {
     // Empty matcher means "match all tools" in Claude Code hooks —
     // this is intentional so every tool call is scanned against ATR rules.
     matcher: '',
-    command: 'npx agent-threat-rules guard',
+    hooks: [{ type: 'command', command: 'npx agent-threat-rules guard' }],
   };
 
   // Determine target settings file
@@ -736,14 +736,30 @@ function cmdInit(options: Record<string, string>): void {
   }
   const preToolUse = hooks['PreToolUse'] as Array<Record<string, unknown>>;
 
-  // Check if hook is already configured (validate each element is an object before accessing .command)
-  const alreadyConfigured = preToolUse.some(
-    (entry: unknown) =>
-      typeof entry === 'object' &&
-      entry !== null &&
-      !Array.isArray(entry) &&
-      (entry as Record<string, unknown>)['command'] === hookEntry.command
-  );
+  // Check if the guard hook is already configured. The command lives inside
+  // each entry's nested `hooks` array; we also tolerate the legacy flat
+  // `command` field so re-running init stays idempotent on older configs.
+  const hasGuardCommand = (entry: unknown): boolean => {
+    if (typeof entry !== 'object' || entry === null || Array.isArray(entry)) {
+      return false;
+    }
+    const e = entry as Record<string, unknown>;
+    if (e['command'] === 'npx agent-threat-rules guard') {
+      return true;
+    }
+    const nested = e['hooks'];
+    return (
+      Array.isArray(nested) &&
+      nested.some(
+        (h) =>
+          typeof h === 'object' &&
+          h !== null &&
+          (h as Record<string, unknown>)['command'] === 'npx agent-threat-rules guard'
+      )
+    );
+  };
+
+  const alreadyConfigured = preToolUse.some(hasGuardCommand);
 
   if (alreadyConfigured) {
     console.log(`${GREEN}ATR guard hook already configured${RESET} in ${settingsPath}`);


### PR DESCRIPTION
## Summary

`atr init` (and `atr init --global`) writes a `PreToolUse` hook entry that Claude Code rejects, so the guard hook never runs and `claude doctor` reports a settings error.

## What broke

`cmdInit` emits each entry as a flat object:

```json
{ "matcher": "", "command": "npx agent-threat-rules guard" }
```

Claude Code requires the command to live inside a nested `hooks` array. The flat form is silently ignored at runtime **and** fails settings validation — `claude doctor` reports:

```
Settings (~/.claude/settings.json › hooks.PreToolUse.0.hooks): Expected array, but received undefined
```

Every user who runs `atr init` ends up with an invalid settings file and a guard hook that never fires.

## Fix

Emit the structure Claude Code expects:

```json
{ "matcher": "", "hooks": [{ "type": "command", "command": "npx agent-threat-rules guard" }] }
```

- `cmdInit` now builds `hooks: [{ type: 'command', command: '...' }]`.
- The "already configured" idempotency check looks inside the nested `hooks` array, while still tolerating the legacy flat `command` field so re-running `atr init` on a pre-fix config stays idempotent and doesn't double-add the hook.

Single file changed: `src/cli.ts`.

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm test` passes (30 files, 467 passed / 1 skipped — the skip is the optional `@xenova/transformers` embedding model)
- [x] `atr init` writes `hooks.PreToolUse[].hooks` as an array; `claude doctor` reports no settings error
- [x] Re-running `atr init` reports "already configured" and does not duplicate the entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)
