### PR TITLE
docs: sync rule counts to 651 across README + website

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ ATR is publishing proposal-stage standardization scaffolding ahead of OASIS Open
 - [`certification/`](certification/) — proposed ATR-Certified™ program guide
 - [`engines/`](engines/) — Python and Go reference impl interface contracts (TypeScript is the existing engine at `src/`)
 
-**All scaffolding is tagged PROPOSED v1.0 / v2.0 and is NOT ratified.** The 9-seat TSC has not been formed. The trust marks are not registered. Existing v1.1 governance ([`GOVERNANCE.md`](GOVERNANCE.md)) continues to operate. The rule format, npm package, TypeScript engine API, and all 462 rules are unchanged — existing ecosystem integrations (Microsoft AGT, Cisco AI Defense, MISP CIRCL, OWASP A-S-R-H, precize, Sage) work without modification.
+**All scaffolding is tagged PROPOSED v1.0 / v2.0 and is NOT ratified.** The 9-seat TSC has not been formed. The trust marks are not registered. Existing v1.1 governance ([`GOVERNANCE.md`](GOVERNANCE.md)) continues to operate. The rule format, npm package, TypeScript engine API, and all 651 rules are unchanged — existing ecosystem integrations (Microsoft AGT, Cisco AI Defense, MISP CIRCL, OWASP A-S-R-H, precize, Sage) work without modification.
 
 See [`STANDARDIZATION-STATUS.md`](STANDARDIZATION-STATUS.md) for the full status matrix mapping every new artifact to `{STABLE IN PRODUCTION, PROPOSED, SKELETON, PRELIMINARY}` and timeline for OASIS submission, community comment, and ratification.
 
@@ -289,17 +289,17 @@ ATR maps its rules onto established frameworks so adopters can answer "we deploy
 
 | Category | Rules | What it catches |
 |---|---:|---|
-| Prompt Injection | 172 | Instruction override, persona hijacking, encoded payloads (base-N, ROT, Unicode tags, zalgo, ecoji), CJK attacks, latent injection, glitch tokens, leakreplay |
-| Agent Manipulation | 105 | DAN family, AutoDAN, DanInTheWild, tense framing, grandma roleplay, doctor-XML puppetry, goal hijacking, Sybil consensus, lambda+eval RCE |
-| Skill Compromise | 41 | Typosquatting, context poisoning, subcommand overflow, rug pull, supply-chain attacks, credential-exfil combos, HuggingFace unsafe artifacts |
-| Context Exfiltration | 41 | API-key generation/completion, system-prompt theft, credential harvesting, env-var exfil, markdown-URL exfil, XSS in tool response, cross-user memory leakage |
-| Tool Poisoning | 27 | Malicious MCP responses, consent bypass, hidden LLM instructions, schema contradictions, ANSI escape elicitation, vector-store filter injection |
-| Privilege Escalation | 12 | Scope creep, delayed execution bypass, admin function access, shell escape, SQL injection in admin endpoints, autostart file write |
-| Model Abuse | 10 | Malware code generation (malwaregen), EICAR/GTUBE signatures, AV-evasion gen |
-| Excessive Autonomy | 8 | Runaway loops, resource exhaustion, unauthorized financial actions |
+| Prompt Injection | 223 | Instruction override, persona hijacking, encoded payloads (base-N, ROT, Unicode tags, zalgo, ecoji), CJK attacks, latent injection, glitch tokens, leakreplay |
+| Agent Manipulation | 106 | DAN family, AutoDAN, DanInTheWild, tense framing, grandma roleplay, doctor-XML puppetry, goal hijacking, Sybil consensus, lambda+eval RCE |
+| Skill Compromise | 45 | Typosquatting, context poisoning, subcommand overflow, rug pull, supply-chain attacks, credential-exfil combos, HuggingFace unsafe artifacts |
+| Context Exfiltration | 103 | API-key generation/completion, system-prompt theft, credential harvesting, env-var exfil, markdown-URL exfil, XSS in tool response, cross-user memory leakage |
+| Tool Poisoning | 65 | Malicious MCP responses, consent bypass, hidden LLM instructions, schema contradictions, ANSI escape elicitation, vector-store filter injection |
+| Privilege Escalation | 35 | Scope creep, delayed execution bypass, admin function access, shell escape, SQL injection in admin endpoints, autostart file write |
+| Model Abuse | 37 | Malware code generation (malwaregen), EICAR/GTUBE signatures, AV-evasion gen |
+| Excessive Autonomy | 29 | Runaway loops, resource exhaustion, unauthorized financial actions |
 | Model Security | 3 | Behavior extraction, malicious fine-tuning data |
