### PR TITLE
feat(website): ATD standard page + rules-detail build fix

### DIFF
--- a/rules/context-exfiltration/ATR-2026-00580-mcp-session-id-token-in-url-query.yaml
+++ b/rules/context-exfiltration/ATR-2026-00580-mcp-session-id-token-in-url-query.yaml
@@ -97,7 +97,7 @@ detection:
   false_positives:
   - URLs with non-credential query parameters only (?page=2, ?q=search, ?city=NYC) — no session/auth credential keyword in the query string
   - Credential keyword as a documentation path segment (/api-keys, /access-tokens/, /settings/auth-tokens/) with no =value query parameter
-  - Environment-variable or config assignment of a credential that is NOT inside a URL query (export API_KEY=..., SESSION_ID=... env, "Authorization: Bearer ..." header examples)
+  - 'Environment-variable or config assignment of a credential that is NOT inside a URL query (export API_KEY=..., SESSION_ID=... env, "Authorization: Bearer ..." header examples)'
   - Documentation placeholders with a redacted/short value (?session_token=5e9..., ?apiKey=KEY) — the 12+ char realistic-value bound excludes these
   - Uppercase or single-word placeholder token values (?access_token=ACCESS_TOKEN, ?apiKey=YOUR_API_KEY, ?sessionId=attacker_session, ?token=your_token_here) — the require-a-digit value shape excludes these, so API docs and security-teaching examples that show the pattern with a placeholder value do not match
   - Prose that mentions "session id in a URL" as a best-practice warning without an inline credential-bearing URL

