### PR TITLE
docs: correct PINT framing — self-built corpus, not Lakera's official PINT

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -367,7 +367,7 @@ Responsive grid (1/2/3 cols) of 8 threat categories. Each: name + count + one-li
 The story: engineer submitted PR, reviewed, merged in 3 days. Link to PR #79.
 
 **Scene 6 — The Standards:**
-4-column row: OWASP 10/10 / SAFE-MCP 91.8% / AST10 7/10 / PINT F1 76.7
+4-column row: OWASP 10/10 / SAFE-MCP 91.8% / AST10 7/10 / PINT-format F1 77.3
 
 **Scene 7 — The Future (AI-Native Contribution + Crystallization):**
 "ATR rules don't have to be written by hand."
@@ -390,7 +390,7 @@ Four paths: TypeScript, Python, Raw YAML, SIEM converters.
 | OWASP Agentic Top 10 merge | Scene 6 + /coverage | PR #14, 10/10 categories |
 | SAFE-MCP coverage | Scene 6 + /coverage | 78/85 techniques, 91.8% |
 | OWASP AST10 coverage | Scene 6 + /coverage | 7/10, 3 are process-level |
-| PINT external benchmark | Scene 3 + /research | 850 samples, 99.4% precision, 62.7% recall, F1 76.7 |
+| PINT-format corpus (self-built) | Scene 3 + /research | 850 samples, 99.7% precision, 63.2% recall, F1 77.3 |
 | ClawHub full scan | Scene 2 + /research | 36,394 skills, 182 CRITICAL, 1,124 HIGH |
 | Skills.sh crawl | /research | 91,226 skills from 124 publishers |
 | npm downloads | Footer or Scene 3 | 23,000+ monthly across all packages |

--- a/LIMITATIONS.md
+++ b/LIMITATIONS.md
@@ -1,8 +1,8 @@
 # ATR Limitations
 
-ATR v2.0.0 uses regex-based pattern detection (`detection_tier: pattern`, `schema_version: 0.1`). This document is a transparent accounting of what that approach can and cannot do. Read this before deploying ATR in production.
+ATR v3.0.5 uses regex-based pattern detection (`detection_tier: pattern`, `schema_version: 0.1`). This document is a transparent accounting of what that approach can and cannot do. Read this before deploying ATR in production.
 
