### PR TITLE
fix(rules): round-2 FP hardening on 5 rules (0 TP regression)

### DIFF
--- a/rules/agent-manipulation/ATR-2026-00440-semantic-kernel-vector-store-eval-rce.yaml
+++ b/rules/agent-manipulation/ATR-2026-00440-semantic-kernel-vector-store-eval-rce.yaml
@@ -104,8 +104,8 @@ detection:
 
     - field: content
       operator: regex
-      value: '(?i)BuiltinImporter|FunctionType|getattr\s*\(\s*(?:object|type|__builtins__)'
-      description: "Direct reference to BuiltinImporter or reflective getattr on built-in roots — second stage of the AST-bypass chain"
+      value: '(?i)BuiltinImporter|\btypes\.FunctionType\b|\bFunctionType\s*\(|getattr\s*\(\s*(?:object|type|__builtins__)'
+      description: "BuiltinImporter, Python types.FunctionType reflective construction, or reflective getattr on built-in roots — excludes bare 'FunctionType' which collides with TypeScript terminology"
 
     - field: content
       operator: regex

--- a/rules/data-poisoning/ATR-2026-00450-spring-ai-prompt-memory-poisoning.yaml
+++ b/rules/data-poisoning/ATR-2026-00450-spring-ai-prompt-memory-poisoning.yaml
@@ -109,8 +109,8 @@ detection:
 
     - field: user_input
       operator: regex
-      value: '(?i)\bremember\s*:\s*[^.]{0,200}\b(?:you\s+are|act\s+as|always|never|from\s+now\s+on|in\s+every\s+(?:reply|response|turn))\b'
-      description: "Explicit REMEMBER: directive followed by persona-shaping verbs — instructs the advisor to keep the override across turns"
+      value: '(?i)\bremember\s*:\s*[^.]{0,200}\b(?:from\s+now\s+on|in\s+every\s+(?:reply|response|turn)|in\s+all\s+(?:future\s+)?(?:replies|responses|turns)|once\s+(?:stored|saved|persisted)|across\s+(?:all\s+)?(?:sessions?|turns?))\b'
+      description: "REMEMBER: directive paired with a cross-turn persistence marker (from now on / in every reply / once stored) — drops bare always/never/you-are emphasis that benign skills use"
 
     - field: user_input
       operator: regex

--- a/rules/prompt-injection/ATR-2026-00230-persona-moral-bypass.yaml
+++ b/rules/prompt-injection/ATR-2026-00230-persona-moral-bypass.yaml
@@ -60,10 +60,6 @@ detection:
       description: 'Disclaimer about misalignment with creator views'
     - field: content
       operator: regex
-      value: '(?i)\[(?:your\s+)?(?:prompt|question|request|query)\s+here\]|\{(?:your\s+)?(?:prompt|question|request|query)\s+here\}|(?:prompt|question|request|query):\s*\[|\bprompt:\s*$'
-      description: 'Template placeholder indicating structure for follow-up injection'
-    - field: content
-      operator: regex
       value: '(?i)provide\s+(?:detailed\s+)?responses?\s+to\s+each\s+(?:prompt|question|request|query|instruction)'
       description: 'Instruction to respond to follow-up prompts without filtering'
   condition: any

--- a/rules/prompt-injection/ATR-2026-00235-persona-moral-bypass.yaml
+++ b/rules/prompt-injection/ATR-2026-00235-persona-moral-bypass.yaml
@@ -60,10 +60,6 @@ detection:
       description: 'Disclaimer about misalignment with creator views'
     - field: content
       operator: regex
-      value: '(?i)\[(?:your\s+)?(?:prompt|question|request|query)\s+here\]|\{(?:your\s+)?(?:prompt|question|request|query)\s+here\}|(?:prompt|question|request|query):\s*\[|\bprompt:\s*$'
-      description: 'Template placeholder indicating structure for follow-up injection'
-    - field: content
-      operator: regex
       value: '(?i)provide\s+(?:detailed\s+)?responses?\s+to\s+each\s+(?:prompt|question|request|query|instruction)'
       description: 'Instruction to respond to follow-up prompts without filtering'
   condition: any

