### PR TITLE
fix: build with plain tsc -p so emit auto-creates dist dirs

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,8 +70,7 @@
     "README.md"
   ],
   "scripts": {
-    "prebuild": "node scripts/prebuild-dirs.mjs",
-    "build": "tsc --build",
+    "build": "tsc -p tsconfig.json",
     "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",


### PR DESCRIPTION
Follow-up to #134. The prebuild mirror script failed on CI because npm ci runs prepare->build with a cwd where relative mkdir('dist') hit ENOENT.

Simpler root cause: tsc --build does not create the outDir root before emitting (that was the original TS5033). Plain tsc -p tsconfig.json calls mkdirSync(recursive) before each write and resolves outDir from the tsconfig location, not cwd. So switching build from 'tsc --build' to 'tsc -p tsconfig.json' fixes it directly and drops the prebuild hook entirely.

Composite declaration emit is unchanged. Verified locally: rm -rf dist && npm run build produces every dist subtree (incl. dist/quality/adapters) with 0 errors.