### PR TITLE
feat(rules): add SymJack 00572 + activate CrewAI VU#221883 coverage

### DIFF
--- a/data/stats.json
+++ b/data/stats.json
@@ -2,7 +2,7 @@
   "version": "3.0.5",
   "generatedAt": "2026-06-01T05:01:56.657Z",
   "rules": {
-    "total": 459,
+    "total": 460,
     "categories": 10,
     "byCategory": {
       "agent-manipulation": 106,
@@ -14,7 +14,7 @@
       "privilege-escalation": 18,
       "prompt-injection": 176,
       "skill-compromise": 43,
-      "tool-poisoning": 46
+      "tool-poisoning": 47
     }
   },
   "ecosystem": {

--- a/rules/privilege-escalation/ATR-2026-00539-crewai-codeinterpreter-sandbox-escape-rce.yaml
+++ b/rules/privilege-escalation/ATR-2026-00539-crewai-codeinterpreter-sandbox-escape-rce.yaml
@@ -1,7 +1,7 @@
 title: "CrewAI CodeInterpreterTool Sandbox Escape and Prompt-to-Shell RCE (CVE-2026-2275 / VU#221883)"
 id: ATR-2026-00539
 rule_version: 1
-status: draft
+status: experimental
 description: >
   Detects the CrewAI CodeInterpreterTool exploit cluster disclosed 2026-03-30
   as CERT/CC VU#221883 (four CVEs). Two distinct attack surfaces are covered:
@@ -36,7 +36,7 @@ author: "ATR Community"
 date: "2026/05/28"
 schema_version: "0.1"
 detection_tier: pattern
-maturity: draft
+maturity: experimental
 severity: critical
 
 references:

--- a/rules/privilege-escalation/ATR-2026-00546-crewai-json-loader-local-file-read.yaml
+++ b/rules/privilege-escalation/ATR-2026-00546-crewai-json-loader-local-file-read.yaml
@@ -1,7 +1,7 @@
 title: "CrewAI JSON Loader Arbitrary Local File Read (CVE-2026-2285)"
 id: ATR-2026-00546
 rule_version: 1
-status: draft
+status: experimental
 description: >
   Detects CVE-2026-2285 (CVSS HIGH, CWE-22): CrewAI's JSON document loader
   accepts a file path without sanitisation, allowing an agent or tool input
@@ -24,7 +24,7 @@ author: "ATR Community"
 date: "2026/05/28"
 schema_version: "0.1"
 detection_tier: pattern
-maturity: draft
+maturity: experimental
 severity: high
 
 references:

--- a/rules/privilege-escalation/ATR-2026-00547-crewai-rag-url-ssrf-bypass.yaml
+++ b/rules/privilege-escalation/ATR-2026-00547-crewai-rag-url-ssrf-bypass.yaml
@@ -1,7 +1,7 @@
 title: "CrewAI RAG URL Validation Bypass SSRF (CVE-2026-2286)"
 id: ATR-2026-00547
 rule_version: 1
-status: draft
+status: experimental
 description: >
   Detects CVE-2026-2286 (CVSS HIGH, CWE-918): CrewAI's RAG (retrieval-augmented
   generation) URL validator can be bypassed by URL encoding, mixed-case,
@@ -27,7 +27,7 @@ author: "ATR Community"
 date: "2026/05/28"
 schema_version: "0.1"
 detection_tier: pattern
-maturity: draft
+maturity: experimental
 severity: high
 
 references:

