### PR TITLE
feat(ci): daily CVE-proposal promotion workflow

### DIFF
--- a/.github/workflows/promote-cve.yml
+++ b/.github/workflows/promote-cve.yml
@@ -1,0 +1,111 @@
+name: Promote CVE Proposals to Rules
+
+# Crystallizes PoC-grounded CVE/advisory proposals (GHSA/AVID/NVD/CISA) into draft
+# rules via scripts/promote-detection-ready.ts. The MiroFish grounding gate keeps
+# prose-only proposals OUT — they stay flagged needs-human-poc, so we never ship a
+# rule that detects the sentence describing an attack instead of the attack.
+#
+# Complements crystallize.yml (which handles TC ecosystem + adversarial samples).
+# Together the two keep both automated threat-intake lanes flowing into rules daily.
+#
+# Why this exists: promote-detection-ready.ts shipped but had no scheduled runner,
+# so hundreds of READY CVE proposals piled up unconverted for weeks. This is the runner.
+
+on:
+  workflow_run:
+    workflows: ["CVE Collector — Daily Sync"]
+    types: [completed]
+  schedule:
+    - cron: '40 5 * * *'   # daily safety net, after the CVE collector's morning run
+  workflow_dispatch:
+    inputs:
+      max:
+        description: 'Max promotions this run'
+        required: false
+        default: '20'
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  promote:
+    name: Promote PoC-grounded CVE proposals
+    runs-on: ubuntu-latest
+    # Only run on a successful collector run, or on manual/scheduled trigger.
+    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name != 'workflow_run' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '22'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build ATR engine
+        run: npm run build
+
+      - name: Count rules before
+        id: before
+        run: |
+          count=$(find rules -name "*.yaml" | wc -l | tr -d ' ')
+          echo "count=$count" >> "$GITHUB_OUTPUT"
+          echo "Rules before promotion: $count"
+
+      - name: Promote PoC-grounded CVE proposals
+        run: |
+          npx tsx scripts/promote-detection-ready.ts \
+            --write \
+            --max "${{ github.event.inputs.max || '20' }}" \
+            --report /tmp/promote-report.json \
+            || echo "Promotion completed with warnings"
+
+      - name: Validate new rules
+        run: npm run validate
+
+      - name: Run tests
+        run: npm test
+
+      - name: Count rules after
+        id: after
+        run: |
+          count=$(find rules -name "*.yaml" | wc -l | tr -d ' ')
+          echo "count=$count" >> "$GITHUB_OUTPUT"
+          echo "Rules after promotion: $count"
+
+      - name: Open PR for promoted rules (human review via check-rules-safety gate)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git config user.name "ATR CVE Promoter"
+          git config user.email "promoter@atr-framework.org"
+
+          BEFORE=${{ steps.before.outputs.count }}
+          AFTER=${{ steps.after.outputs.count }}
+          NEW=$((AFTER - BEFORE))
+
+          git add rules/ data/ 2>/dev/null || git add rules/
+          if git diff --cached --quiet; then
+            echo "No PoC-grounded proposals ready to promote this run (prose-only ones stay flagged needs-human-poc)."
+          else
+            BRANCH="auto-promote-cve/run-${{ github.run_id }}"
+            git checkout -b "$BRANCH"
+            git commit -m "feat: promote ${NEW} PoC-grounded CVE proposal(s) to draft rules
+
+          Source: CVE/advisory proposals (GHSA/AVID/NVD/CISA) carrying real PoC payloads.
+          Pipeline: promote-detection-ready.ts — MiroFish grounding gate keeps prose-only proposals out.
+          Status: draft/test — requires human review via check-rules-safety before promotion."
+            git push -u origin "$BRANCH"
+            gh pr create \
+              --title "auto-promote: ${NEW} CVE proposal(s) -> draft rule(s)" \
+              --body "Promoted from PoC-grounded CVE/advisory proposals via promote-detection-ready.ts. The MiroFish grounding gate kept prose-only proposals out (they remain flagged needs-human-poc for a human to supply a real payload). status=draft / maturity=test. Do NOT auto-merge; human review required via the check-rules-safety gate." \
+              --label "needs-human-review" \
+              || echo "PR creation failed; branch '${BRANCH}' pushed — open PR manually (main was NOT modified)."
+            echo "Opened PR from ${BRANCH} with ${NEW} promoted rules"
+          fi


### PR DESCRIPTION
Adds the missing scheduled runner for scripts/promote-detection-ready.ts.

Problem: the promote tool shipped weeks ago but nothing ran it, so READY CVE/advisory proposals (GHSA/AVID/NVD/CISA) piled up unconverted -- 261 candidates sitting in proposals/ with no path into rules/. The CVE threat-intake lane was effectively dead even though the collector ran daily.

This workflow: runs after each "CVE Collector -- Daily Sync" (plus a daily cron safety net at 05:40 UTC and manual dispatch), promotes only PoC-grounded proposals, validates and tests, then opens a needs-human-review PR. The MiroFish grounding gate keeps prose-only proposals out (they stay flagged needs-human-poc for a human to supply a real payload).

Verified locally: promote-detection-ready.ts dry-run over the backlog promoted 4 of 15 attempted (the rest correctly held back as no-patterns or needs-human-poc), with unique monotonic IDs from nextAtrId(). Complements crystallize.yml (the TC + adversarial-samples lane).
