### PR TITLE
fix: pre-create dist tree so tsc --build survives clean CI checkout

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "README.md"
   ],
   "scripts": {
+    "prebuild": "node scripts/prebuild-dirs.mjs",
     "build": "tsc --build",
     "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "typecheck": "tsc --noEmit",

--- a/scripts/prebuild-dirs.mjs
+++ b/scripts/prebuild-dirs.mjs
@@ -1,0 +1,24 @@
+// Pre-create the dist/ directory tree mirroring src/ before `tsc --build` runs.
+//
+// Why this exists: package.json has `composite: true` with no project
+// references, so `tsc --build` emits in parallel. On a clean checkout (no
+// dist/ yet), CI on Linux hit `error TS5033: ... ENOENT: mkdir 'dist/adapters'`
+// because emit ordering tried to write dist/adapters/* before dist/ root
+// existed. macOS readdir ordering happened to avoid it, so it only failed in CI.
+//
+// Mirroring the tree up front makes emit independent of ordering: every
+// directory tsc writes into already exists. This runs via the npm `prebuild`
+// lifecycle, so it also covers `npm ci` (which triggers `prepare` -> build).
+import { mkdirSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+
+function mirror(srcDir, distDir) {
+  mkdirSync(distDir, { recursive: true });
+  for (const entry of readdirSync(srcDir, { withFileTypes: true })) {
+    if (entry.isDirectory()) {
+      mirror(join(srcDir, entry.name), join(distDir, entry.name));
+    }
+  }
+}
+
+mirror('src', 'dist');


### PR DESCRIPTION
Problem

Every open PR (#126-133 and others) fails CI at the npm ci step with:

  error TS5033: Could not write file dist/action-executor.d.ts: ENOENT
  error TS5033: ... ENOENT: mkdir dist/adapters

npm ci runs the prepare script, which runs npm run build (tsc --build).

Root cause

tsconfig has composite: true but no project references. That makes tsc --build
emit files in parallel. On a clean checkout (no dist/ yet), the Linux file
ordering writes dist/adapters/* before the dist/ root directory exists, so the
mkdir fails. macOS ordering happens to avoid it, so the build only fails in CI.
This blocks the build for the whole repo, not any one PR.

Fix

Add scripts/prebuild-dirs.mjs and a prebuild npm lifecycle step that mirrors the
src/ directory tree into dist/ before tsc runs. Every directory tsc emits into
then already exists, removing the ordering dependency. No build-semantics change;
composite declaration emit is untouched. Verified locally: clean build (rm -rf
dist + npm run build) produces all dist subtrees with 0 errors, and the script
is idempotent.