-| Data Poisoning | 2 | RAG / knowledge-base tampering, memory manipulation, persistence-aware override |
-| **Total** | **421** |  |
+| Data Poisoning | 5 | RAG / knowledge-base tampering, memory manipulation, persistence-aware override |
+| **Total** | **651** |  |
 
 ### CVE coverage (selected)
 

--- a/website/app/[locale]/about/page.tsx
+++ b/website/app/[locale]/about/page.tsx
@@ -157,12 +157,12 @@ const MILESTONES: Milestone[] = [
   {
     date: "2026-06",
     title: {
-      en: "v3.1.x · 462 rules across 10 categories",
-      zh: "v3.1.x · 462 條規則,跨 10 個類別",
+      en: "v3.3.x · 651 rules across 10 categories",
+      zh: "v3.3.x · 651 條規則,跨 10 個類別",
     },
     detail: {
-      en: "Current release line: 462 detection rules across 10 categories, specification 3.0.0-alpha.1 (Working Draft).",
-      zh: "目前釋出線:462 條偵測規則,跨 10 個類別,規範 3.0.0-alpha.1（Working Draft）。",
+      en: "Current release line: 651 detection rules across 10 categories, specification 3.0.0-alpha.1 (Working Draft).",
+      zh: "目前釋出線:651 條偵測規則,跨 10 個類別,規範 3.0.0-alpha.1（Working Draft）。",
     },
   },
 ];

--- a/website/public/og-image.svg
+++ b/website/public/og-image.svg
@@ -30,7 +30,7 @@
 
   <!-- Stats bar -->
   <text x="80" y="400" font-family="ui-monospace, monospace" font-size="16" fill="#6B6B76" letter-spacing="2">
-    <tspan>113 RULES</tspan>
+    <tspan>651 RULES</tspan>
     <tspan dx="30">96K SCANNED</tspan>
     <tspan dx="30">751 MALWARE</tspan>
     <tspan dx="30">CISCO SHIPPED</tspan>


### PR DESCRIPTION
Sync the hardcoded rule-count surfaces to the current ground truth (651 rules / 10 categories / v3.3.x). Verified against find rules + data/stats.json (both 651) and package.json (3.3.1).

README
- Detection-category table refreshed to the live 10-category breakdown summing to 651 (was a stale 7-visible / 421 total): Prompt Injection 223, Agent Manipulation 106, Context Exfiltration 103, Tool Poisoning 65, Skill Compromise 45, Model Abuse 37, Privilege Escalation 35, Excessive Autonomy 29, Data Poisoning 5, Model Security 3.
- Standardization-status paragraph: "all 651 rules are unchanged" (was 462).

Website
- about page current-release timeline entry: v3.3.x / 651 rules (the 2026-04-15 v2.0.0 / 113-rule entry stays as history).
- og-image social card: 651 RULES (was 113).

Not touched (correctly)
- Dynamic counts (homepage hero, stats bar) read lib/stats.ts -> ../rules at build time and were already current.
- Benchmark table stays the 2026-05-23 version-pinned snapshot, consistent with data/stats.json; updating it requires re-running the measurement pipeline, not a hand edit.

Test plan
- [x] find rules -name "*.yaml" | wc -l == data/stats.json rules.total == 651
- [x] per-category counts verified by directory count
- [x] no stale 462/421 left in current-state copy