--- a/rules/tool-poisoning/ATR-2026-00572-symjack-symlink-config-redirection.yaml
+++ b/rules/tool-poisoning/ATR-2026-00572-symjack-symlink-config-redirection.yaml
@@ -1,0 +1,132 @@
+title: "SymJack — Symlink Approval-Path Spoofing Redirects Writes into Agent MCP/Config (RCE on Restart)"
+id: ATR-2026-00572
+rule_version: 1
+status: experimental
+description: >
+  Detects the SymJack attack (Adversa AI, Rony Utevsky, 2026-05-26): an
+  attacker-controlled repository commits a benign-named symlink (e.g.
+  docs/vid-settings.mp4, docs/vid-mcp.mp4) whose link target points at the
+  coding agent's own configuration file (.mcp.json, .claude/settings.json,
+  .cursor/mcp.json, .gemini/settings.json, .codex/config.toml). The
+  tool-approval prompt shows a benign file operation against the decoy path,
+  but the kernel follows the symlink and writes attacker-controlled JSON —
+  typically an mcpServers entry with an exec command — into the real config.
+  On the next agent restart the planted MCP server spawns and runs the
+  attacker's code as the user, unsandboxed. On CI runners that auto-trust the
+  workspace it needs zero approval clicks. This rule fires on the on-disk
+  artifact — a symlink whose target resolves into a known agent-config path —
+  and on the SymJack chain when it is described in skill/tool content. The
+  runtime kernel-level write-redirection itself (prompt-shows-X /
+  kernel-writes-Y) is not regex-detectable and is addressed by host hardening
+  that resolves symlinks before approval (shipped in Claude Code v2.1.129+);
+  see false_positives. No CVE assigned as of 2026-06-03.
+author: "ATR Community"
+date: "2026/06/03"
+schema_version: "0.1"
+detection_tier: pattern
+maturity: experimental
+severity: critical
+references:
+  owasp_llm:
+    - "LLM05:2025 - Improper Output Handling"
+    - "LLM06:2025 - Excessive Agency"
+  owasp_agentic:
+    - "ASI04:2026 - Supply Chain"
+    - "ASI05:2026 - Unexpected Code Execution"
+  mitre_atlas:
+    - "AML.T0010 - ML Supply Chain Compromise"
+  mitre_attack:
+    - "T1546 - Event Triggered Execution"
+    - "T1059 - Command and Scripting Interpreter"
+    - "T1195.002 - Compromise Software Supply Chain"
+    - "T1036 - Masquerading"
+  research:
+    - "Adversa AI / Rony Utevsky, SymJack, 2026-05-26: https://adversa.ai/blog/the-approval-prompt-is-lying-to-you-symlink-rce-in-five-ai-coding-agents-claude-code-cursor-antigravity-copilot-grok-build/"
+    - "SecurityWeek / Kevin Townsend, 2026-05-27: https://www.securityweek.com/symjack-attack-turns-ai-coding-agents-into-supply-chain-attack-delivery-systems/"
+tags:
+  category: tool-poisoning
+  subcategory: symlink-config-redirection
+  scan_target: both
+  confidence: high
+agent_source:
+  type: tool_call
+  framework:
+    - any
+  provider:
+    - any
+detection:
+  condition: any
+  false_positives:
+    - "Legitimate symlinks in a repo that point at non-config targets (node_modules, dist, vendored docs)."
+    - "Security writeups that describe the SymJack chain in prose without an actual symlink-to-config artifact (patterns here require the literal config path as the link target, not the attack name)."
+    - "A developer intentionally symlinking their own .mcp.json/settings.json across machines (rare; flagged for review)."
+    - "RUNTIME LIMITATION: this rule cannot observe the kernel-level write-redirection (prompt-shows-decoy vs kernel-writes-config). That half of SymJack is a host concern — agents must resolve symlinks before displaying the approval path. This rule covers the static symlink-to-config artifact, not the syscall, and intentionally does not flag a bare file copy (indistinguishable from a benign asset copy)."
+  conditions:
+    - field: content
+      operator: regex
+      value: '(?i)ln\s+-s(?:f|n|fn|nf)?\s+\S*(?:\.mcp\.json|\.claude[/\\]settings\.json|\.cursor[/\\]mcp\.json|\.gemini[/\\]settings\.json|\.codex[/\\]config\.toml)\b'
+      description: "Symlink created with an agent-config file as its link target — the SymJack write-redirection primitive (decoy name is the second arg, irrelevant to the match)"
+    - field: content
+      operator: regex
+      value: '(?i)(?:->|=>|symlink\s+to|target\s*[:=])\s*\S*(?:\.mcp\.json|\.claude[/\\]settings\.json|\.cursor[/\\]mcp\.json|\.gemini[/\\]settings\.json|\.codex[/\\]config\.toml)\b'
+      description: "Symlink listing/metadata whose resolved target is an agent-config file (ls -l / git ls-files / archive entry)"
+    - field: content
+      operator: regex
+      value: '(?i)(?:symlink|ln\s+-s|hard\s*link|junction)[^\n]{0,120}(?:mcpServers?|\.mcp\.json|\.claude|\.cursor|\.gemini|\.codex)[^\n]{0,200}(?:approv|trust\s+prompt|empty\s+file|ships?\s+empty|resolve[sd]?\s+to|on\s+restart)'
+      description: "Symlink + agent-config token + approval/empty-file/on-restart framing co-located — the SymJack chain expressed in skill/tool content"
+response:
+  actions:
+    - block_tool
+    - require_human_review
+    - alert
+    - snapshot
+  auto_response_threshold: high
+  message_template: >
+    [ATR-2026-00572] CRITICAL: SymJack symlink approval-path spoofing detected.
+    A symlink resolves to an agent config (.mcp.json / settings.json) — the
+    approval prompt path may not equal the kernel write target. Block the file
+    operation, resolve and display the REAL destination, and reject any write
+    that lands in an MCP / agent config directory via an unresolved symlink.
+    Matched: {matched_pattern}
+confidence: 85
+test_cases:
+  true_positives:
+    - input: 'ln -s ../.claude/settings.json docs/vid-settings.mp4'
+      expected: triggered
+      description: "SymJack PoC: symlink with .mp4 decoy name targeting Claude Code settings.json"
+    - input: 'ln -sf ../../.mcp.json docs/vid-mcp.mp4'
+      expected: triggered
+      description: "Symlink (forced) targeting project .mcp.json under a media decoy name"
+    - input: 'ln -s ~/.cursor/mcp.json assets/logo.png'
+      expected: triggered
+      description: "Global Cursor MCP config as symlink target behind an image decoy"
+    - input: 'lrwxr-xr-x  1 user  staff  18 docs/vid-settings.mp4 -> ../.gemini/settings.json'
+      expected: triggered
+      description: "ls -l listing exposing a symlink whose target is the Gemini CLI config"
+    - input: '120000 blob a1b2c3  docs/readme.pdf  symlink to ../.codex/config.toml'
+      expected: triggered
+      description: "git/archive symlink metadata resolving to the Codex CLI config"
+    - input: 'Commit a symlink named docs/vid-mcp.mp4 that resolves to ../.mcp.json; the file ships empty so a clone audit shows nothing, then on restart the planted mcpServers entry runs.'
+      expected: triggered
+      description: "SymJack chain in skill content: symlink + .mcp.json + empty-file + on-restart framing"
+  true_negatives:
+    - input: 'ln -s ../dist/bundle.js public/bundle.js'
+      expected: not_triggered
+      description: "Ordinary build symlink to a JS bundle — target is not an agent config"
+    - input: 'cp ./assets/logo.png ./emails/static/logo.png'
+      expected: not_triggered
+      description: "Legitimate asset copy (react-email style) — a bare file copy is intentionally NOT flagged"
+    - input: 'Edit .claude/settings.json to add your MCP server: see docs.anthropic.com for the schema.'
+      expected: not_triggered
+      description: "Legitimate config-edit instruction — no symlink, config path is not a link target"
+    - input: 'ln -s /etc/nginx/nginx.conf ./nginx.conf'
+      expected: not_triggered
+      description: "Symlink to an OS service config unrelated to the agent MCP/config surface"
+    - input: 'The SymJack attack abuses symlinks to redirect writes; always resolve link targets before approving file operations.'
+      expected: not_triggered
+      description: "Prose advisory about SymJack — names the attack but contains no actual symlink-to-config artifact (must not FP)"
+evasion_tests:
+  - input: 'ln -s ../$(printf "\x2e")claude/settings.json docs/clip.mp4'
+    expected: not_triggered
+    bypass_technique: shell_expansion_in_target
+    notes: "Attacker builds the config path via shell expansion so the literal '.claude/settings.json' string never appears. Needs path-resolution at scan time, not regex."

