### PR TITLE
fix(crystallize): allocate rule IDs per-attempt, not per-success

### DIFF
--- a/scripts/local-crystallize.ts
+++ b/scripts/local-crystallize.ts
@@ -15,7 +15,7 @@
  *         + POST to TC as proposals
  */
 
-import { readFileSync, writeFileSync, existsSync, readdirSync, statSync } from 'node:fs';
+import { readFileSync, writeFileSync, existsSync, readdirSync, statSync, unlinkSync } from 'node:fs';
 import { resolve, join } from 'node:path';
 import { createHash } from 'node:crypto';
 import yaml from 'js-yaml';
@@ -211,7 +211,7 @@ async function main() {
   const baseId = scanMaxId('rules');
   console.log(`Allocating new rule IDs from ATR-2026-${String(baseId + 1).padStart(5, '0')}`);
 
-  let created = 0, pushed = 0;
+  let created = 0, pushed = 0, allocated = 0;
   for (const [tech, items] of crystallizable) {
     const samplePayloads = items.slice(0, 10).map(i => `- "${i.payload}"`).join('\n');
     const prompt = ATR_DRAFTER_PROMPT + `\n\nAttack technique: ${tech}\nSamples (${items.length} total, showing 10):\n${samplePayloads}`;
@@ -234,8 +234,15 @@ async function main() {
       
       const ruleContent = yamlMatch[1]!.trim();
       
-      // Assign real ID
-      const nextId = baseId + 1 + created;
+      // Assign real ID. Use a dedicated `allocated` counter that increments PER ATTEMPT,
+      // not `created` (which only increments on full success at the bottom). Binding the ID
+      // to `created` meant any rule that failed validate/test below did not consume its
+      // number, so the NEXT rule reused it — producing 5 files all stamped ATR-2026-00579
+      // and red-failing the corpus-wide validate with "Duplicate rule ID". Per-attempt
+      // allocation guarantees every emitted file gets a unique, monotonic ID; gaps from
+      // discarded attempts are fine (IDs need not be contiguous, only unique).
+      const nextId = baseId + 1 + allocated;
+      allocated++;
       const finalContent = ruleContent.replace('ATR-2026-DRAFT', `ATR-2026-${String(nextId).padStart(5, '0')}`);
       
       // Determine category and write file
@@ -266,6 +273,7 @@ async function main() {
         const v = validateRule(rule);
         if (!v.valid) {
           console.log(`  → Invalid: ${v.errors.join(', ')}`);
+          if (!DRY_RUN) unlinkSync(filePath);  // remove rejected file so it can't pollute the corpus-wide validate
           continue;
         }
         
@@ -283,6 +291,7 @@ async function main() {
         
         if (!testPass) {
           console.log(`  → Test case failed`);
+          if (!DRY_RUN) unlinkSync(filePath);  // remove failing file so it can't pollute the corpus-wide validate
           continue;
         }
         
@@ -296,6 +305,7 @@ async function main() {
         }
       } catch (e) {
         console.log(`  → Error: ${e instanceof Error ? e.message : e}`);
+        if (!DRY_RUN) { try { unlinkSync(filePath); } catch { /* file may not have been written */ } }
       }
     } catch (e) {
       console.log(`  → LLM error: ${e instanceof Error ? e.message : e}`);


### PR DESCRIPTION
The #112 fix stopped the hardcoded 142 collision but exposed a second bug.

Root cause
nextId was baseId + 1 + created, and created only increments on full success (write + validate + test all pass). Any rule that failed validate or test did not consume its number, so the next rule reused it. The 2026-06-12 manual workflow_dispatch run crystallized 00577 and 00578, then five prompt-injection rules each failed validate and all took 00579 -- the corpus-wide validate step red-failed with "Duplicate rule ID: ATR-2026-00579" and no PR was opened. main was never modified by the failed run.

Fix
- Allocate IDs from a dedicated allocated counter that increments per attempt, decoupled from created. Discarded attempts leave gaps, which is fine: IDs need not be contiguous, only unique.
- unlink rejected files in the validate, test, and catch paths so a single bad rule cannot pollute the corpus-wide validate.

Verification
Reproduced the exact failure in a standalone script (2 successes + 5 failures):
  old logic: 00577 00578 00579 00579 00579 00579 00579  (collides)
  new logic: 00577 00578 00579 00580 00581 00582 00583  (unique, monotonic)
Local type-check and e2e are deferred to CI (the script needs the Anthropic API and Threat Cloud to run end to end). Suggest triggering one crystallize run after merge to confirm e2e.

Diff: +14 / -4 in scripts/local-crystallize.ts.