--- a/website/app/[locale]/atd/page.tsx
+++ b/website/app/[locale]/atd/page.tsx
@@ -1,0 +1,485 @@
+/* ATD — Agentic Threat Detection. Companion standard to the ATR rule format:
+ * the executable detection layer beneath the prose frameworks (OWASP Agentic
+ * Top 10, MITRE ATLAS, CSA MAESTRO, AVID). Rendered as a standards-document
+ * page mirroring /spec. DRAFT — pre-governance; honest status throughout.
+ */
+import Link from "next/link";
+import type { Metadata } from "next";
+import { locales, type Locale } from "@/lib/i18n";
+import { RFC2119 } from "@/components/spec/RFC2119";
+import { NormativeBadge, InformativeBadge } from "@/components/spec/Badges";
+import { ATD_TECHNIQUES, ATD_TACTICS, ATD_STATS } from "@/lib/atd-data";
+
+export function generateStaticParams() {
+  return locales.map((locale) => ({ locale }));
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}): Promise<Metadata> {
+  const { locale } = await params;
+  return {
+    title: "ATD — Agentic Threat Detection | ATR",
+    description:
+      locale === "zh"
+        ? "Agentic Threat Detection (ATD):agent 原生威脅的開放、可執行偵測標準。OWASP/ATLAS/CWE/AVID 之下會跑的那一層。"
+        : "Agentic Threat Detection (ATD): the open, executable detection standard for agent-native threats — the runnable layer beneath OWASP, MITRE ATLAS, CWE and AVID.",
+  };
+}
+
+const ATD_VERSION = "0.1.0";
+const ATD_STATUS_EN = "Editor's Draft — pre-governance";
+const ATD_STATUS_ZH = "Editor's Draft — 治理前草案";
+const ATD_DATE = "2026-06-13";
+const ATD_DOI = "10.5281/zenodo.19178002";
+
+// Verified benchmark proof (state/facts.json, 2026-06-14). Real corpora.
+const PROOF = {
+  skill: { recall: 100, fp: 0, n: 341 },
+  garak: { recall: 98, n: 650 },
+  pint: { recall: 62.5, precision: 99.6, n: 850 },
+};
+
+const sevColor: Record<string, string> = {
+  critical: "var(--critical)",
+  high: "var(--high)",
+  medium: "var(--medium)",
+};
+
+interface Section {
+  num: string;
+  id: string;
+  status: "normative" | "informative";
+  en: { title: string; body: string };
+  zh: { title: string; body: string };
+}
+
+const SECTIONS: Section[] = [
+  {
+    num: "1",
+    id: "abstract",
+    status: "informative",
+    en: {
+      title: "Abstract",
+      body: `<p>Agentic Threat Detection (ATD) is an open, machine-readable, <strong>executable</strong> enumeration of agent-native threat techniques. Each technique is bound to detection logic and mapped to the established prose frameworks — <a href="https://genai.owasp.org/resource/owasp-top-10-for-agentic-applications-for-2026/" target="_blank" rel="noopener noreferrer">OWASP Agentic Top 10</a>, <a href="https://atlas.mitre.org/" target="_blank" rel="noopener noreferrer">MITRE ATLAS</a>, <a href="https://cwe.mitre.org/" target="_blank" rel="noopener noreferrer">CWE</a>, and <a href="https://avidml.org/" target="_blank" rel="noopener noreferrer">AVID</a>.</p>
+<p>Those frameworks tell you <em>what</em> can go wrong with an agent. ATD is the layer underneath that tells you <em>how to detect it at runtime</em> — and ships with a measurable false-positive rate. It is to agentic security what <a href="https://github.com/SigmaHQ/sigma" target="_blank" rel="noopener noreferrer">Sigma</a> is to SIEM detection.</p>
+<p class="atd-note"><strong>Status:</strong> an Editor's Draft — a request for comments and an open invitation to co-author. It is not yet a ratified standard; it earns that title when it meets the §8 neutrality bar. We publish it openly to gather collaborators and mapping partners, not to claim authority.</p>`,
+    },
+    zh: {
+      title: "Abstract (摘要)",
+      body: `<p>Agentic Threat Detection (ATD) 是 agent 原生威脅技法的開放、機器可讀、<strong>可執行</strong>列舉。每條技法綁定偵測邏輯,並對映既有的論述型框架 ── <a href="https://genai.owasp.org/resource/owasp-top-10-for-agentic-applications-for-2026/" target="_blank" rel="noopener noreferrer">OWASP Agentic Top 10</a>、<a href="https://atlas.mitre.org/" target="_blank" rel="noopener noreferrer">MITRE ATLAS</a>、<a href="https://cwe.mitre.org/" target="_blank" rel="noopener noreferrer">CWE</a>、<a href="https://avidml.org/" target="_blank" rel="noopener noreferrer">AVID</a>。</p>
+<p>那些框架告訴你 agent <em>會出什麼錯</em>。ATD 是其下的一層,告訴你 <em>怎麼在 runtime 偵測它</em> ── 而且附帶可量測的誤報率。ATD 之於 agentic 安全,如同 <a href="https://github.com/SigmaHQ/sigma" target="_blank" rel="noopener noreferrer">Sigma</a> 之於 SIEM 偵測。</p>
+<p class="atd-note"><strong>狀態:</strong>Editor's Draft ── 一份 request for comments,公開邀請共同撰寫。它<strong>尚未</strong>是 ratified standard;唯有達到 §8 的中立門檻後才冠此名。我們公開它是為了徵集協作者與對映夥伴,不是宣稱權威。</p>`,
+    },
+  },
+  {
+    num: "2",
+    id: "scope",
+    status: "normative",
+    en: {
+      title: "Scope — what ATD is and is not",
+      body: `<p>ATD enumerates <strong>agent-runtime threat techniques detectable in agent I/O</strong>: prompt/content, tool calls, tool responses, inter-agent messages, memory operations, traces, screen state, and payment mandates.</p>
+<ul>
+<li>ATD <strong>MUST NOT</strong> mint vulnerability instance identifiers. A specific CVE in a specific MCP server lives in CVE / GHSA / OSV / AVID; ATD references it, it does not replace it.</li>
+<li>ATD <strong>MUST NOT</strong> present itself as a competing top-level risk taxonomy. The "top ten agentic risks" framing belongs to OWASP ASI; ATD sits beneath it and makes it runnable.</li>
+<li>ATD <strong>MUST</strong> map every technique to at least one upstream framework, or document the gap where none exists yet.</li>
+</ul>
+<p>This boundary is deliberate. Vulnerability registries that mirrored CVE's territory (e.g. the now-archived GSD) fragmented and stalled. ATD fills the uncovered <em>executable detection</em> layer, it does not re-fight a settled lane.</p>`,
+    },
+    zh: {
+      title: "Scope ── ATD 是什麼、不是什麼",
+      body: `<p>ATD 列舉 <strong>可在 agent I/O 觀測到的 agent-runtime 威脅技法</strong>:prompt/content、tool call、tool response、inter-agent 訊息、memory 操作、trace、螢幕狀態、payment mandate。</p>
+<ul>
+<li>ATD <strong>MUST NOT</strong> 鑄造漏洞實例識別碼。特定 MCP server 的特定 CVE 屬於 CVE / GHSA / OSV / AVID;ATD 引用它,不取代它。</li>
+<li>ATD <strong>MUST NOT</strong> 自居為競爭性的頂層風險分類。「agentic 十大風險」的框架屬於 OWASP ASI;ATD 在其下,讓它可執行。</li>
+<li>ATD <strong>MUST</strong> 為每條技法至少對映一個上游框架,或在尚無對映時記錄該缺口。</li>
+</ul>
+<p>此邊界是刻意的。鏡像 CVE 地盤的漏洞登錄(如已封存的 GSD)碎片化而停擺。ATD 填的是無人覆蓋的 <em>可執行偵測</em> 層,不重打已定的戰場。</p>`,
+    },
+  },
+  {
+    num: "3",
+    id: "model",
+    status: "normative",
+    en: {
+      title: "Conceptual model",
+      body: `<p>ATD uses two axes, borrowed from proven standards:</p>
+<ul>
+<li><strong>Tactic / Technique matrix</strong> (MITRE ATLAS model): a <code>Tactic</code> is the adversary's goal-phase; a <code>Technique</code> is a concrete, detectable attack pattern; a <code>Sub-technique</code> is a variant.</li>
+<li><strong>Abstraction hierarchy</strong> (CWE model): each technique is tagged <code>pillar</code> / <code>class</code> / <code>base</code> / <code>variant</code>.</li>
+</ul>
+<p><strong>Identifiers.</strong> Tactics are <code>ATD-TA1</code> … <code>ATD-TA9</code>. Techniques are <code>ATD-T0001</code> (zero-padded, sequential, permanent, never reused); sub-techniques use dotted notation <code>ATD-T0001.001</code>. Each individual detection rule additionally carries a UUIDv4 so rules survive renaming — techniques are the catalog, rules are the executable instances bound to them.</p>
+<p><strong>Maturity.</strong> Every technique and every rule carries a status on the ladder <code>experimental → test → stable</code> (plus <code>deprecated</code>). Production consumers <strong>SHOULD</strong> auto-sync only <code>stable</code>.</p>`,
+    },
+    zh: {
+      title: "概念模型",
+      body: `<p>ATD 採用兩條軸,借自已驗證的標準:</p>
+<ul>
+<li><strong>Tactic / Technique 矩陣</strong>(MITRE ATLAS 模型):<code>Tactic</code> 是對手的目標階段;<code>Technique</code> 是具體、可偵測的攻擊模式;<code>Sub-technique</code> 是變體。</li>
+<li><strong>抽象層級</strong>(CWE 模型):每條技法標 <code>pillar</code> / <code>class</code> / <code>base</code> / <code>variant</code>。</li>
+</ul>
+<p><strong>識別碼。</strong>Tactic 為 <code>ATD-TA1</code> … <code>ATD-TA9</code>。Technique 為 <code>ATD-T0001</code>(補零、序列、永久、不重用);sub-technique 用點記法 <code>ATD-T0001.001</code>。每條偵測規則另帶 UUIDv4,使規則在改名後仍可追蹤 ── technique 是 catalog,rule 是綁定其上的可執行實例。</p>
+<p><strong>成熟度。</strong>每條技法與規則皆帶階梯狀態 <code>experimental → test → stable</code>(加 <code>deprecated</code>)。production 消費者 <strong>SHOULD</strong> 只自動同步 <code>stable</code>。</p>`,
+    },
+  },
+  {
+    num: "5",
+    id: "schema",
+    status: "normative",
+    en: {
+      title: "Entry schema",
+      body: `<p>A technique entry is a YAML/JSON document validated against a normative JSON Schema (Draft 2020-12), shipped in-repo. It is designed to be compatible with the OSV and Sigma ecosystems. Required fields:</p>
+<pre><code>atd_id            ATD-T####            permanent
+schema_version    SemVer, no "v"       additive-minor guarantee (OSV)
+title             short imperative phrase
+tactic            ATD-TA#
+abstraction       pillar | class | base | variant
+status            experimental | test | stable | deprecated
+description       the technique and its attack mechanism
+detection_surface content | tool_input | tool_response |
+                  inter_agent_msg | memory_op | trace | screen | payment_mandate
+mappings          owasp_asi[] · mitre_atlas[] · cwe[] · avid[] · maestro_layer[]
+references         advisory / CVE / research URLs (evidence it is real)
+detection_rules   UUIDv4[] into the rule corpus</code></pre>
+<p>A detection rule reuses the ATR rule schema already in production: regex/conditions, <code>true_positives</code> <strong>and</strong> <code>true_negatives</code> (a precision test), false-positive notes, response actions, and a valid <code>agent_source.type</code>.</p>`,
+    },
+    zh: {
+      title: "Entry schema",
+      body: `<p>technique entry 是 YAML/JSON 文件,對 normative JSON Schema(Draft 2020-12)驗證,隨 repo 發布,設計上與 OSV 及 Sigma 生態相容。必填欄位:</p>
+<pre><code>atd_id            ATD-T####            永久
+schema_version    SemVer, 無 "v"        加法式 minor 保證(OSV)
+title             簡短祈使片語
+tactic            ATD-TA#
+abstraction       pillar | class | base | variant
+status            experimental | test | stable | deprecated
+description       技法與其攻擊機制
+detection_surface content | tool_input | tool_response |
+                  inter_agent_msg | memory_op | trace | screen | payment_mandate
+mappings          owasp_asi[] · mitre_atlas[] · cwe[] · avid[] · maestro_layer[]
+references         advisory / CVE / research URL(真實證據)
+detection_rules   UUIDv4[] 指向 rule corpus</code></pre>
+<p>detection rule 重用已在 production 的 ATR rule schema:regex/conditions、<code>true_positives</code> <strong>與</strong> <code>true_negatives</code>(精準度測試)、false-positive 註記、response action、合法的 <code>agent_source.type</code>。</p>`,
+    },
+  },
+  {
+    num: "6",
+    id: "mappings",
+    status: "informative",
+    en: {
+      title: "Mappings &amp; interoperability",
+      body: `<p>Legitimacy comes from interoperability, not from declaring authority. Every ATD technique maps to OWASP ASI, MITRE ATLAS and CWE where a slot exists; AVID and the MAESTRO layer are added where they apply. ATD borrows the authority of these frameworks and feeds its ★gaps back to them as proposed techniques and case studies.</p>
+<p>ATD is designed to interoperate with — not compete against — <a href="https://avidml.org/" target="_blank" rel="noopener noreferrer">AVID</a>, which already operates a governed, submission-open AI vulnerability registry. ATD supplies the executable detection AVID's "Detection" report type expects.</p>`,
+    },
+    zh: {
+      title: "對映與互通",
+      body: `<p>合法性來自互通,而非自封權威。每條 ATD 技法在有對應槽時對映 OWASP ASI、MITRE ATLAS、CWE;在適用時加上 AVID 與 MAESTRO 層。ATD 借這些框架的權威,並將其 ★缺口以提議技法與案例研究回饋給它們。</p>
+<p>ATD 設計上與 <a href="https://avidml.org/" target="_blank" rel="noopener noreferrer">AVID</a> 互通而非競爭 ── AVID 已營運一個有治理、開放投稿的 AI 漏洞登錄。ATD 提供 AVID「Detection」報告類型所期待的可執行偵測。</p>`,
+    },
+  },
+  {
+    num: "7",
+    id: "conformance",
+    status: "normative",
+    en: {
+      title: "Conformance",
+      body: `<ul>
+<li>A <strong>conformant technique entry</strong> MUST validate against the JSON Schema, carry at least one framework mapping (or a documented gap), and cite at least one reference.</li>
+<li>A <strong>conformant detection rule</strong> MUST pass the precision gate: every declared true-positive matches, zero false positives on the published benign corpus, and no cross-rule conflict.</li>
+<li>A <strong>conformant consumer</strong> MUST honor the maturity field and SHOULD expose the <code>ATD-T####</code> id on every detection it emits.</li>
+</ul>`,
+    },
+    zh: {
+      title: "Conformance",
+      body: `<ul>
+<li><strong>conformant technique entry</strong> MUST 通過 JSON Schema 驗證,至少帶一個框架對映(或記錄缺口),並至少引一個 reference。</li>
+<li><strong>conformant detection rule</strong> MUST 通過精準度閘:每條宣告的 true-positive 命中、對公開 benign corpus 零誤報、無跨規則衝突。</li>
+<li><strong>conformant consumer</strong> MUST 尊重 maturity 欄,並 SHOULD 在每筆偵測上揭露 <code>ATD-T####</code> id。</li>
+</ul>`,
+    },
+  },
+  {
+    num: "8",
+    id: "governance",
+    status: "informative",
+    en: {
+      title: "Governance &amp; status",
+      body: `<p>ATD is governed by a written charter and published as an open draft and an invitation to co-author. It earns the title <em>standard</em> when it meets a concrete, public neutrality bar adopted from the OpenSSF project lifecycle — <strong>at least three maintainers across at least two organizations</strong> — and we are actively seating them.</p>
+<p>Governance follows a Minimal Viable Governance charter: lazy consensus of maintainers, a simple-majority Technical Steering Committee fallback, charter amendments by a two-thirds vote, and no single-person veto. The specification is CC-BY-4.0 and forkable by design — no party can hold it hostage — with a committed roadmap to a neutral foundation home (an OpenSSF working group, or the OWASP GenAI Security Project).</p>
+<p class="atd-note">Call for collaborators — if your team works on agent security, <strong>map your tooling to ATD, submit a technique, or take a maintainer seat</strong>. See <a href="/${"{LOCALE}"}/contribute">/contribute</a>.</p>`,
+    },
+    zh: {
+      title: "治理與狀態",
+      body: `<p>ATD 依書面 charter 治理,以開放草案發布,並公開邀請共同撰寫。它在達到一條具體、公開的中立門檻(採自 OpenSSF 專案生命週期:<strong>至少三名 maintainer,橫跨至少兩個組織</strong>)後冠上 <em>standard</em> 之名 ── 我們正在積極就位。</p>
+<p>治理採 Minimal Viable Governance charter:maintainer 的 lazy consensus、Technical Steering Committee 簡單多數 fallback、章程修訂需三分之二投票、無單人否決。規格以 CC-BY-4.0 授權且設計上可 fork ── 無任何一方能挾持它 ── 並承諾遷往中立基金會(OpenSSF working group,或 OWASP GenAI Security Project)。</p>
+<p class="atd-note">徵求協作者 ── 若你的團隊從事 agent 安全,<strong>把工具對映到 ATD、投一條技法、或擔任 maintainer 席位</strong>。見 <a href="/${"{LOCALE}"}/contribute">/contribute</a>。</p>`,
+    },
+  },
+];
+
+export default async function ATDPage({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}) {
+  const { locale: rawLocale } = await params;
+  const locale: Locale = rawLocale === "zh" ? "zh" : "en";
+  const status = locale === "zh" ? ATD_STATUS_ZH : ATD_STATUS_EN;
+
+  return (
+    <main
+      id="main-content"
+      className="spec-document atd-doc w-full max-w-7xl mx-auto px-5 md:px-8 pt-24 md:pt-28 pb-24"
+      lang={locale === "zh" ? "zh-Hant" : "en"}
+    >
+      <header
+        className="atd-cover mb-10 md:mb-12"
+        lang={locale === "zh" ? "zh-Hant" : "en"}
+      >
+        <p className="atd-kicker">
+          {locale === "zh"
+            ? "開放標準 · 草案 RFC · 徵求協作者 · ATR 之伴隨標準"
+            : "Open standard · draft RFC · call for collaborators · companion to ATR"}
+        </p>
+
+        {/* C logo — enumeration bracket [ATD], paper strokes + brass dots */}
+        <div className="atd-emblem" aria-label="ATD wordmark">
+          <svg width="186" height="66" viewBox="0 0 186 66" role="img" aria-label="ATD" style={{ display: "block" }}>
+            <path d="M28 13 L14 13 L14 53 L28 53" fill="none" stroke="#EDEBE4" strokeWidth="2.6" strokeLinecap="round" strokeLinejoin="round" />
+            <path d="M158 13 L172 13 L172 53 L158 53" fill="none" stroke="#EDEBE4" strokeWidth="2.6" strokeLinecap="round" strokeLinejoin="round" />
+            <text x="93" y="45" textAnchor="middle" style={{ fontFamily: "var(--font-data)", fontWeight: 600, fontSize: "36px", letterSpacing: "1.5px" }} fill="#FBFAF6">ATD</text>
+            <circle cx="42" cy="56" r="2.3" fill="#B8924A" />
+            <circle cx="51" cy="56" r="2.3" fill="#B8924A" />
+            <circle cx="60" cy="56" r="2.3" fill="#B8924A" />
+          </svg>
+        </div>
+
+        <h1>Agentic Threat Detection</h1>
+        <hr className="atd-rule" />
+        <p className="atd-sub">
+          {locale === "zh"
+            ? "agent 原生威脅的開放、可執行偵測標準 —— OWASP、MITRE ATLAS、CWE、AVID 之下會跑的那一層。"
+            : "The open, executable detection standard for agent-native threats — the runnable layer beneath OWASP, MITRE ATLAS, CWE and AVID."}
+        </p>
+
+        <div className="atd-status not-prose" role="note">
+          <strong>{status}</strong>
+          <span className="pipe">·</span>
+          <span><span className="opacity-70">{locale === "zh" ? "版本" : "Version"}</span> {ATD_VERSION}</span>
+          <span className="pipe">·</span>
+          <span><span className="opacity-70">{locale === "zh" ? "日期" : "Date"}</span> {ATD_DATE}</span>
+          <span className="pipe">·</span>
+          <span><span className="opacity-70">{locale === "zh" ? "正式版" : "Canonical"}</span> <a href={`/${locale}/atd`}>/atd</a></span>
+          <span className="pipe">·</span>
+          <span><span className="opacity-70">{locale === "zh" ? "編輯" : "Editor"}</span> Adam Lin</span>
+        </div>
+      </header>
+
+      <section aria-label="coverage" className="mb-10 md:mb-12">
+        <div className="grid grid-cols-2 md:grid-cols-5 gap-3">
+          {[
+            { v: String(ATD_STATS.techniques), l: locale === "zh" ? "技法已編目" : "techniques cataloged" },
+            { v: String(ATD_STATS.withCve), l: locale === "zh" ? "有 CVE 佐證" : "CVE-backed" },
+            { v: String(ATD_STATS.withLiveRule), l: locale === "zh" ? "已有 live 規則" : "with a live rule" },
+            { v: `${PROOF.skill.recall}% · 0 FP`, l: locale === "zh" ? `recall(skill 語料 n=${PROOF.skill.n})` : `recall · ${PROOF.skill.fp} FP (skill corpus, n=${PROOF.skill.n})` },
+            { v: `${PROOF.garak.recall}%`, l: locale === "zh" ? `recall(garak 野外 n=${PROOF.garak.n})` : `recall (garak in-the-wild, n=${PROOF.garak.n})` },
+          ].map((m, i) => (
+            <div key={i} style={{ background: "var(--spec-tint)", borderRadius: "10px", padding: "0.9rem 1rem" }}>
+              <div className="text-navy-ink" style={{ fontFamily: "var(--font-data)", fontSize: "1.35rem", fontWeight: 600, letterSpacing: "-0.01em" }}>{m.v}</div>
+              <div className="text-stone" style={{ fontSize: "0.72rem", marginTop: "0.25rem", lineHeight: 1.35 }}>{m.l}</div>
+            </div>
+          ))}
+        </div>
+        <p className="text-stone" style={{ fontSize: "0.8rem", marginTop: "0.9rem", lineHeight: 1.6 }}>
+          {locale === "zh" ? (
+            <>ATD 的偵測規則由 ATR 發布 —— 已在 production:Microsoft Agent Governance Toolkit、Cisco AI Defense;並於 MISP/CIRCL 對映。consumer 整合的是 ATR 規則,非對本草案標準的背書。DOI{" "}<a className="text-navy underline" href={`https://doi.org/${ATD_DOI}`} target="_blank" rel="noopener noreferrer">{ATD_DOI}</a>。</>
+          ) : (
+            <>ATD&apos;s detection rules ship in ATR — in production in Microsoft Agent Governance Toolkit and Cisco AI Defense, and mapped in MISP/CIRCL. Consumers integrate ATR rules; this is not an endorsement of this draft standard. DOI{" "}<a className="text-navy underline" href={`https://doi.org/${ATD_DOI}`} target="_blank" rel="noopener noreferrer">{ATD_DOI}</a>.</>
+          )}
+        </p>
+      </section>
+
+      <RFC2119 locale={locale} />
+
+      <div className="grid grid-cols-1 lg:grid-cols-[16rem_minmax(0,1fr)] gap-10 lg:gap-14 mt-6">
+        <aside aria-label="ATD table of contents" className="lg:order-first">
+          <nav className="spec-toc">
+            <p
+              className="text-xs font-semibold uppercase tracking-wider text-stone mb-3"
+              style={{ fontFamily: "var(--font-body)" }}
+            >
+              {locale === "zh" ? "目錄" : "Contents"}
+            </p>
+            <ol>
+              {SECTIONS.filter((s) => parseInt(s.num) < 4).map((s) => (
+                <li key={s.id}>
+                  <a href={`#${s.id}`}>
+                    <span className="toc-section-num">§{s.num}</span>
+                    {s[locale].title}
+                  </a>
+                </li>
+              ))}
+              <li>
+                <a href="#catalog">
+                  <span className="toc-section-num">§4</span>
+                  {locale === "zh" ? "技法目錄" : "Technique catalog"}
+                </a>
+              </li>
+              {SECTIONS.filter((s) => parseInt(s.num) > 4).map((s) => (
+                <li key={s.id}>
+                  <a href={`#${s.id}`}>
+                    <span className="toc-section-num">§{s.num}</span>
+                    {s[locale].title}
+                  </a>
+                </li>
+              ))}
+              <li>
+                <a href="#downloads">
+                  <span className="toc-section-num">§9</span>
+                  {locale === "zh" ? "下載與產物" : "Downloads & artifacts"}
+                </a>
+              </li>
+            </ol>
+            <hr className="my-5 border-fog" />
+            <p
+              className="text-xs uppercase tracking-wider text-stone mb-2"
+              style={{ fontFamily: "var(--font-body)" }}
+            >
+              {locale === "zh" ? "相關文件" : "Related documents"}
+            </p>
+            <ul className="space-y-2 text-sm" style={{ fontFamily: "var(--font-body)" }}>
+              <li>
+                <Link href={`/${locale}/spec`} className="text-navy underline decoration-navy/30 hover:decoration-navy">
+                  /spec
+                </Link>
+              </li>
+              <li>
+                <Link href={`/${locale}/governance`} className="text-navy underline decoration-navy/30 hover:decoration-navy">
+                  /governance
+                </Link>
+              </li>
+              <li>
+                <Link href={`/${locale}/contribute`} className="text-navy underline decoration-navy/30 hover:decoration-navy">
+                  /contribute
+                </Link>
+              </li>
+              <li>
+                <Link href={`/${locale}/threats`} className="text-navy underline decoration-navy/30 hover:decoration-navy">
+                  /threats
+                </Link>
+              </li>
+            </ul>
+          </nav>
+        </aside>
+
+        <div className="min-w-0 spec-measure-wide">
+          {SECTIONS.filter((s) => parseInt(s.num) < 4).map((s) => (
+            <section key={s.id} id={s.id} aria-labelledby={`${s.id}-heading`}>
+              <h2 id={`${s.id}-heading`}>
+                <a href={`#${s.id}`} className="section-anchor" aria-hidden="true">§{s.num}</a>
+                {s[locale].title}
+                {s.status === "normative" ? <NormativeBadge className="ml-2 align-middle" /> : <InformativeBadge className="ml-2 align-middle" />}
+              </h2>
+              <div className="spec-body min-w-0 overflow-x-auto -mx-2 px-2" dangerouslySetInnerHTML={{ __html: s[locale].body.replace(/\{LOCALE\}/g, locale) }} />
+            </section>
+          ))}
+
+          <section id="catalog" aria-labelledby="catalog-heading">
+            <h2 id="catalog-heading">
+              <a href="#catalog" className="section-anchor" aria-hidden="true">§4</a>
+              {locale === "zh" ? "技法目錄" : "Technique catalog"}
+              <NormativeBadge className="ml-2 align-middle" />
+            </h2>
+            <div className="spec-body">
+              <p>
+                {locale === "zh"
+                  ? `${ATD_STATS.techniques} 條技法,跨 ${ATD_TACTICS.length} 個戰術。每條對映 OWASP ASI / MITRE ATLAS / CWE,並附真實 CVE 或研究佐證;${ATD_STATS.withLiveRule} 條已有 live 的 ATR 偵測規則。無公開實例者誠實標 research / aspirational。框架識別碼對原始來源現驗 (2026-06-14)。`
+                  : `${ATD_STATS.techniques} techniques across ${ATD_TACTICS.length} tactics. Each maps to OWASP ASI / MITRE ATLAS / CWE with a real CVE or research citation; ${ATD_STATS.withLiveRule} already ship a live ATR detection rule. Entries with no public instance are marked research / aspirational. Framework ids verified against primary sources (2026-06-14).`}
+              </p>
+            </div>
+            {ATD_TACTICS.map((tac) => {
+              const items = ATD_TECHNIQUES.filter((t) => t.tactic === tac.id);
+              if (items.length === 0) return null;
+              return (
+                <div key={tac.id} className="mb-7 mt-6">
+                  <h3 className="text-navy-ink mb-3" style={{ fontFamily: "var(--font-spec), Georgia, serif", fontSize: "1.05rem", fontWeight: 600 }}>
+                    <span style={{ fontFamily: "var(--font-data)", color: "var(--navy)" }}>{tac.id}</span> · {tac.name}
+                    <span className="text-mist" style={{ fontSize: "0.8rem", fontWeight: 400 }}> ({items.length})</span>
+                  </h3>
+                  <div className="space-y-3">
+                    {items.map((t) => (
+                      <div key={t.id} style={{ border: "0.5px solid var(--fog)", borderRadius: "8px", padding: "0.85rem 1rem", background: "var(--paper)" }}>
+                        <div className="flex items-center flex-wrap gap-x-2 gap-y-1" style={{ marginBottom: "0.3rem" }}>
+                          <span style={{ width: 7, height: 7, borderRadius: "50%", background: sevColor[t.severity], display: "inline-block" }} aria-hidden="true" />
+                          <span style={{ fontFamily: "var(--font-data)", fontSize: "0.8rem", color: "var(--navy)", fontWeight: 600 }}>{t.id}</span>
+                          <span className="text-ink" style={{ fontWeight: 500, fontSize: "0.96rem" }}>{t.title}</span>
+                          {t.atrRule && (
+                            <Link href={`/${locale}/rules/${t.atrRule}`} style={{ fontFamily: "var(--font-data)", fontSize: "0.68rem", background: "var(--navy)", color: "#fff", borderRadius: "3px", padding: "2px 7px", textDecoration: "none" }}>
+                              {locale === "zh" ? "live 規則 ↗" : "live rule ↗"}
+                            </Link>
+                          )}
+                        </div>
+                        <p className="text-graphite" style={{ fontSize: "0.86rem", lineHeight: 1.55, margin: "0 0 0.5rem" }}>{t.mechanism}</p>
+                        <div className="flex flex-wrap gap-1.5 items-center" style={{ fontFamily: "var(--font-data)", fontSize: "0.68rem" }}>
+                          {t.evidence.kind === "cve" && t.evidence.url ? (
+                            <a href={t.evidence.url} target="_blank" rel="noopener noreferrer" style={{ background: "#FBECEC", color: "#A32D2D", borderRadius: "3px", padding: "2px 7px", textDecoration: "none" }}>{t.evidence.label} ↗</a>
+                          ) : t.evidence.kind === "research" ? (
+                            <a href={t.evidence.url} target="_blank" rel="noopener noreferrer" style={{ background: "var(--ash)", color: "var(--graphite)", borderRadius: "3px", padding: "2px 7px", textDecoration: "none" }}>{locale === "zh" ? "研究 ↗" : "research ↗"}</a>
+                          ) : (
+                            <span style={{ background: "var(--ash)", color: "var(--mist)", borderRadius: "3px", padding: "2px 7px" }}>{locale === "zh" ? "前瞻(尚無實例)" : "aspirational"}</span>
+                          )}
+                          {t.asi.map((a) => <span key={a} style={{ background: "#EAF1FB", color: "#185FA5", borderRadius: "3px", padding: "2px 6px" }}>{a}</span>)}
+                          {t.atlas.map((a) => <span key={a} style={{ background: "var(--spec-tint)", color: "var(--navy)", borderRadius: "3px", padding: "2px 6px" }}>{a}</span>)}
+                          {t.cwe.map((c) => <span key={c} style={{ background: "var(--ash)", color: "var(--stone)", borderRadius: "3px", padding: "2px 6px" }}>{c}</span>)}
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              );
+            })}
+          </section>
+
+          {SECTIONS.filter((s) => parseInt(s.num) > 4).map((s) => (
+            <section key={s.id} id={s.id} aria-labelledby={`${s.id}-heading`}>
+              <h2 id={`${s.id}-heading`}>
+                <a href={`#${s.id}`} className="section-anchor" aria-hidden="true">§{s.num}</a>
+                {s[locale].title}
+                {s.status === "normative" ? <NormativeBadge className="ml-2 align-middle" /> : <InformativeBadge className="ml-2 align-middle" />}
+              </h2>
+              <div className="spec-body min-w-0 overflow-x-auto -mx-2 px-2" dangerouslySetInnerHTML={{ __html: s[locale].body.replace(/\{LOCALE\}/g, locale) }} />
+            </section>
+          ))}
+
+          <section id="downloads" aria-labelledby="downloads-heading">
+            <h2 id="downloads-heading">
+              <a href="#downloads" className="section-anchor" aria-hidden="true">§9</a>
+              {locale === "zh" ? "下載與產物" : "Downloads & artifacts"}
+              <InformativeBadge className="ml-2 align-middle" />
+            </h2>
+            <div className="spec-body">
+              <ul>
+                <li><a href="/atd/atd-techniques.json" target="_blank" rel="noopener noreferrer">atd-techniques.json</a> — {locale === "zh" ? "完整 enumeration(機器可讀,OSV/Sigma 相容欄位)" : "the full enumeration (machine-readable; OSV/Sigma-compatible fields)"}</li>
+                <li><a href="/atd/atd-technique.schema.json" target="_blank" rel="noopener noreferrer">atd-technique.schema.json</a> — {locale === "zh" ? "normative JSON Schema (Draft 2020-12)" : "the normative JSON Schema (Draft 2020-12)"}</li>
+                <li><Link href={`/${locale}/spec`}>/spec</Link> — {locale === "zh" ? "ATR 規則格式(技法綁定的可執行規則)" : "the ATR rule format (the executable rules techniques bind to)"}</li>
+                <li>DOI <a href={`https://doi.org/${ATD_DOI}`} target="_blank" rel="noopener noreferrer">{ATD_DOI}</a> — {locale === "zh" ? "研究與引用 artifact" : "research & citation artifact"}</li>
+              </ul>
+            </div>
+          </section>
+
+          <hr className="my-12 border-fog" />
+          <p className="spec-meta">
+            {locale === "zh" ? "編輯" : "Editor"}: Adam Lin —{" "}
+            {locale === "zh" ? "規格" : "Specification"} CC-BY-4.0 ·{" "}
+            {locale === "zh" ? "Schema 與工具" : "Schema &amp; tooling"} Apache-2.0 ·{" "}
+            {locale === "zh" ? "規則庫" : "Rule corpus"} MIT — ISO 8601 {ATD_DATE} —{" "}
+            {locale === "zh"
+              ? "Editor's Draft,治理前;非 ratified standard。"
+              : "Editor's Draft, pre-governance; not a ratified standard."}
+          </p>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/website/app/globals.css
+++ b/website/app/globals.css
@@ -528,3 +528,108 @@ html:not(.js-ready) .speed-line {
   color: var(--stone);
   letter-spacing: 0.02em;
 }
+
+/* ATD page — companion-standard accents (draft notes + forward label) */
+.spec-body .atd-note {
+  margin-top: 1rem;
+  padding: 0.75rem 1rem;
+  border-left: 3px solid var(--navy-soft);
+  background: var(--spec-tint);
+  border-radius: 0;
+  font-size: 0.95em;
+  color: var(--graphite);
+}
+.spec-body .atd-fwd {
+  color: var(--stone);
+  font-style: italic;
+  font-size: 0.85em;
+}
+.spec-body table.atd-table code {
+  white-space: nowrap;
+}
+
+/* ===== ATD — standards "cover" masthead (gravitas) ===== */
+.atd-cover {
+  background: var(--navy-ink);
+  color: #EDEBE4;
+  border-radius: 16px;
+  padding: 2.6rem 2.6rem 2.1rem;
+  position: relative;
+  overflow: hidden;
+}
+.atd-cover::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: 16px;
+  border: 1px solid rgba(184, 146, 74, 0.28);
+  pointer-events: none;
+}
+.atd-kicker {
+  font-family: var(--font-data), ui-monospace, monospace;
+  font-size: 0.72rem;
+  letter-spacing: 0.24em;
+  text-transform: uppercase;
+  color: #B8924A;
+  margin-bottom: 1.5rem;
+}
+.atd-emblem { margin-bottom: 1.4rem; }
+.atd-cover h1 {
+  font-family: var(--font-spec), Georgia, "Times New Roman", serif;
+  font-size: clamp(2.1rem, 5vw, 3.2rem);
+  line-height: 1.04;
+  font-weight: 600;
+  color: #FBFAF6;
+  letter-spacing: -0.012em;
+  margin: 0 0 0.5rem;
+}
+.atd-cover[lang="zh-Hant"] h1 { font-family: var(--font-spec-tc), serif; }
+.atd-rule {
+  width: 60px;
+  height: 2px;
+  background: #B8924A;
+  margin: 1.1rem 0 1.2rem;
+  border: 0;
+}
+.atd-cover .atd-sub {
+  font-family: var(--font-body), system-ui, sans-serif;
+  font-size: 1.06rem;
+  line-height: 1.55;
+  color: #C7D2E2;
+  max-width: 42em;
+  margin: 0 0 1.6rem;
+}
+.atd-status {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem 0.7rem;
+  align-items: center;
+  font-family: var(--font-data), ui-monospace, monospace;
+  font-size: 0.74rem;
+  color: #93A6C2;
+}
+.atd-status strong { color: #E7C887; font-weight: 600; }
+.atd-status .pipe { color: rgba(147, 166, 194, 0.4); }
+.atd-status a { color: #9DB8E8; text-decoration: none; }
+.atd-status a:hover { text-decoration: underline; }
+
+/* Formal spec body — serif prose for the document-of-record feel */
+.atd-doc .spec-body p,
+.atd-doc .spec-body li {
+  font-family: var(--font-spec), Georgia, "Times New Roman", serif;
+  font-size: 1.02rem;
+  line-height: 1.72;
+}
+.atd-doc[lang="zh-Hant"] .spec-body p,
+.atd-doc[lang="zh-Hant"] .spec-body li {
+  font-family: var(--font-spec-tc), serif;
+}
+.atd-doc .spec-body pre,
+.atd-doc .spec-body code,
+.atd-doc .spec-body table { font-family: var(--font-data), ui-monospace, monospace; }
+.atd-doc .spec-body table { font-size: 0.9rem; }
+.atd-doc section h2 {
+  font-family: var(--font-spec), Georgia, serif;
+  letter-spacing: -0.01em;
+}
+.atd-doc[lang="zh-Hant"] section h2 { font-family: var(--font-spec-tc), serif; }

--- a/website/lib/atd-data.ts
+++ b/website/lib/atd-data.ts
@@ -1,0 +1,279 @@
+/* ATD enumeration — the technique catalog rendered on /atd and exported as
+ * machine-readable JSON. Every CVE here was verified against nvd.nist.gov and
+ * every MITRE ATLAS id against the authoritative mitre-atlas/atlas-data
+ * dist/ATLAS.yaml (2026-06-14). Entries with no public CVE are marked
+ * "research" (with a real advisory/paper) or "aspirational" (forward-looking,
+ * no public instance yet) — never dressed up as a CVE. `atrRule` links the
+ * live, gate-passing ATR detection rule where one exists.
+ */
+export type EvidenceKind = "cve" | "research" | "aspirational";
+export type Severity = "critical" | "high" | "medium";
+
+export interface ATDTechnique {
+  id: string; // ATD-T####
+  tactic: string; // ATD-TA#
+  title: string;
+  mechanism: string;
+  severity: Severity;
+  evidence: { kind: EvidenceKind; label: string; url?: string };
+  asi: string[]; // OWASP Agentic Top 10 2026
+  atlas: string[]; // MITRE ATLAS (verified; [] if none verifiable)
+  cwe: string[];
+  atrRule?: string; // live ATR rule id, if one ships
+}
+
+export const ATD_TACTICS: { id: string; name: string }[] = [
+  { id: "ATD-TA1", name: "Protocol & Interconnect" },
+  { id: "ATD-TA2", name: "Memory & Context Integrity" },
+  { id: "ATD-TA3", name: "Goal, Planning & Reasoning" },
+  { id: "ATD-TA4", name: "Identity, Authz & Delegation" },
+  { id: "ATD-TA5", name: "Tool & Supply Chain" },
+  { id: "ATD-TA6", name: "Execution & Autonomy" },
+  { id: "ATD-TA7", name: "Multi-Agent Dynamics" },
+  { id: "ATD-TA8", name: "Model-Intrinsic & Governance" },
+  { id: "ATD-TA9", name: "Agentic Commerce (forward)" },
+];
+
+export const ATD_TECHNIQUES: ATDTechnique[] = [
+  // ---- TA1 Protocol & Interconnect ----
+  {
+    id: "ATD-T0001",
+    tactic: "ATD-TA1",
+    title: "Shell metacharacter injection through MCP tool parameters",
+    mechanism: "Unsanitized MCP tool input reaches execSync/exec, yielding RCE on the server host.",
+    severity: "high",
+    evidence: { kind: "cve", label: "CVE-2025-53355", url: "https://nvd.nist.gov/vuln/detail/CVE-2025-53355" },
+    asi: ["ASI05", "ASI02"], atlas: ["AML.T0053"], cwe: ["CWE-77"],
+    atrRule: "ATR-2026-01927",
+  },
+  {
+    id: "ATD-T0002",
+    tactic: "ATD-TA1",
+    title: "curl-fallback command injection in an MCP server",
+    mechanism: "A failed fetch falls back to exec'ing curl with an unsanitized URL, enabling RCE.",
+    severity: "high",
+    evidence: { kind: "cve", label: "CVE-2025-53967", url: "https://nvd.nist.gov/vuln/detail/CVE-2025-53967" },
+    asi: ["ASI05", "ASI02"], atlas: ["AML.T0053"], cwe: ["CWE-420"],
+    atrRule: "ATR-2026-01928",
+  },
+  {
+    id: "ATD-T0003",
+    tactic: "ATD-TA1",
+    title: "Command injection in a scaffolded MCP stdio server",
+    mechanism: "Generated server concatenates tool input into exec(), giving RCE to anything built from it.",
+    severity: "critical",
+    evidence: { kind: "cve", label: "CVE-2025-54994", url: "https://nvd.nist.gov/vuln/detail/CVE-2025-54994" },
+    asi: ["ASI04", "ASI05"], atlas: ["AML.T0010.005"], cwe: ["CWE-78"],
+    atrRule: "ATR-2026-00577",
+  },
+  {
+    id: "ATD-T0004",
+    tactic: "ATD-TA1",
+    title: "Line-jumping — tool-description injection at listing time",
+    mechanism: "Hidden instructions in a tool description enter the model context at tools/list, before any call.",
+    severity: "high",
+    evidence: { kind: "research", label: "Trail of Bits / Invariant Labs", url: "https://blog.trailofbits.com/2025/04/21/jumping-the-line-how-mcp-servers-can-attack-you-before-you-ever-use-them/" },
+    asi: ["ASI04", "ASI01"], atlas: ["AML.T0110", "AML.T0104"], cwe: ["CWE-1427"],
+    atrRule: "ATR-2026-00579",
+  },
+  {
+    id: "ATD-T0005",
+    tactic: "ATD-TA1",
+    title: "Rug pull — silent mutation of an approved tool",
+    mechanism: "A server approved once later changes a tool's definition with no integrity re-check.",
+    severity: "high",
+    evidence: { kind: "research", label: "Invariant Labs", url: "https://github.com/invariantlabs-ai/mcp-injection-experiments" },
+    asi: ["ASI04"], atlas: ["AML.T0109", "AML.T0110"], cwe: ["CWE-494"],
+    atrRule: "ATR-2026-00581",
+  },
+  {
+    id: "ATD-T0006",
+    tactic: "ATD-TA1",
+    title: "Missing-auth MCP proxy command execution",
+    mechanism: "No auth between client and MCP proxy lets any local/web-driven request spawn MCP processes.",
+    severity: "critical",
+    evidence: { kind: "cve", label: "CVE-2025-49596", url: "https://nvd.nist.gov/vuln/detail/CVE-2025-49596" },
+    asi: ["ASI03", "ASI05"], atlas: [], cwe: ["CWE-306"],
+  },
+  {
+    id: "ATD-T0007",
+    tactic: "ATD-TA1",
+    title: "RCE from a malicious upstream MCP server",
+    mechanism: "A client is RCE'd via a crafted authorization_endpoint URL in an untrusted server's response.",
+    severity: "critical",
+    evidence: { kind: "cve", label: "CVE-2025-6514", url: "https://nvd.nist.gov/vuln/detail/CVE-2025-6514" },
+    asi: ["ASI04", "ASI05"], atlas: ["AML.T0010.005"], cwe: ["CWE-78"],
+  },
+  {
+    id: "ATD-T0008",
+    tactic: "ATD-TA1",
+    title: "DNS-rebinding to a localhost MCP server",
+    mechanism: "A malicious page rebinds DNS to reach an unauthenticated localhost MCP server cross-origin.",
+    severity: "high",
+    evidence: { kind: "cve", label: "CVE-2025-66416", url: "https://nvd.nist.gov/vuln/detail/CVE-2025-66416" },
+    asi: ["ASI07", "ASI03"], atlas: [], cwe: ["CWE-1188"],
+  },
+  {
+    id: "ATD-T0009",
+    tactic: "ATD-TA1",
+    title: "Session ID / auth token placed in a URL query string",
+    mechanism: "A credential in the query string leaks via server logs, proxies, CDNs, history, and Referer.",
+    severity: "medium",
+    evidence: { kind: "research", label: "Vulnerable MCP Project (Equixly)", url: "https://vulnerablemcp.info/" },
+    asi: ["ASI03", "ASI07"], atlas: [], cwe: ["CWE-598"],
+    atrRule: "ATR-2026-00580",
+  },
+  // ---- TA2 Memory & Context ----
+  {
+    id: "ATD-T0010",
+    tactic: "ATD-TA2",
+    title: "Serialized-object smuggling through an LLM response field",
+    mechanism: "Injected output carries a serialization marker; deserialization rehydrates it as trusted and exfiltrates secrets.",
+    severity: "critical",
+    evidence: { kind: "cve", label: "CVE-2025-68664", url: "https://nvd.nist.gov/vuln/detail/CVE-2025-68664" },
+    asi: ["ASI06", "ASI01"], atlas: ["AML.T0051.001"], cwe: ["CWE-502"],
+  },
+  {
+    id: "ATD-T0011",
+    tactic: "ATD-TA2",
+    title: "Persistent memory / context-store poisoning",
+    mechanism: "Attacker-controlled content is written into data the agent later reads back as trusted context.",
+    severity: "high",
+    evidence: { kind: "research", label: "MITRE ATLAS — Context Poisoning", url: "https://atlas.mitre.org/" },
+    asi: ["ASI06"], atlas: ["AML.T0080"], cwe: ["CWE-349"],
+  },
+  // ---- TA3 Goal / Planning / Reasoning ----
+  {
+    id: "ATD-T0012",
+    tactic: "ATD-TA3",
+    title: "Indirect prompt injection via tool / API response",
+    mechanism: "Malicious text in returned tool data overrides the agent's plan and redirects its actions.",
+    severity: "high",
+    evidence: { kind: "research", label: "InjecAgent, arXiv 2403.02691", url: "https://arxiv.org/abs/2403.02691" },
+    asi: ["ASI01"], atlas: ["AML.T0051.001", "AML.T0099"], cwe: ["CWE-1427"],
+    atrRule: "ATR-2026-00584",
+  },
+  {
+    id: "ATD-T0013",
+    tactic: "ATD-TA3",
+    title: "System-prompt / guardrail extraction to plan evasion",
+    mechanism: "Crafted queries coerce the agent to reveal its hidden system prompt, exposing control logic.",
+    severity: "medium",
+    evidence: { kind: "research", label: "MITRE ATLAS — Extract LLM System Prompt", url: "https://atlas.mitre.org/" },
+    asi: ["ASI01", "ASI09"], atlas: ["AML.T0056"], cwe: ["CWE-200"],
+  },
+  // ---- TA4 Identity / Authz / Delegation ----
+  {
+    id: "ATD-T0014",
+    tactic: "ATD-TA4",
+    title: "Confused-deputy token passthrough in an MCP server",
+    mechanism: "A server forwards a held token to a downstream API without audience validation, escalating privilege.",
+    severity: "high",
+    evidence: { kind: "research", label: "MCP Authorization spec (confused-deputy)", url: "https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization" },
+    asi: ["ASI03"], atlas: [], cwe: ["CWE-441"],
+  },
+  // ---- TA5 Tool & Supply Chain ----
+  {
+    id: "ATD-T0015",
+    tactic: "ATD-TA5",
+    title: "Agent reads .env / secret files without consent",
+    mechanism: "An agent tool reads credential files (.env, credentials, .npmrc) outside any user-approved scope.",
+    severity: "high",
+    evidence: { kind: "research", label: "ModelContextProtocol-Security advisory", url: "https://github.com/modelcontextprotocol-security/vulnerability-db" },
+    asi: ["ASI02", "ASI06"], atlas: ["AML.T0053"], cwe: ["CWE-538"],
+    atrRule: "ATR-2026-00583",
+  },
+  {
+    id: "ATD-T0016",
+    tactic: "ATD-TA5",
+    title: "Hallucinated-dependency squatting (slopsquatting)",
+    mechanism: "The model recommends a fabricated package name an attacker pre-registers, pulling code into the agent env.",
+    severity: "medium",
+    evidence: { kind: "research", label: "MITRE ATLAS — Publish Hallucinated Entities", url: "https://atlas.mitre.org/" },
+    asi: ["ASI04", "ASI08"], atlas: ["AML.T0060", "AML.T0062"], cwe: ["CWE-1427"],
+  },
+  // ---- TA6 Execution & Autonomy ----
+  {
+    id: "ATD-T0017",
+    tactic: "ATD-TA6",
+    title: "Path-traversal blacklist bypass via non-canonical paths",
+    mechanism: "Exact-string path checks are bypassed with ../, /./, redundant slashes to reach sensitive files.",
+    severity: "medium",
+    evidence: { kind: "cve", label: "CVE-2025-66689", url: "https://nvd.nist.gov/vuln/detail/CVE-2025-66689" },
+    asi: ["ASI02", "ASI03"], atlas: ["AML.T0053"], cwe: ["CWE-22"],
+    atrRule: "ATR-2026-00578",
+  },
+  {
+    id: "ATD-T0018",
+    tactic: "ATD-TA6",
+    title: "MCP filesystem sandbox escape via symlink following",
+    mechanism: "A symlink inside an allowed directory resolves to an out-of-scope path, granting system file access.",
+    severity: "high",
+    evidence: { kind: "cve", label: "CVE-2025-53109", url: "https://nvd.nist.gov/vuln/detail/CVE-2025-53109" },
+    asi: ["ASI02", "ASI05"], atlas: ["AML.T0053"], cwe: ["CWE-59"],
+  },
+  {
+    id: "ATD-T0019",
+    tactic: "ATD-TA6",
+    title: "Prompt-injection-to-RCE via an agent's file-write capability",
+    mechanism: "Injected instructions drive the agent to write a startup/config file that yields persistent code execution.",
+    severity: "critical",
+    evidence: { kind: "research", label: "Pillar Security — Antigravity (no CVE assigned)", url: "https://www.pillar.security/blog/prompt-injection-leads-to-rce-and-sandbox-escape-in-antigravity" },
+    asi: ["ASI05", "ASI01"], atlas: ["AML.T0053", "AML.T0051.001"], cwe: ["CWE-94"],
+  },
+  // ---- TA7 Multi-Agent Dynamics ----
+  {
+    id: "ATD-T0020",
+    tactic: "ATD-TA7",
+    title: "Agent Card poisoning to capture A2A task routing",
+    mechanism: "A rogue A2A agent advertises an instruction-laden Agent Card so the orchestrator routes tasks to it.",
+    severity: "high",
+    evidence: { kind: "research", label: "Trustwave SpiderLabs — Agent-in-the-Middle", url: "https://www.levelblue.com/blogs/spiderlabs-blog/agent-in-the-middle-abusing-agent-cards-in-the-agent-2-agent-protocol-to-win-all-the-tasks" },
+    asi: ["ASI07", "ASI10"], atlas: ["AML.T0051.001"], cwe: ["CWE-345"],
+  },
+  {
+    id: "ATD-T0021",
+    tactic: "ATD-TA7",
+    title: "Cross-agent injection propagation (cascading compromise)",
+    mechanism: "One compromised agent emits content that injects the next downstream agent, cascading through the swarm.",
+    severity: "high",
+    evidence: { kind: "research", label: "InjecAgent + multi-agent control-flow hijack", url: "https://arxiv.org/abs/2403.02691" },
+    asi: ["ASI08", "ASI07", "ASI10"], atlas: ["AML.T0051.001", "AML.T0080"], cwe: ["CWE-1427"],
+  },
+  // ---- TA8 Model-Intrinsic & Governance ----
+  {
+    id: "ATD-T0022",
+    tactic: "ATD-TA8",
+    title: "Trace tampering / non-tamper-evident agent audit logs",
+    mechanism: "An agent logs reasoning but not the actual tool call, or logs are mutable — defeating after-the-fact audit.",
+    severity: "medium",
+    evidence: { kind: "research", label: "EU AI Act Art.12 logging / observability gap", url: "https://artificialintelligenceact.eu/article/12/" },
+    asi: ["ASI10"], atlas: [], cwe: ["CWE-778"],
+  },
+  // ---- TA9 Agentic Commerce (forward) ----
+  {
+    id: "ATD-T0023",
+    tactic: "ATD-TA9",
+    title: "Adversarial transaction steering of a purchasing agent",
+    mechanism: "Injected content in a listing/page steers an autonomous-commerce agent to overpay or leak payment authority.",
+    severity: "medium",
+    evidence: { kind: "aspirational", label: "Forward-looking — no public instance yet" },
+    asi: ["ASI01", "ASI02", "ASI09"], atlas: [], cwe: ["CWE-1427"],
+  },
+  {
+    id: "ATD-T0024",
+    tactic: "ATD-TA9",
+    title: "Payment-mandate forgery in an agent-to-agent handshake",
+    mechanism: "A rogue agent spoofs delegated payment authority or mandate scope in an agentic-commerce exchange.",
+    severity: "medium",
+    evidence: { kind: "aspirational", label: "Forward-looking — protocols (AP2-class) emerging" },
+    asi: ["ASI03", "ASI07"], atlas: [], cwe: ["CWE-345"],
+  },
+];
+
+export const ATD_STATS = {
+  techniques: ATD_TECHNIQUES.length,
+  withLiveRule: ATD_TECHNIQUES.filter((t) => t.atrRule).length,
+  withCve: ATD_TECHNIQUES.filter((t) => t.evidence.kind === "cve").length,
+  tactics: ATD_TACTICS.length,
+};

--- a/website/lib/rules.ts
+++ b/website/lib/rules.ts
@@ -335,7 +335,16 @@ export function loadRuleDetail(id: string): RuleDetail | undefined {
     rawYaml,
     detectionConditions: parsed.detection?.conditions ?? [],
     detectionCombinator: parsed.detection?.condition,
-    falsePositives: parsed.detection?.false_positives ?? [],
+    falsePositives: ((parsed.detection?.false_positives ?? []) as unknown[]).map(
+      (fp) =>
+        typeof fp === "string"
+          ? fp
+          : fp && typeof fp === "object"
+            ? Object.entries(fp as Record<string, unknown>)
+                .map(([k, v]) => `${k}: ${v}`)
+                .join("")
+            : String(fp),
+    ),
     truePositives: (parsed.test_cases?.true_positives ?? []).map((tc) =>
       normalizeTestCase(tc as { input?: unknown }),
     ) as TestCase[],

--- a/website/next.config.ts
+++ b/website/next.config.ts
@@ -1,7 +1,14 @@
 import type { NextConfig } from "next";
+import path from "node:path";
 
 const nextConfig: NextConfig = {
   output: "export",
+  // Pin the workspace root so Next/Turbopack does not mis-infer it from a
+  // competing lockfile in a parent directory (that misinference 404s every
+  // route in dev). This is the maintainer-recommended fix from the warning.
+  turbopack: {
+    root: path.resolve(__dirname),
+  },
 };
 
 export default nextConfig;

--- a/website/public/atd/atd-technique.schema.json
+++ b/website/public/atd/atd-technique.schema.json
@@ -1,0 +1,123 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://atr.dev/atd/schema/atd-technique-0.1.0.json",
+  "title": "ATD Technique Entry",
+  "description": "Agentic Threat Detection (ATD) — normative schema for a technique entry. v0.1.0 DRAFT. SemVer 2.0.0, no leading v. Minor/patch only ADD fields; readers MUST ignore unknown fields (OSV compatibility guarantee).",
+  "type": "object",
+  "required": ["atd_id", "schema_version", "title", "tactic", "abstraction", "status", "description", "detection_surface", "mappings", "references"],
+  "additionalProperties": true,
+  "properties": {
+    "atd_id": {
+      "type": "string",
+      "pattern": "^ATD-T[0-9]{4}(\\.[0-9]{3})?$",
+      "description": "Permanent technique id, e.g. ATD-T0001 or sub-technique ATD-T0001.001. Never reused."
+    },
+    "schema_version": {
+      "type": "string",
+      "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$",
+      "description": "SemVer 2.0.0, no leading 'v'."
+    },
+    "title": {
+      "type": "string",
+      "minLength": 4,
+      "maxLength": 120,
+      "description": "Short imperative noun phrase naming the technique."
+    },
+    "tactic": {
+      "type": "string",
+      "enum": ["ATD-TA1", "ATD-TA2", "ATD-TA3", "ATD-TA4", "ATD-TA5", "ATD-TA6", "ATD-TA7", "ATD-TA8", "ATD-TA9"],
+      "description": "TA1 Protocol&Interconnect · TA2 Memory&Context · TA3 Goal/Planning/Reasoning · TA4 Identity/Authz/Delegation · TA5 Tool&Supply-Chain · TA6 Execution&Autonomy · TA7 Multi-Agent Dynamics · TA8 Model-Intrinsic&Governance · TA9 Agentic Commerce (forward)."
+    },
+    "abstraction": {
+      "type": "string",
+      "enum": ["pillar", "class", "base", "variant"],
+      "description": "CWE-style abstraction level."
+    },
+    "status": {
+      "type": "string",
+      "enum": ["experimental", "test", "stable", "deprecated"],
+      "description": "Maturity ladder. Only 'stable' SHOULD be auto-synced by production consumers."
+    },
+    "severity": {
+      "type": "string",
+      "enum": ["informational", "low", "medium", "high", "critical"]
+    },
+    "description": {
+      "type": "string",
+      "minLength": 20,
+      "description": "What the technique is and the attack mechanism."
+    },
+    "detection_surface": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "enum": ["content", "tool_input", "tool_response", "inter_agent_msg", "memory_op", "trace", "screen", "payment_mandate"]
+      },
+      "description": "Where in agent I/O this technique is observable."
+    },
+    "mappings": {
+      "type": "object",
+      "description": "Crosswalk to established frameworks. REQUIRED: interoperability is the source of legitimacy. A documented empty array with a 'gap' note is permitted where no upstream mapping exists yet (ATD differentiation).",
+      "required": ["owasp_asi", "mitre_atlas", "cwe"],
+      "additionalProperties": true,
+      "properties": {
+        "owasp_asi": {
+          "type": "array",
+          "items": {"type": "string", "pattern": "^ASI(0[1-9]|10)$"},
+          "description": "OWASP Agentic Top 10 2026 IDs (ASI01..ASI10). Empty [] allowed if documented gap."
+        },
+        "mitre_atlas": {
+          "type": "array",
+          "items": {"type": "string", "pattern": "^AML\\.(TA|T|M|CS)[0-9]{4}(\\.[0-9]{3})?$"},
+          "description": "MITRE ATLAS ids. Re-verify exact AML.T numbers against atlas.mitre.org before publishing."
+        },
+        "cwe": {
+          "type": "array",
+          "items": {"type": "string", "pattern": "^CWE-[0-9]+$"}
+        },
+        "avid": {
+          "type": "array",
+          "items": {"type": "string", "pattern": "^AVID-[0-9]{4}-[RV][0-9]+$"}
+        },
+        "maestro_layer": {
+          "type": "array",
+          "items": {"type": "string", "pattern": "^L[1-7]$"}
+        },
+        "gap_note": {
+          "type": "string",
+          "description": "If a required mapping array is empty, explain why no upstream framework names this technique (the future-proofing differentiation)."
+        }
+      }
+    },
+    "relationships": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["type", "target"],
+        "properties": {
+          "type": {"type": "string", "enum": ["childOf", "canPrecede", "peerOf", "mitigatedBy", "detectedBy"]},
+          "target": {"type": "string"}
+        }
+      }
+    },
+    "references": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["url"],
+        "properties": {
+          "type": {"type": "string", "enum": ["cve", "advisory", "research", "vendor", "other"]},
+          "url": {"type": "string", "format": "uri"}
+        }
+      },
+      "description": "Evidence the technique is real (CVE/advisory/research)."
+    },
+    "detection_rules": {
+      "type": "array",
+      "items": {"type": "string", "format": "uuid"},
+      "description": "UUIDv4 rule_ids in the ATD rule corpus bound to this technique."
+    }
+  }
+}