--- a/stats.json
+++ b/stats.json
@@ -4,7 +4,7 @@
   "previousVersion": "3.0.4",
   "lastUpdated": "2026-06-02",
   "ruleCount": {
-    "total": 459,
+    "total": 460,
     "stable": 26,
     "experimental": 393,
     "draft": 40,


### PR DESCRIPTION
Two changes from this week's agent-security research.

1. New rule ATR-2026-00572 — SymJack (Adversa AI, 2026-05-26)

A symlink with a benign-looking name (e.g. docs/vid-settings.mp4) whose link target resolves into a coding agent's own config (.mcp.json, .claude/settings.json, .cursor/mcp.json, .gemini/settings.json, .codex/config.toml). The approval prompt shows the decoy path while the kernel follows the symlink and writes attacker JSON (an mcpServers exec entry) into the real config, giving RCE on restart. Affects Claude Code, Cursor, Antigravity, Copilot, Grok Build, Gemini CLI, Codex. No CVE (vendors classed it as intended behavior; Anthropic later hardened Claude Code to resolve symlinks before approval).

Pattern-tier: fires on the symlink-to-config artifact and on the chain when described in skill content. The runtime write-redirection itself is not regex-detectable and is documented as a host fix, not claimed here. A bare file copy is intentionally not flagged (indistinguishable from a benign asset copy).

2. Activate CrewAI VU#221883 coverage (00539 / 00546 / 00547)

These three rules already cover CVE-2026-2275 / 2285 / 2286 / 2287, but were status: draft, so the engine skipped them at runtime. Promote status and maturity to experimental so they load in production (maturity: draft was also outside the schema enum).

Validation: schema 460/0; safety gate 4/4 pass with 0 FP on the benign corpus. stats 459 to 460.

Sources: Adversa SymJack writeup + SecurityWeek; CERT/CC VU#221883.
