### PR TITLE
fix(crystallize): real next rule-ID + reject malformed YAML; route auto-rules through PR

### DIFF
--- a/.github/workflows/crystallize.yml
+++ b/.github/workflows/crystallize.yml
@@ -13,6 +13,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   crystallize:
@@ -155,8 +156,10 @@ jobs:
             }
           "
 
-      - name: Commit new rules and stats
+      - name: Open PR for new rules (human review via check-rules-safety gate)
         if: ${{ github.event.inputs.dry_run != 'true' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git config user.name "ATR Crystallizer"
           git config user.email "crystallizer@atr-framework.org"
@@ -169,10 +172,18 @@ jobs:
           if git diff --cached --quiet; then
             echo "No new rules crystallized"
           else
-            git commit -m "feat: auto-crystallize ${NEW_RULES} new rules (${BEFORE} -> ${AFTER} total)
+            BRANCH="auto-crystallize/run-${{ github.run_id }}"
+            git checkout -b "$BRANCH"
+            git commit -m "feat: auto-crystallize ${NEW_RULES} new draft rules (${BEFORE} -> ${AFTER} total)
 
             Source: TC ecosystem scan + adversarial samples
-            Pipeline: local-crystallize.ts"
-            git push
-            echo "Committed ${NEW_RULES} new rules"
+            Pipeline: local-crystallize.ts
+            Status: draft/test — requires human review before promotion."
+            git push -u origin "$BRANCH"
+            gh pr create \
+              --title "auto-crystallize: ${NEW_RULES} new draft rule(s)" \
+              --body "Automated crystallization from TC attack data. New rules are status=draft / maturity=test and must pass the check-rules-safety gate before promotion. Do NOT auto-merge — human review required." \
+              --label "needs-human-review" \
+              || echo "PR creation failed; branch '$BRANCH' pushed — open PR manually (main was NOT modified)."
+            echo "Opened PR from ${BRANCH} with ${NEW_RULES} new rules"
           fi

--- a/scripts/local-crystallize.ts
+++ b/scripts/local-crystallize.ts
@@ -15,9 +15,10 @@
  *         + POST to TC as proposals
  */
 
-import { readFileSync, writeFileSync, existsSync } from 'node:fs';
+import { readFileSync, writeFileSync, existsSync, readdirSync, statSync } from 'node:fs';
 import { resolve, join } from 'node:path';
 import { createHash } from 'node:crypto';
+import yaml from 'js-yaml';
 import { ATREngine } from '../dist/engine.js';
 import { validateRule, loadRuleFile } from '../dist/loader.js';
 
@@ -195,6 +196,21 @@ async function main() {
   }
   
   // Crystallize each technique
+  // Real next-ID from the existing corpus. Previously hardcoded `142 + created` (written when
+  // the repo had ~141 rules) — it now collides with every existing ID up to the current max,
+  // one of the two reasons the daily crystallize run red-failed.
+  const scanMaxId = (dir: string): number => {
+    let max = 0;
+    for (const entry of readdirSync(dir)) {
+      const full = join(dir, entry);
+      if (statSync(full).isDirectory()) max = Math.max(max, scanMaxId(full));
+      else { const m = entry.match(/ATR-2026-(\d{5})/); if (m) max = Math.max(max, parseInt(m[1]!, 10)); }
+    }
+    return max;
+  };
+  const baseId = scanMaxId('rules');
+  console.log(`Allocating new rule IDs from ATR-2026-${String(baseId + 1).padStart(5, '0')}`);
+
   let created = 0, pushed = 0;
   for (const [tech, items] of crystallizable) {
     const samplePayloads = items.slice(0, 10).map(i => `- "${i.payload}"`).join('\n');
@@ -219,7 +235,7 @@ async function main() {
       const ruleContent = yamlMatch[1]!.trim();
       
       // Assign real ID
-      const nextId = 142 + created; // Continue from ATR-2026-00141
+      const nextId = baseId + 1 + created;
       const finalContent = ruleContent.replace('ATR-2026-DRAFT', `ATR-2026-${String(nextId).padStart(5, '0')}`);
       
       // Determine category and write file
@@ -229,7 +245,17 @@ async function main() {
       const slug = slugMatch?.[1] ?? tech;
       
       const filePath = `rules/${category}/ATR-2026-${String(nextId).padStart(5, '0')}-${slug}.yaml`;
-      
+
+      // Reject malformed LLM YAML BEFORE it touches disk. A duplicate-key file pollutes the
+      // engine's directory scan and silently red-fails the whole run (the `duplicated mapping
+      // key (50:1)` error that broke crystallize for days). js-yaml throws on duplicate keys.
+      try {
+        yaml.load(finalContent);
+      } catch (e) {
+        console.log(`  → Malformed YAML, skipping: ${e instanceof Error ? e.message : e}`);
+        continue;
+      }
+
       if (!DRY_RUN) {
         writeFileSync(filePath, finalContent);
       }


### PR DESCRIPTION
Two root causes of the daily Crystallize-from-TC CI failure (red for ~5 days):

1. nextId was hardcoded "142 + created" (written when the repo had ~141 rules). It now collides with every existing ID up to the current max (00574). Replaced with a real max-ID scan, so new rules start at the next free ID.

2. Malformed LLM YAML (a duplicate mapping key) was written to disk before validation, polluting the engine rules scan and red-failing the whole run. Now the YAML is parse-validated before write; bad drafts are skipped and logged.

Safety change: the workflow no longer pushes auto-generated rules straight to main. It opens a PR (branch auto-crystallize/run-<id>, label needs-human-review) so new draft rules pass the check-rules-safety gate before a human merges.

Verified locally: js-yaml rejects the duplicate-key case; the max-ID scan returns 00574 (next 00575); type-check clean; workflow YAML parses.