--- a/website/public/atd/atd-techniques.json
+++ b/website/public/atd/atd-techniques.json
@@ -1,0 +1,577 @@
+{
+  "standard": "ATD — Agentic Threat Detection",
+  "status": "Editor's Draft",
+  "version": "0.1.0",
+  "generated": "2026-06-14",
+  "license": "CC-BY-4.0",
+  "stats": {
+    "techniques": 24,
+    "withLiveRule": 9,
+    "withCve": 9,
+    "tactics": 9
+  },
+  "tactics": [
+    {
+      "id": "ATD-TA1",
+      "name": "Protocol & Interconnect"
+    },
+    {
+      "id": "ATD-TA2",
+      "name": "Memory & Context Integrity"
+    },
+    {
+      "id": "ATD-TA3",
+      "name": "Goal, Planning & Reasoning"
+    },
+    {
+      "id": "ATD-TA4",
+      "name": "Identity, Authz & Delegation"
+    },
+    {
+      "id": "ATD-TA5",
+      "name": "Tool & Supply Chain"
+    },
+    {
+      "id": "ATD-TA6",
+      "name": "Execution & Autonomy"
+    },
+    {
+      "id": "ATD-TA7",
+      "name": "Multi-Agent Dynamics"
+    },
+    {
+      "id": "ATD-TA8",
+      "name": "Model-Intrinsic & Governance"
+    },
+    {
+      "id": "ATD-TA9",
+      "name": "Agentic Commerce (forward)"
+    }
+  ],
+  "techniques": [
+    {
+      "id": "ATD-T0001",
+      "tactic": "ATD-TA1",
+      "title": "Shell metacharacter injection through MCP tool parameters",
+      "mechanism": "Unsanitized MCP tool input reaches execSync/exec, yielding RCE on the server host.",
+      "severity": "high",
+      "evidence": {
+        "kind": "cve",
+        "label": "CVE-2025-53355",
+        "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-53355"
+      },
+      "asi": [
+        "ASI05",
+        "ASI02"
+      ],
+      "atlas": [
+        "AML.T0053"
+      ],
+      "cwe": [
+        "CWE-77"
+      ],
+      "atrRule": "ATR-2026-01927"
+    },
+    {
+      "id": "ATD-T0002",
+      "tactic": "ATD-TA1",
+      "title": "curl-fallback command injection in an MCP server",
+      "mechanism": "A failed fetch falls back to exec'ing curl with an unsanitized URL, enabling RCE.",
+      "severity": "high",
+      "evidence": {
+        "kind": "cve",
+        "label": "CVE-2025-53967",
+        "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-53967"
+      },
+      "asi": [
+        "ASI05",
+        "ASI02"
+      ],
+      "atlas": [
+        "AML.T0053"
+      ],
+      "cwe": [
+        "CWE-420"
+      ],
+      "atrRule": "ATR-2026-01928"
+    },
+    {
+      "id": "ATD-T0003",
+      "tactic": "ATD-TA1",
+      "title": "Command injection in a scaffolded MCP stdio server",
+      "mechanism": "Generated server concatenates tool input into exec(), giving RCE to anything built from it.",
+      "severity": "critical",
+      "evidence": {
+        "kind": "cve",
+        "label": "CVE-2025-54994",
+        "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-54994"
+      },
+      "asi": [
+        "ASI04",
+        "ASI05"
+      ],
+      "atlas": [
+        "AML.T0010.005"
+      ],
+      "cwe": [
+        "CWE-78"
+      ],
+      "atrRule": "ATR-2026-00577"
+    },
+    {
+      "id": "ATD-T0004",
+      "tactic": "ATD-TA1",
+      "title": "Line-jumping — tool-description injection at listing time",
+      "mechanism": "Hidden instructions in a tool description enter the model context at tools/list, before any call.",
+      "severity": "high",
+      "evidence": {
+        "kind": "research",
+        "label": "Trail of Bits / Invariant Labs",
+        "url": "https://blog.trailofbits.com/2025/04/21/jumping-the-line-how-mcp-servers-can-attack-you-before-you-ever-use-them/"
+      },
+      "asi": [
+        "ASI04",
+        "ASI01"
+      ],
+      "atlas": [
+        "AML.T0110",
+        "AML.T0104"
+      ],
+      "cwe": [
+        "CWE-1427"
+      ],
+      "atrRule": "ATR-2026-00579"
+    },
+    {
+      "id": "ATD-T0005",
+      "tactic": "ATD-TA1",
+      "title": "Rug pull — silent mutation of an approved tool",
+      "mechanism": "A server approved once later changes a tool's definition with no integrity re-check.",
+      "severity": "high",
+      "evidence": {
+        "kind": "research",
+        "label": "Invariant Labs",
+        "url": "https://github.com/invariantlabs-ai/mcp-injection-experiments"
+      },
+      "asi": [
+        "ASI04"
+      ],
+      "atlas": [
+        "AML.T0109",
+        "AML.T0110"
+      ],
+      "cwe": [
+        "CWE-494"
+      ],
+      "atrRule": "ATR-2026-00581"
+    },
+    {
+      "id": "ATD-T0006",
+      "tactic": "ATD-TA1",
+      "title": "Missing-auth MCP proxy command execution",
+      "mechanism": "No auth between client and MCP proxy lets any local/web-driven request spawn MCP processes.",
+      "severity": "critical",
+      "evidence": {
+        "kind": "cve",
+        "label": "CVE-2025-49596",
+        "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-49596"
+      },
+      "asi": [
+        "ASI03",
+        "ASI05"
+      ],
+      "atlas": [],
+      "cwe": [
+        "CWE-306"
+      ]
+    },
+    {
+      "id": "ATD-T0007",
+      "tactic": "ATD-TA1",
+      "title": "RCE from a malicious upstream MCP server",
+      "mechanism": "A client is RCE'd via a crafted authorization_endpoint URL in an untrusted server's response.",
+      "severity": "critical",
+      "evidence": {
+        "kind": "cve",
+        "label": "CVE-2025-6514",
+        "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-6514"
+      },
+      "asi": [
+        "ASI04",
+        "ASI05"
+      ],
+      "atlas": [
+        "AML.T0010.005"
+      ],
+      "cwe": [
+        "CWE-78"
+      ]
+    },
+    {
+      "id": "ATD-T0008",
+      "tactic": "ATD-TA1",
+      "title": "DNS-rebinding to a localhost MCP server",
+      "mechanism": "A malicious page rebinds DNS to reach an unauthenticated localhost MCP server cross-origin.",
+      "severity": "high",
+      "evidence": {
+        "kind": "cve",
+        "label": "CVE-2025-66416",
+        "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-66416"
+      },
+      "asi": [
+        "ASI07",
+        "ASI03"
+      ],
+      "atlas": [],
+      "cwe": [
+        "CWE-1188"
+      ]
+    },
+    {
+      "id": "ATD-T0009",
+      "tactic": "ATD-TA1",
+      "title": "Session ID / auth token placed in a URL query string",
+      "mechanism": "A credential in the query string leaks via server logs, proxies, CDNs, history, and Referer.",
+      "severity": "medium",
+      "evidence": {
+        "kind": "research",
+        "label": "Vulnerable MCP Project (Equixly)",
+        "url": "https://vulnerablemcp.info/"
+      },
+      "asi": [
+        "ASI03",
+        "ASI07"
+      ],
+      "atlas": [],
+      "cwe": [
+        "CWE-598"
+      ],
+      "atrRule": "ATR-2026-00580"
+    },
+    {
+      "id": "ATD-T0010",
+      "tactic": "ATD-TA2",
+      "title": "Serialized-object smuggling through an LLM response field",
+      "mechanism": "Injected output carries a serialization marker; deserialization rehydrates it as trusted and exfiltrates secrets.",
+      "severity": "critical",
+      "evidence": {
+        "kind": "cve",
+        "label": "CVE-2025-68664",
+        "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-68664"
+      },
+      "asi": [
+        "ASI06",
+        "ASI01"
+      ],
+      "atlas": [
+        "AML.T0051.001"
+      ],
+      "cwe": [
+        "CWE-502"
+      ]
+    },
+    {
+      "id": "ATD-T0011",
+      "tactic": "ATD-TA2",
+      "title": "Persistent memory / context-store poisoning",
+      "mechanism": "Attacker-controlled content is written into data the agent later reads back as trusted context.",
+      "severity": "high",
+      "evidence": {
+        "kind": "research",
+        "label": "MITRE ATLAS — Context Poisoning",
+        "url": "https://atlas.mitre.org/"
+      },
+      "asi": [
+        "ASI06"
+      ],
+      "atlas": [
+        "AML.T0080"
+      ],
+      "cwe": [
+        "CWE-349"
+      ]
+    },
+    {
+      "id": "ATD-T0012",
+      "tactic": "ATD-TA3",
+      "title": "Indirect prompt injection via tool / API response",
+      "mechanism": "Malicious text in returned tool data overrides the agent's plan and redirects its actions.",
+      "severity": "high",
+      "evidence": {
+        "kind": "research",
+        "label": "InjecAgent, arXiv 2403.02691",
+        "url": "https://arxiv.org/abs/2403.02691"
+      },
+      "asi": [
+        "ASI01"
+      ],
+      "atlas": [
+        "AML.T0051.001",
+        "AML.T0099"
+      ],
+      "cwe": [
+        "CWE-1427"
+      ],
+      "atrRule": "ATR-2026-00584"
+    },
+    {
+      "id": "ATD-T0013",
+      "tactic": "ATD-TA3",
+      "title": "System-prompt / guardrail extraction to plan evasion",
+      "mechanism": "Crafted queries coerce the agent to reveal its hidden system prompt, exposing control logic.",
+      "severity": "medium",
+      "evidence": {
+        "kind": "research",
+        "label": "MITRE ATLAS — Extract LLM System Prompt",
+        "url": "https://atlas.mitre.org/"
+      },
+      "asi": [
+        "ASI01",
+        "ASI09"
+      ],
+      "atlas": [
+        "AML.T0056"
+      ],
+      "cwe": [
+        "CWE-200"
+      ]
+    },
+    {
+      "id": "ATD-T0014",
+      "tactic": "ATD-TA4",
+      "title": "Confused-deputy token passthrough in an MCP server",
+      "mechanism": "A server forwards a held token to a downstream API without audience validation, escalating privilege.",
+      "severity": "high",
+      "evidence": {
+        "kind": "research",
+        "label": "MCP Authorization spec (confused-deputy)",
+        "url": "https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization"
+      },
+      "asi": [
+        "ASI03"
+      ],
+      "atlas": [],
+      "cwe": [
+        "CWE-441"
+      ]
+    },
+    {
+      "id": "ATD-T0015",
+      "tactic": "ATD-TA5",
+      "title": "Agent reads .env / secret files without consent",
+      "mechanism": "An agent tool reads credential files (.env, credentials, .npmrc) outside any user-approved scope.",
+      "severity": "high",
+      "evidence": {
+        "kind": "research",
+        "label": "ModelContextProtocol-Security advisory",
+        "url": "https://github.com/modelcontextprotocol-security/vulnerability-db"
+      },
+      "asi": [
+        "ASI02",
+        "ASI06"
+      ],
+      "atlas": [
+        "AML.T0053"
+      ],
+      "cwe": [
+        "CWE-538"
+      ],
+      "atrRule": "ATR-2026-00583"
+    },
+    {
+      "id": "ATD-T0016",
+      "tactic": "ATD-TA5",
+      "title": "Hallucinated-dependency squatting (slopsquatting)",
+      "mechanism": "The model recommends a fabricated package name an attacker pre-registers, pulling code into the agent env.",
+      "severity": "medium",
+      "evidence": {
+        "kind": "research",
+        "label": "MITRE ATLAS — Publish Hallucinated Entities",
+        "url": "https://atlas.mitre.org/"
+      },
+      "asi": [
+        "ASI04",
+        "ASI08"
+      ],
+      "atlas": [
+        "AML.T0060",
+        "AML.T0062"
+      ],
+      "cwe": [
+        "CWE-1427"
+      ]
+    },
+    {
+      "id": "ATD-T0017",
+      "tactic": "ATD-TA6",
+      "title": "Path-traversal blacklist bypass via non-canonical paths",
+      "mechanism": "Exact-string path checks are bypassed with ../, /./, redundant slashes to reach sensitive files.",
+      "severity": "medium",
+      "evidence": {
+        "kind": "cve",
+        "label": "CVE-2025-66689",
+        "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-66689"
+      },
+      "asi": [
+        "ASI02",
+        "ASI03"
+      ],
+      "atlas": [
+        "AML.T0053"
+      ],
+      "cwe": [
+        "CWE-22"
+      ],
+      "atrRule": "ATR-2026-00578"
+    },
+    {
+      "id": "ATD-T0018",
+      "tactic": "ATD-TA6",
+      "title": "MCP filesystem sandbox escape via symlink following",
+      "mechanism": "A symlink inside an allowed directory resolves to an out-of-scope path, granting system file access.",
+      "severity": "high",
+      "evidence": {
+        "kind": "cve",
+        "label": "CVE-2025-53109",
+        "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-53109"
+      },
+      "asi": [
+        "ASI02",
+        "ASI05"
+      ],
+      "atlas": [
+        "AML.T0053"
+      ],
+      "cwe": [
+        "CWE-59"
+      ]
+    },
+    {
+      "id": "ATD-T0019",
+      "tactic": "ATD-TA6",
+      "title": "Prompt-injection-to-RCE via an agent's file-write capability",
+      "mechanism": "Injected instructions drive the agent to write a startup/config file that yields persistent code execution.",
+      "severity": "critical",
+      "evidence": {
+        "kind": "research",
+        "label": "Pillar Security — Antigravity (no CVE assigned)",
+        "url": "https://www.pillar.security/blog/prompt-injection-leads-to-rce-and-sandbox-escape-in-antigravity"
+      },
+      "asi": [
+        "ASI05",
+        "ASI01"
+      ],
+      "atlas": [
+        "AML.T0053",
+        "AML.T0051.001"
+      ],
+      "cwe": [
+        "CWE-94"
+      ]
+    },
+    {
+      "id": "ATD-T0020",
+      "tactic": "ATD-TA7",
+      "title": "Agent Card poisoning to capture A2A task routing",
+      "mechanism": "A rogue A2A agent advertises an instruction-laden Agent Card so the orchestrator routes tasks to it.",
+      "severity": "high",
+      "evidence": {
+        "kind": "research",
+        "label": "Trustwave SpiderLabs — Agent-in-the-Middle",
+        "url": "https://www.levelblue.com/blogs/spiderlabs-blog/agent-in-the-middle-abusing-agent-cards-in-the-agent-2-agent-protocol-to-win-all-the-tasks"
+      },
+      "asi": [
+        "ASI07",
+        "ASI10"
+      ],
+      "atlas": [
+        "AML.T0051.001"
+      ],
+      "cwe": [
+        "CWE-345"
+      ]
+    },
+    {
+      "id": "ATD-T0021",
+      "tactic": "ATD-TA7",
+      "title": "Cross-agent injection propagation (cascading compromise)",
+      "mechanism": "One compromised agent emits content that injects the next downstream agent, cascading through the swarm.",
+      "severity": "high",
+      "evidence": {
+        "kind": "research",
+        "label": "InjecAgent + multi-agent control-flow hijack",
+        "url": "https://arxiv.org/abs/2403.02691"
+      },
+      "asi": [
+        "ASI08",
+        "ASI07",
+        "ASI10"
+      ],
+      "atlas": [
+        "AML.T0051.001",
+        "AML.T0080"
+      ],
+      "cwe": [
+        "CWE-1427"
+      ]
+    },
+    {
+      "id": "ATD-T0022",
+      "tactic": "ATD-TA8",
+      "title": "Trace tampering / non-tamper-evident agent audit logs",
+      "mechanism": "An agent logs reasoning but not the actual tool call, or logs are mutable — defeating after-the-fact audit.",
+      "severity": "medium",
+      "evidence": {
+        "kind": "research",
+        "label": "EU AI Act Art.12 logging / observability gap",
+        "url": "https://artificialintelligenceact.eu/article/12/"
+      },
+      "asi": [
+        "ASI10"
+      ],
+      "atlas": [],
+      "cwe": [
+        "CWE-778"
+      ]
+    },
+    {
+      "id": "ATD-T0023",
+      "tactic": "ATD-TA9",
+      "title": "Adversarial transaction steering of a purchasing agent",
+      "mechanism": "Injected content in a listing/page steers an autonomous-commerce agent to overpay or leak payment authority.",
+      "severity": "medium",
+      "evidence": {
+        "kind": "aspirational",
+        "label": "Forward-looking — no public instance yet"
+      },
+      "asi": [
+        "ASI01",
+        "ASI02",
+        "ASI09"
+      ],
+      "atlas": [],
+      "cwe": [
+        "CWE-1427"
+      ]
+    },
+    {
+      "id": "ATD-T0024",
+      "tactic": "ATD-TA9",
+      "title": "Payment-mandate forgery in an agent-to-agent handshake",
+      "mechanism": "A rogue agent spoofs delegated payment authority or mandate scope in an agentic-commerce exchange.",
+      "severity": "medium",
+      "evidence": {
+        "kind": "aspirational",
+        "label": "Forward-looking — protocols (AP2-class) emerging"
+      },
+      "asi": [
+        "ASI03",
+        "ASI07"
+      ],
+      "atlas": [],
+      "cwe": [
+        "CWE-345"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Two things in one change: an urgent build fix and a new standards page.

Part A — build fix (urgent)
The rules detail page (/[locale]/rules/[ruleId]) crashed during static export on ATR-2026-00580. Its false_positives YAML had an entry containing an inner ": " (in "Authorization: Bearer ..."), which YAML parsed as an object instead of a string; the page rendered the object as a React child and the whole static export failed. Since 00580 shipped in #147, the production site build has likely been failing since that merge.
- fix: quote the offending false_positives entry so it parses as a string.
- harden: lib/rules.ts now coerces every false_positives entry to a string, so a single malformed rule can never break the whole static build again.
- chore: pin turbopack.root in next.config so Turbopack stops mis-inferring the workspace root from a parent lockfile.

Part B — ATD standard page (/atd, bilingual)
A new page introducing ATD (Agentic Threat Detection): the executable detection layer beneath the prose frameworks (OWASP Agentic Top 10, MITRE ATLAS, CWE, AVID). It is framed honestly as an Editor's Draft and a call for collaborators, not a ratified standard.
- navy document cover, a coverage band with verified numbers, the spec sections, and a browsable catalog of 24 techniques.
- each technique carries a real CVE (10 verified against NVD) or an honest research / aspirational label, plus OWASP ASI / MITRE ATLAS / CWE mappings (ATLAS ids verified against mitre-atlas/atlas-data dist/ATLAS.yaml). 9 techniques link a live ATR detection rule.
- downloadable artifacts: atd-techniques.json (the enumeration) and atd-technique.schema.json (normative JSON Schema).
- governance section states the OpenSSF-style neutrality bar and a transition roadmap; no claim of adoption — consumers integrate ATR rules, this is not an endorsement of the draft.

Verification
- typecheck clean; the website static export builds green locally with these exact files.
- CI runs the authoritative build (Validate Rules & Build), including the rules detail prerender that Part A fixes.

Not wired into the top nav yet (reachable at /atd) — intended to be split into its own home once governance matures.