--- a/rules/tool-poisoning/ATR-2026-00270-xss-in-tool-response.yaml
+++ b/rules/tool-poisoning/ATR-2026-00270-xss-in-tool-response.yaml
@@ -50,7 +50,7 @@ detection:
   conditions:
     - field: tool_response
       operator: regex
-      value: '<script[^>]*>\s*(?:[^\n<]{0,200}(?:eval\s*\(|document\.cookie|window\.location\s*=|fetch\s*\(|XMLHttpRequest|localStorage|sessionStorage|atob\s*\()[^\n<]{0,200})<\/script>'
+      value: '<script\b(?![^>]*(?:\bsetup\b|\blang[\s=]))[^>]*>\s*(?:[^\n<]{0,200}(?:eval\s*\(|document\.cookie|window\.location\s*=|fetch\s*\(|XMLHttpRequest|localStorage|sessionStorage|atob\s*\()[^\n<]{0,200})<\/script>'
       description: 'Script tag whose body contains a known XSS sink (eval/cookie/fetch/etc) — excludes bare src= includes'
     - field: tool_response
       operator: regex
@@ -66,7 +66,7 @@ detection:
       description: 'Instruction to emit HTML/script payload containing common XSS sinks'
     - field: tool_response
       operator: regex
-      value: '<(?:script|iframe|svg)\b[^>]*>[^<]{0,200}(?:eval\s*\(|alert\s*\(|document\.cookie|window\.location\s*=|fetch\s*\(|XMLHttpRequest)'
+      value: '<(?:script\b(?![^>]*(?:\bsetup\b|\blang[\s=]))|iframe|svg)\b[^>]*>[^<]{0,200}(?:eval\s*\(|alert\s*\(|document\.cookie|window\.location\s*=|fetch\s*\(|XMLHttpRequest)'
       description: 'Script/iframe/SVG block containing known XSS sink functions'
   condition: any
   false_positives:


### PR DESCRIPTION
Summary

Round-2 false-positive hardening on 5 rules surfaced by the 99k ecosystem scan. All changes verified against 324 benign skills (68 wild-confirmed + 256 official), with all 31 affected true-positives still firing (0 regression).

Changes
- 00230 / 00235 (persona-moral-bypass, duplicates): dropped the template-placeholder condition that matched any "Question: [" / "query: [" prompt template. On its own that condition triggered the whole jailbreak rule. TPs still fire via the persona + moral-removal conditions.
- 00450 (spring-ai memory-poisoning): REMEMBER: now requires a cross-turn persistence marker (from now on / in every reply / once stored); dropped bare always/never/you-are emphasis that benign skills use ("Remember: always validate input").
- 00270 (xss-in-tool-response): excluded Vue/Svelte <script setup> / <script lang=> SFC syntax, where useFetch/$fetch matched the fetch( sink.
- 00440 (semantic-kernel eval-rce): FunctionType now requires Python context (types.FunctionType / FunctionType()), since bare "FunctionType" collided with the TypeScript "function type" term.

Impact
- ~35 benign false positives eliminated on the 324-sample benign corpus.
- 0 true-positive regressions (00230 5/5, 00235 5/5, 00450 8/8, 00270 5/5, 00440 8/8).
- validate-rules: 462 passed, 0 failed.

Notes
- Remaining benign hits (00123 over-privileged Bash(*)/AGENTS.md, 00163 autonomy instructions, 00120 system-tags, 00270 security-skill XSS examples) are dual-use signals where intent matters, better handled by the semantic-judge tier than regex suppression, so they are intentionally left for that layer.
- 00230 and 00235 are exact duplicates; deprecating one is a separate lifecycle decision.

Test plan
- [ ] CI green.
- [ ] 0 FP regression on benign corpus.