-**Current stats:** 113 rules, 361 tests passing. MCP benchmark: 62.7% recall, 99.6% precision (PINT, 850 samples). SKILL.md benchmark: 100% recall, 97% precision, 0.20% FP (498 real-world samples). Plus 64 evasion tests documenting known bypasses.
+**Current stats:** 459 rules. On an 850-sample PINT-format corpus (deepset/prompt-injections + Lakera Gandalf -- not Lakera's official private PINT benchmark): 63.2% recall, 99.7% precision. SKILL.md benchmark: 100% recall, 97% precision, 0.20% FP (498 real-world samples). Plus 64 evasion tests documenting known bypasses.
 
 That pass rate sounds impressive. It is not. It means ATR correctly matches the patterns it was written to match. It says nothing about attacks that use different words to express the same intent.
 
@@ -127,29 +127,29 @@ The tiers are additive, not replacements. Tier 1 handles the fast path (block ob
 
 ATR's self-test corpus produces a 99.4% recall rate. That number is misleading if taken in isolation. Self-tests are written by the same people who wrote the rules -- they test whether ATR matches the patterns it was designed to match. External benchmarks paint a very different picture.
 
-### PINT Benchmark (850 samples)
+### PINT-format public corpus (850 samples)
 
-We evaluated ATR against 850 external samples sourced from deepset/prompt-injections and Lakera's Gandalf dataset. These are real-world prompt injection and jailbreak payloads that ATR was not trained against.
+We evaluated ATR against 850 external samples sourced from deepset/prompt-injections and Lakera's Gandalf dataset, assembled into Lakera's PINT format. This is ATR's own reconstructed corpus -- not a run of Lakera's official PINT benchmark, which is private (~4,314 samples). These are real-world prompt injection and jailbreak payloads that ATR was not trained against.
 
 | Metric | Score |
 |--------|-------|
 | Precision | 99.7% |
-| Recall | 62.7% |
-| F1 | 77.0% |
+| Recall | 63.2% |
+| F1 | 77.3% |
 
 **Precision is high.** When ATR fires, it is almost always correct. This is by design -- regex patterns are specific, so false positives are rare.
 
-**Recall is moderate.** ATR misses 37.3% of external attack samples. This is the honest cost of regex-based detection.
+**Recall is moderate.** ATR misses 36.8% of external attack samples. This is the honest cost of regex-based detection.
 
 ### Recall Breakdown by Category
 
 | Category | Recall |
 |----------|--------|
-| English jailbreaks | 51.6% |
-| English prompt-injection | 27.6% |
-| Non-English attacks | 24.4% |
+| Jailbreak | 73.7% |
+| Prompt-injection | 55.6% |
+| Non-English (hard subset) | 57.3% |
 
-Non-English recall at 24.4% is consistent with the multilingual limitation documented above. The rules are English-only; non-English detections occur only when attackers include English keywords alongside non-English text.
+Non-English (hard-subset) recall at 57.3% remains below the English jailbreak rate; the rules are English-first, so non-English detections still rely largely on English keywords appearing alongside non-English text.
 
 ### Rule Concentration
 
@@ -160,9 +160,9 @@ On the MCP/PINT benchmark (v0.4, 71 rules at the time), only 6 rules fired on ex
 | Corpus | Recall |
 |--------|--------|
 | Self-test (341 samples) | 99.4% |
-| External (850 samples) | 62.7% |
+| External (850 samples) | 63.2% |
 
-The 37-point gap is explained entirely by the paraphrase problem. Self-test samples use the exact phrasings the rules were written to match. External samples express the same malicious intent using different words, sentence structures, and languages. This is the fundamental limitation of regex-based detection, documented extensively in the "What Regex CANNOT Detect" section above.
+The 36-point gap is explained entirely by the paraphrase problem. Self-test samples use the exact phrasings the rules were written to match. External samples express the same malicious intent using different words, sentence structures, and languages. This is the fundamental limitation of regex-based detection, documented extensively in the "What Regex CANNOT Detect" section above.
 
 ### Competitive Context
 

--- a/README.md
+++ b/README.md
@@ -339,7 +339,7 @@ Aggregated into [`data/stats.json`](data/stats.json) under `benchmarks[]`.
 | MITRE ATLAS | snapshot-2026-04 | 182 | 100.0% | 100.0% | 0.0% | 2026-05-23 |
 | NeMo Guardrails (NVIDIA test fixtures) | corpus-2026-05-12 | 6 | 100.0% | 100.0% | 0.0% | 2026-05-23 |
 | OWASP LLM Top 10 | snapshot-2026-04 | 56 | 100.0% | 100.0% | 0.0% | 2026-05-23 |
-| PINT (Invariant Labs) | v1 | 850 | 63.2% | 99.7% | 0.0% | 2026-05-23 |
+| PINT-format (deepset + Lakera Gandalf) | public-850 | 850 | 63.2% | 99.7% | 0.0% | 2026-05-23 |
 | PromptBench (academic adversarial) | snapshot-2026-04 | 3,280 | 0.0% | 100.0% | 0.0% | 2026-05-23 |
 | promptfoo (red-team plugin fixtures) | corpus-2026-05-12 | 44 | 79.5% | 100.0% | 0.0% | 2026-05-23 |
 | PromptInject (academic adversarial) | snapshot-2026-04 | 1,080 | 0.0% | 100.0% | 0.0% | 2026-05-23 |
@@ -470,7 +470,7 @@ ATR is released under the [MIT License](LICENSE). All contributions are MIT-lice
 
 ## 16. Acknowledgments
 
-ATR's design draws on prior work in: [Sigma](https://github.com/SigmaHQ/sigma) (SIEM detection format), [YARA](https://github.com/VirusTotal/yara) (malware signature format), [OWASP LLM Top 10](https://owasp.org/www-project-top-10-for-large-language-model-applications/), [OWASP Agentic Top 10](https://genai.owasp.org/resource/owasp-top-10-for-agentic-applications-for-2026/), [MITRE ATLAS](https://atlas.mitre.org/), [NVIDIA garak](https://github.com/NVIDIA/garak), [Invariant Labs PINT](https://invariantlabs.ai/), [Meta LlamaFirewall](https://ai.meta.com/research/publications/llamafirewall-an-open-source-guardrail-system-for-building-secure-ai-agents/), and [SAFE-MCP (OpenSSF)](https://github.com/safe-agentic-framework/safe-mcp).
+ATR's design draws on prior work in: [Sigma](https://github.com/SigmaHQ/sigma) (SIEM detection format), [YARA](https://github.com/VirusTotal/yara) (malware signature format), [OWASP LLM Top 10](https://owasp.org/www-project-top-10-for-large-language-model-applications/), [OWASP Agentic Top 10](https://genai.owasp.org/resource/owasp-top-10-for-agentic-applications-for-2026/), [MITRE ATLAS](https://atlas.mitre.org/), [NVIDIA garak](https://github.com/NVIDIA/garak), [Lakera PINT](https://github.com/lakeraai/pint-benchmark), [Meta LlamaFirewall](https://ai.meta.com/research/publications/llamafirewall-an-open-source-guardrail-system-for-building-secure-ai-agents/), and [SAFE-MCP (OpenSSF)](https://github.com/safe-agentic-framework/safe-mcp).
 
 The 96,096-skill ecosystem scan was made possible by the maintainers of OpenClaw, Skills.sh, Hermes Agent, and ClawHub publishing their registries openly.
 

--- a/docs/SAFE-MCP-MAPPING.md
+++ b/docs/SAFE-MCP-MAPPING.md
@@ -209,7 +209,7 @@ SAFE-MCP version: latest (85 techniques, 47 mitigations)
 | **Output** | "These attacks exist and here's how they work" | "Here's how to detect these attacks in real MCP traffic" |
 | **Format** | Markdown technique descriptions with mitigations | Machine-readable YAML rules with regex patterns |
 | **Data** | Theoretical framework with example scenarios | 36,394 real-world skills scanned, empirical findings |
-| **Benchmark** | No benchmark | PINT benchmark: 62.7% recall, 99.7% precision |
+| **Benchmark** | No benchmark | PINT-format corpus (self-built): 63.2% recall, 99.7% precision |
 | **OWASP** | Not mapped | 10/10 OWASP Agentic Top 10 coverage |
 
 **ATR provides the detection layer that operationalizes SAFE-MCP's threat taxonomy.** SAFE-MCP tells you what to look for; ATR tells you how to find it.

--- a/docs/ecosystem-pr-proposals.md
+++ b/docs/ecosystem-pr-proposals.md
@@ -251,7 +251,7 @@ async def check_blacklist(skill_name: str) -> dict:
 
 **PR: Leaderboard entry**
 - Pre-requirement: email opensource@lakera.ai
-- Numbers: 62.7% recall, 99.7% precision, F1 77.1%
+- Numbers: 63.2% recall, 99.7% precision, F1 77.3% (850-sample PINT-format corpus, self-built — not Lakera's official PINT)
 - Method: Regex-based, <1ms, 108 rules
 - Positioning: "Fast first gate before LLM-based detectors"
 

--- a/docs/owasp-pr/ASI01_Agent_Behaviour_Hijack.md
+++ b/docs/owasp-pr/ASI01_Agent_Behaviour_Hijack.md
@@ -20,7 +20,7 @@ The attack surface is broad: any channel through which an agent receives natural
 
 1. Prevention Step 1: **Input Sanitization and Instruction Hierarchy:** Enforce strict separation between system instructions and user/external input. Strip or neutralize model-specific tokens (`[INST]`, `<<SYS>>`, `<|im_start|>`) from all external content before processing. Implement instruction hierarchy where system prompts cannot be overridden by user-level input.
 
-2. Prevention Step 2: **Multi-Layer Detection with Pattern Matching:** Deploy detection rules that identify injection patterns across all input channels. ATR (Agent Threat Rules) provides 13 rules for this category, including ATR-2026-001 (Direct Prompt Injection), ATR-2026-002 (Indirect Prompt Injection with 13 detection layers), ATR-2026-003 (Jailbreak with 15+ technique categories and multilingual support), ATR-2026-004 (System Prompt Override with 15 detection layers), and ATR-2026-005 (Multi-Turn Injection). These rules achieve 99.7% precision on the PINT benchmark.
+2. Prevention Step 2: **Multi-Layer Detection with Pattern Matching:** Deploy detection rules that identify injection patterns across all input channels. ATR (Agent Threat Rules) provides 13 rules for this category, including ATR-2026-001 (Direct Prompt Injection), ATR-2026-002 (Indirect Prompt Injection with 13 detection layers), ATR-2026-003 (Jailbreak with 15+ technique categories and multilingual support), ATR-2026-004 (System Prompt Override with 15 detection layers), and ATR-2026-005 (Multi-Turn Injection). These rules achieve 99.7% precision on an 850-sample PINT-format corpus (deepset + Lakera Gandalf).
 
 3. Prevention Step 3: **Context Isolation and Output Filtering:** Process external content (web pages, documents, API responses) in isolated contexts where embedded instructions cannot affect the agent's core behavior. Apply output filtering to detect when the agent begins following injected instructions rather than its legitimate task. Monitor for behavioral anomalies such as sudden topic shifts or unauthorized data disclosure.
 
@@ -32,7 +32,7 @@ Scenario #2: An attacker engages an agent across multiple conversation turns: Tu
 
 **Reference Links:**
 
-1. [PINT Benchmark — Prompt Injection Test Suite](https://github.com/PINT-Benchmark/PINT): Standardized evaluation framework for prompt injection detection.
+1. [Lakera PINT — Prompt Injection Test Suite](https://github.com/lakeraai/pint-benchmark): Standardized evaluation framework for prompt injection detection.
 2. [ATR-2026-001: Direct Prompt Injection](https://github.com/Agent-Threat-Rule/agent-threat-rules): Open-source detection rule with regex patterns for instruction override, task switching, and forget-all attacks.
 3. [ATR-2026-002: Indirect Prompt Injection](https://github.com/Agent-Threat-Rule/agent-threat-rules): 13-layer detection covering HTML comments, zero-width characters, model tokens, CSS-hidden text, and base64 payloads.
 4. [CVE-2024-5184](https://nvd.nist.gov/vuln/detail/CVE-2024-5184): Prompt injection vulnerability in AI assistant leading to unauthorized data access.

--- a/docs/owasp-pr/README.md
+++ b/docs/owasp-pr/README.md
@@ -6,7 +6,7 @@ This PR adds real-world attack examples, prevention strategies, and detection re
 
 - **76 open-source detection rules** from [ATR (Agent Threat Rules)](https://github.com/Agent-Threat-Rule/agent-threat-rules), MIT licensed
 - **36,394 MCP skills scanned** on ClawHub (182 CRITICAL, 1,124 HIGH findings)
-- **PINT benchmark results**: 62.7% recall, 99.7% precision
+- **PINT-format corpus** (850 samples from deepset + Lakera Gandalf, not Lakera's official PINT benchmark): 63.2% recall, 99.7% precision
 - **Real CVEs**: CVE-2026-28363 (CVSS 9.9), CVE-2026-25253 (CVSS 8.8), CVE-2025-59536 (CVSS 8.7), CVE-2025-49150, CVE-2025-53773, and others
 - **Real attack campaigns**: ClawHavoc (1,184 malicious skills), AMOS infostealer (314 skills), Snyk ToxicSkills (76 confirmed malicious)
 
@@ -14,7 +14,7 @@ This PR adds real-world attack examples, prevention strategies, and detection re
 
 | ASI Category | ATR Rules | Real CVEs | Attack Campaigns |
 |---|---|---|---|
-| ASI01: Agent Behaviour Hijack | 13 | CVE-2024-5184, CVE-2025-53773 | PINT benchmark |
+| ASI01: Agent Behaviour Hijack | 13 | CVE-2024-5184, CVE-2025-53773 | PINT-format eval |
 | ASI02: Tool Misuse & Exploitation | 11 | CVE-2025-59536, CVE-2025-49150 | MCP server compromises |
 | ASI03: Identity & Privilege Abuse | 9 | CVE-2025-59536 | Snyk 280+ leaky skills |
 | ASI04: Supply Chain Vulnerabilities | 8 | CVE-2026-28363 (9.9), CVE-2026-25253 (8.8) | ClawHavoc, AMOS, ToxicSkills |
@@ -46,5 +46,5 @@ ATR (Agent Threat Rules) is an open-source, MIT-licensed detection ruleset for a
 
 - Repository: https://github.com/Agent-Threat-Rule/agent-threat-rules
 - Rules: 76 (71 MCP + 5 skill-level)
-- Benchmark: PINT (62.7% recall, 99.7% precision)
+- Eval: PINT-format corpus, self-built from public datasets (63.2% recall, 99.7% precision)
 - License: MIT

--- a/docs/paper/ATR-Paper.tex
+++ b/docs/paper/ATR-Paper.tex
@@ -732,7 +732,7 @@ Recall by input type:
 
   Structured skill manifests (SKILL.md):     100%   <-- Schema-constrained,
                                                          limited paraphrase space
-  Adversarial natural language (PINT):        62.7%  <-- Infinite paraphrase space,
+  Adversarial natural language (PINT):        63.2%  <-- Infinite paraphrase space,
                                                          multi-language, encoding tricks
 \end{lstlisting}
 

--- a/governance/oasis-proposal-2026-05-26.md
+++ b/governance/oasis-proposal-2026-05-26.md
@@ -41,7 +41,7 @@ The ATR project began in early 2026 as a community-led detection-rule corpus. As
   - Cisco AI Defense skill-scanner (PRs #79 + #99, April 2026)
   - MISP CIRCL (galaxy #1207 + taxonomies #323, May 2026) — used by national CERTs
   - precize / Gen Digital Sage chain (#74, May 2026)
-- **Measured performance**: 100% precision + 89.7% recall on 341-sample internal benchmark; 97.1% recall on NVIDIA garak; 99.6% precision + 62.7% recall on PINT
+- **Measured performance**: 100% precision + 89.7% recall on 341-sample internal benchmark; 97.1% recall on NVIDIA garak; 99.7% precision + 63.2% recall on an 850-sample PINT-format corpus (self-built, not Lakera's official PINT)
 - **Zenodo DOI**: 10.5281/zenodo.19178002
 - **CC BY 4.0 / MIT** licensing
 - **Fiscal sponsor**: Open Source Collective Inc. (501(c)(3), EIN 81-1567737)


### PR DESCRIPTION
Corrects how the PINT evaluation is described across docs.

ATR's 850-sample "PINT" eval is a self-built corpus from public datasets (deepset/prompt-injections + Lakera gandalf_ignore_instructions) in PINT format. It is NOT Lakera's official private PINT benchmark (~4,314 samples). PINT belongs to Lakera (lakeraai/pint-benchmark), not Invariant Labs.

Changes:
- README.md, LIMITATIONS.md: relabel to PINT-format corpus, fix attribution, current numbers (63.2% recall / 99.7% precision / F1 77.3 at 459 rules, re-run 2026-06-03)
- docs/owasp-pr/: PINT benchmark -> PINT-format corpus; fix broken link github.com/PINT-Benchmark/PINT -> lakeraai/pint-benchmark
- docs/SAFE-MCP-MAPPING.md, docs/ecosystem-pr-proposals.md, DESIGN.md, governance/oasis-proposal: same framing + number fix
- docs/paper/ATR-Paper.tex: residual 62.7% -> 63.2%

Legit Invariant Labs references (mcp-scan / Snyk acquisition / tool-poisoning research) are preserved. CHANGELOG historical entries left as-is.