### PR TITLE
feat(atd): nav promotion + contribution front-door + schema gate

### DIFF
--- a/.github/ISSUE_TEMPLATE/atd-technique-submission.yml
+++ b/.github/ISSUE_TEMPLATE/atd-technique-submission.yml
@@ -1,0 +1,82 @@
+name: ATD — Submit a technique
+description: Propose a new agent-native threat technique for the ATD enumeration. Submissions enter a review queue; nothing auto-publishes.
+title: "[ATD] Technique: <short imperative title>"
+labels: ["atd", "atd-technique-submission", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for contributing to ATD (Agentic Threat Detection).
+
+        Important: this is a request for review, not a publish. Every submission
+        is treated as untrusted input, runs through a deterministic schema +
+        precision gate, and is reviewed by a maintainer before anything ships.
+        Do NOT paste working exploit payloads — describe the mechanism and link
+        evidence. See the contribution gate: https://agentthreatrule.org/en/atd#downloads
+  - type: input
+    id: title
+    attributes:
+      label: Technique title
+      description: A short imperative noun phrase, e.g. "Rug pull — silent mutation of an approved tool".
+      placeholder: Short imperative title
+    validations:
+      required: true
+  - type: dropdown
+    id: tactic
+    attributes:
+      label: Tactic
+      description: Which ATD tactic does this fall under?
+      options:
+        - "ATD-TA1 Protocol & Interconnect"
+        - "ATD-TA2 Memory & Context Integrity"
+        - "ATD-TA3 Goal, Planning & Reasoning"
+        - "ATD-TA4 Identity, Authz & Delegation"
+        - "ATD-TA5 Tool & Supply Chain"
+        - "ATD-TA6 Execution & Autonomy"
+        - "ATD-TA7 Multi-Agent Dynamics"
+        - "ATD-TA8 Model-Intrinsic & Governance"
+        - "ATD-TA9 Agentic Commerce (forward)"
+    validations:
+      required: true
+  - type: textarea
+    id: mechanism
+    attributes:
+      label: Attack mechanism (one or two sentences)
+      description: How the attack works. Describe the mechanism — do not include a working exploit payload.
+    validations:
+      required: true
+  - type: input
+    id: evidence
+    attributes:
+      label: Evidence URL
+      description: A real CVE (NVD/GHSA), a published advisory, or a peer-reviewed paper. Mark "aspirational" only if no public instance exists.
+      placeholder: https://nvd.nist.gov/vuln/detail/CVE-...  |  https://arxiv.org/abs/...  |  aspirational
+    validations:
+      required: true
+  - type: input
+    id: mappings
+    attributes:
+      label: Proposed framework mappings
+      description: OWASP ASI / MITRE ATLAS (AML.T...) / CWE, where one exists. Leave blank where genuinely none applies.
+      placeholder: "ASI04; AML.T0109; CWE-494"
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Severity
+      options: ["critical", "high", "medium"]
+    validations:
+      required: true
+  - type: textarea
+    id: detection
+    attributes:
+      label: Detection idea (optional)
+      description: If you have a precision-safe detection sketch (a regex or content pattern), describe it. It will go through the 0-FP gate before any rule ships.
+  - type: checkboxes
+    id: ack
+    attributes:
+      label: Acknowledgements
+      options:
+        - label: I am not pasting a working exploit payload; I am describing a mechanism and linking evidence.
+          required: true
+        - label: The evidence URL is real and verifiable (or I marked this aspirational).
+          required: true

--- a/.github/ISSUE_TEMPLATE/atd-tool-mapping.yml
+++ b/.github/ISSUE_TEMPLATE/atd-tool-mapping.yml
@@ -1,0 +1,42 @@
+name: ATD — Map a tool / interoperate
+description: Register that your scanner, framework, or registry maps to ATD, or request a crosswalk. Builds the ecosystem; borrows no authority it hasn't earned.
+title: "[ATD] Mapping: <your tool / project>"
+labels: ["atd", "atd-mapping", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this to declare that your project consumes or maps to ATD, or to
+        request an interop crosswalk (e.g. ATD ↔ your detection IDs, or ATD ↔
+        OWASP ASI / MITRE ATLAS / AVID). ATD maps to the established frameworks
+        rather than competing with them.
+  - type: input
+    id: project
+    attributes:
+      label: Project / tool name
+    validations:
+      required: true
+  - type: input
+    id: url
+    attributes:
+      label: Project URL
+    validations:
+      required: true
+  - type: dropdown
+    id: kind
+    attributes:
+      label: Relationship
+      options:
+        - "Consumes ATD techniques / rules"
+        - "Maps its own detections to ATD"
+        - "Requests a crosswalk to another framework"
+        - "Offers to maintain / co-author"
+    validations:
+      required: true
+  - type: textarea
+    id: detail
+    attributes:
+      label: Details
+      description: What you map, how, and what you need from us.
+    validations:
+      required: true

--- a/.github/workflows/atd-validate.yml
+++ b/.github/workflows/atd-validate.yml
@@ -1,0 +1,24 @@
+name: ATD — Validate enumeration
+
+on:
+  pull_request:
+    paths:
+      - "website/public/atd/**"
+      - "website/lib/atd-data.ts"
+      - "scripts/validate-atd.ts"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
+        with:
+          node-version: "20"
+      - run: npm ci
+      - name: Validate ATD techniques against the schema
+        run: npx tsx scripts/validate-atd.ts

--- a/scripts/validate-atd.ts
+++ b/scripts/validate-atd.ts
@@ -1,0 +1,75 @@
+#!/usr/bin/env npx tsx
+/**
+ * validate-atd.ts — schema gate for the ATD enumeration.
+ *
+ * Validates every technique in website/public/atd/atd-techniques.json against
+ * the normative JSON Schema (website/public/atd/atd-technique.schema.json), and
+ * checks catalog-level invariants (unique ids, known tactics, no broken self).
+ *
+ * This is the deterministic gate behind ATD contributions: a submitted or
+ * edited technique MUST validate here before a maintainer reviews it, and the
+ * CI workflow runs it on any PR touching the ATD data. Nothing auto-publishes.
+ *
+ * Exit 0 = all techniques valid. Exit 1 = at least one failure.
+ */
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import Ajv2020 from "ajv/dist/2020.js";
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const SCHEMA = resolve(REPO_ROOT, "website/public/atd/atd-technique.schema.json");
+const DATA = resolve(REPO_ROOT, "website/public/atd/atd-techniques.json");
+
+function main(): void {
+  const schema = JSON.parse(readFileSync(SCHEMA, "utf-8"));
+  const doc = JSON.parse(readFileSync(DATA, "utf-8"));
+  const techniques: unknown[] = Array.isArray(doc?.techniques) ? doc.techniques : [];
+
+  if (techniques.length === 0) {
+    console.error("[validate-atd] FAIL: no techniques found in atd-techniques.json");
+    process.exit(1);
+  }
+
+  // strict:false so unknown "format" keywords (uri/uuid) don't hard-error in
+  // environments without ajv-formats; we register permissive formats instead.
+  const ajv = new Ajv2020({ allErrors: true, strict: false });
+  ajv.addFormat("uri", () => true);
+  ajv.addFormat("uuid", () => true);
+  const validate = ajv.compile(schema);
+
+  const seen = new Set<string>();
+  const tactics = new Set(
+    (Array.isArray(doc?.tactics) ? doc.tactics : []).map(
+      (t: { id?: string }) => t?.id,
+    ),
+  );
+  const failures: string[] = [];
+
+  for (const t of techniques) {
+    const tech = t as { atd_id?: string; tactic?: string };
+    const id = tech.atd_id ?? "<no id>";
+    if (!validate(t)) {
+      const msg = (validate.errors ?? [])
+        .map((e) => `${e.instancePath || "/"} ${e.message}`)
+        .join("; ");
+      failures.push(`${id}: schema — ${msg}`);
+    }
+    if (tech.atd_id) {
+      if (seen.has(tech.atd_id)) failures.push(`${id}: duplicate atd_id`);
+      seen.add(tech.atd_id);
+    }
+    if (tech.tactic && tactics.size > 0 && !tactics.has(tech.tactic)) {
+      failures.push(`${id}: unknown tactic ${tech.tactic}`);
+    }
+  }
+
+  if (failures.length > 0) {
+    console.error(`[validate-atd] FAIL — ${failures.length} issue(s):`);
+    for (const f of failures) console.error("  - " + f);
+    process.exit(1);
+  }
+  console.log(`[validate-atd] PASS — ${techniques.length} techniques valid.`);
+}
+
+main();

--- a/website/components/Nav.tsx
+++ b/website/components/Nav.tsx
@@ -23,6 +23,7 @@ export function Nav({ locale }: { locale: Locale }) {
   const prefix = `/${locale}`;
   const otherLocale = locale === "en" ? "zh" : "en";
   const pages = [
+    "atd",
     "spec",
     "rules",
     "threats",

--- a/website/lib/atd-data.ts
+++ b/website/lib/atd-data.ts
@@ -257,7 +257,7 @@ export const ATD_TECHNIQUES: ATDTechnique[] = [
     title: "Adversarial transaction steering of a purchasing agent",
     mechanism: "Injected content in a listing/page steers an autonomous-commerce agent to overpay or leak payment authority.",
     severity: "medium",
-    evidence: { kind: "aspirational", label: "Forward-looking — no public instance yet" },
+    evidence: { kind: "aspirational", label: "Forward-looking — no public instance yet", url: "https://cloud.google.com/blog/products/ai-machine-learning/announcing-agents-to-payments-ap2-protocol" },
     asi: ["ASI01", "ASI02", "ASI09"], atlas: [], cwe: ["CWE-1427"],
   },
   {
@@ -266,7 +266,7 @@ export const ATD_TECHNIQUES: ATDTechnique[] = [
     title: "Payment-mandate forgery in an agent-to-agent handshake",
     mechanism: "A rogue agent spoofs delegated payment authority or mandate scope in an agentic-commerce exchange.",
     severity: "medium",
-    evidence: { kind: "aspirational", label: "Forward-looking — protocols (AP2-class) emerging" },
+    evidence: { kind: "aspirational", label: "Forward-looking — protocols (AP2-class) emerging", url: "https://fidoalliance.org/fido-alliance-to-develop-standards-for-trusted-ai-agent-interactions/" },
     asi: ["ASI03", "ASI07"], atlas: [], cwe: ["CWE-345"],
   },
 ];
@@ -277,3 +277,51 @@ export const ATD_STATS = {
   withCve: ATD_TECHNIQUES.filter((t) => t.evidence.kind === "cve").length,
   tactics: ATD_TACTICS.length,
 };
+
+// Map the internal render-model to the normative schema shape used by the
+// public, downloadable enumeration (atd-techniques.json) and validated by
+// scripts/validate-atd.ts. The page renders the simple model; the published
+// artifact conforms to atd-technique.schema.json.
+const TACTIC_SURFACE: Record<string, string[]> = {
+  "ATD-TA1": ["tool_input", "tool_response"],
+  "ATD-TA2": ["memory_op"],
+  "ATD-TA3": ["content", "tool_response"],
+  "ATD-TA4": ["tool_input"],
+  "ATD-TA5": ["tool_input", "tool_response"],
+  "ATD-TA6": ["tool_input", "trace"],
+  "ATD-TA7": ["inter_agent_msg"],
+  "ATD-TA8": ["trace"],
+  "ATD-TA9": ["payment_mandate"],
+};
+
+export function toATDRecord(t: ATDTechnique) {
+  const refType =
+    t.evidence.kind === "cve"
+      ? "cve"
+      : t.evidence.kind === "aspirational"
+        ? "vendor"
+        : "research";
+  return {
+    atd_id: t.id,
+    schema_version: "0.1.0",
+    title: t.title,
+    tactic: t.tactic,
+    abstraction: "base",
+    status: "experimental",
+    severity: t.severity,
+    description: t.mechanism,
+    detection_surface: TACTIC_SURFACE[t.tactic] ?? ["content"],
+    mappings: {
+      owasp_asi: t.asi,
+      mitre_atlas: t.atlas,
+      cwe: t.cwe,
+      ...(t.asi.length === 0 && t.atlas.length === 0
+        ? { gap_note: "No upstream framework names this technique yet." }
+        : {}),
+    },
+    references: t.evidence.url
+      ? [{ type: refType, url: t.evidence.url }]
+      : [],
+    ...(t.atrRule ? { atr_rule: t.atrRule } : {}),
+  };
+}

--- a/website/lib/i18n.ts
+++ b/website/lib/i18n.ts
@@ -246,6 +246,7 @@ export const messages: Record<Locale, Record<string, string>> = {
     "cite.tablist_aria": "Citation format selector",
 
     // Nav additions (kept short)
+    "nav.atd": "ATD",
     "nav.spec": "Specification",
     "nav.implementers": "Implementers",
     "nav.conformance": "Conformance",
@@ -633,6 +634,7 @@ export const messages: Record<Locale, Record<string, string>> = {
     "spec.implementer_report": "\u5BE6\u4F5C\u8005\u5831\u544A (Implementer Report)",
     "cite.tablist_aria": "\u5F15\u7528\u683C\u5F0F\u9078\u64C7\u5668",
 
+    "nav.atd": "ATD",
     "nav.spec": "\u898F\u683C (Specification)",
     "nav.implementers": "\u5BE6\u4F5C\u8005 (Implementers)",
     "nav.conformance": "\u7B26\u898F (Conformance)",

--- a/website/public/atd/atd-techniques.json
+++ b/website/public/atd/atd-techniques.json
@@ -50,527 +50,761 @@
   ],
   "techniques": [
     {
-      "id": "ATD-T0001",
-      "tactic": "ATD-TA1",
+      "atd_id": "ATD-T0001",
+      "schema_version": "0.1.0",
       "title": "Shell metacharacter injection through MCP tool parameters",
-      "mechanism": "Unsanitized MCP tool input reaches execSync/exec, yielding RCE on the server host.",
+      "tactic": "ATD-TA1",
+      "abstraction": "base",
+      "status": "experimental",
       "severity": "high",
-      "evidence": {
-        "kind": "cve",
-        "label": "CVE-2025-53355",
-        "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-53355"
+      "description": "Unsanitized MCP tool input reaches execSync/exec, yielding RCE on the server host.",
+      "detection_surface": [
+        "tool_input",
+        "tool_response"
+      ],
+      "mappings": {
+        "owasp_asi": [
+          "ASI05",
+          "ASI02"
+        ],
+        "mitre_atlas": [
+          "AML.T0053"
+        ],
+        "cwe": [
+          "CWE-77"
+        ]
       },
-      "asi": [
-        "ASI05",
-        "ASI02"
+      "references": [
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-53355"
+        }
       ],
-      "atlas": [
-        "AML.T0053"
-      ],
-      "cwe": [
-        "CWE-77"
-      ],
-      "atrRule": "ATR-2026-01927"
+      "atr_rule": "ATR-2026-01927"
     },
     {
-      "id": "ATD-T0002",
-      "tactic": "ATD-TA1",
+      "atd_id": "ATD-T0002",
+      "schema_version": "0.1.0",
       "title": "curl-fallback command injection in an MCP server",
-      "mechanism": "A failed fetch falls back to exec'ing curl with an unsanitized URL, enabling RCE.",
+      "tactic": "ATD-TA1",
+      "abstraction": "base",
+      "status": "experimental",
       "severity": "high",
-      "evidence": {
-        "kind": "cve",
-        "label": "CVE-2025-53967",
-        "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-53967"
+      "description": "A failed fetch falls back to exec'ing curl with an unsanitized URL, enabling RCE.",
+      "detection_surface": [
+        "tool_input",
+        "tool_response"
+      ],
+      "mappings": {
+        "owasp_asi": [
+          "ASI05",
+          "ASI02"
+        ],
+        "mitre_atlas": [
+          "AML.T0053"
+        ],
+        "cwe": [
+          "CWE-420"
+        ]
       },
-      "asi": [
-        "ASI05",
-        "ASI02"
+      "references": [
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-53967"
+        }
       ],
-      "atlas": [
-        "AML.T0053"
-      ],
-      "cwe": [
-        "CWE-420"
-      ],
-      "atrRule": "ATR-2026-01928"
+      "atr_rule": "ATR-2026-01928"
     },
     {
-      "id": "ATD-T0003",
-      "tactic": "ATD-TA1",
+      "atd_id": "ATD-T0003",
+      "schema_version": "0.1.0",
       "title": "Command injection in a scaffolded MCP stdio server",
-      "mechanism": "Generated server concatenates tool input into exec(), giving RCE to anything built from it.",
+      "tactic": "ATD-TA1",
+      "abstraction": "base",
+      "status": "experimental",
       "severity": "critical",
-      "evidence": {
-        "kind": "cve",
-        "label": "CVE-2025-54994",
-        "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-54994"
+      "description": "Generated server concatenates tool input into exec(), giving RCE to anything built from it.",
+      "detection_surface": [
+        "tool_input",
+        "tool_response"
+      ],
+      "mappings": {
+        "owasp_asi": [
+          "ASI04",
+          "ASI05"
+        ],
+        "mitre_atlas": [
+          "AML.T0010.005"
+        ],
+        "cwe": [
+          "CWE-78"
+        ]
       },
-      "asi": [
-        "ASI04",
-        "ASI05"
+      "references": [
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-54994"
+        }
       ],
-      "atlas": [
-        "AML.T0010.005"
-      ],
-      "cwe": [
-        "CWE-78"
-      ],
-      "atrRule": "ATR-2026-00577"
+      "atr_rule": "ATR-2026-00577"
     },
     {
-      "id": "ATD-T0004",
-      "tactic": "ATD-TA1",
+      "atd_id": "ATD-T0004",
+      "schema_version": "0.1.0",
       "title": "Line-jumping — tool-description injection at listing time",
-      "mechanism": "Hidden instructions in a tool description enter the model context at tools/list, before any call.",
+      "tactic": "ATD-TA1",
+      "abstraction": "base",
+      "status": "experimental",
       "severity": "high",
-      "evidence": {
-        "kind": "research",
-        "label": "Trail of Bits / Invariant Labs",
-        "url": "https://blog.trailofbits.com/2025/04/21/jumping-the-line-how-mcp-servers-can-attack-you-before-you-ever-use-them/"
+      "description": "Hidden instructions in a tool description enter the model context at tools/list, before any call.",
+      "detection_surface": [
+        "tool_input",
+        "tool_response"
+      ],
+      "mappings": {
+        "owasp_asi": [
+          "ASI04",
+          "ASI01"
+        ],
+        "mitre_atlas": [
+          "AML.T0110",
+          "AML.T0104"
+        ],
+        "cwe": [
+          "CWE-1427"
+        ]
       },
-      "asi": [
-        "ASI04",
-        "ASI01"
+      "references": [
+        {
+          "type": "research",
+          "url": "https://blog.trailofbits.com/2025/04/21/jumping-the-line-how-mcp-servers-can-attack-you-before-you-ever-use-them/"
+        }
       ],
-      "atlas": [
-        "AML.T0110",
-        "AML.T0104"
-      ],
-      "cwe": [
-        "CWE-1427"
-      ],
-      "atrRule": "ATR-2026-00579"
+      "atr_rule": "ATR-2026-00579"
     },
     {
-      "id": "ATD-T0005",
-      "tactic": "ATD-TA1",
+      "atd_id": "ATD-T0005",
+      "schema_version": "0.1.0",
       "title": "Rug pull — silent mutation of an approved tool",
-      "mechanism": "A server approved once later changes a tool's definition with no integrity re-check.",
+      "tactic": "ATD-TA1",
+      "abstraction": "base",
+      "status": "experimental",
       "severity": "high",
-      "evidence": {
-        "kind": "research",
-        "label": "Invariant Labs",
-        "url": "https://github.com/invariantlabs-ai/mcp-injection-experiments"
+      "description": "A server approved once later changes a tool's definition with no integrity re-check.",
+      "detection_surface": [
+        "tool_input",
+        "tool_response"
+      ],
+      "mappings": {
+        "owasp_asi": [
+          "ASI04"
+        ],
+        "mitre_atlas": [
+          "AML.T0109",
+          "AML.T0110"
+        ],
+        "cwe": [
+          "CWE-494"
+        ]
       },
-      "asi": [
-        "ASI04"
+      "references": [
+        {
+          "type": "research",
+          "url": "https://github.com/invariantlabs-ai/mcp-injection-experiments"
+        }
       ],
-      "atlas": [
-        "AML.T0109",
-        "AML.T0110"
-      ],
-      "cwe": [
-        "CWE-494"
-      ],
-      "atrRule": "ATR-2026-00581"
+      "atr_rule": "ATR-2026-00581"
     },
     {
-      "id": "ATD-T0006",
-      "tactic": "ATD-TA1",
+      "atd_id": "ATD-T0006",
+      "schema_version": "0.1.0",
       "title": "Missing-auth MCP proxy command execution",
-      "mechanism": "No auth between client and MCP proxy lets any local/web-driven request spawn MCP processes.",
+      "tactic": "ATD-TA1",
+      "abstraction": "base",
+      "status": "experimental",
       "severity": "critical",
-      "evidence": {
-        "kind": "cve",
-        "label": "CVE-2025-49596",
-        "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-49596"
-      },
-      "asi": [
-        "ASI03",
-        "ASI05"
+      "description": "No auth between client and MCP proxy lets any local/web-driven request spawn MCP processes.",
+      "detection_surface": [
+        "tool_input",
+        "tool_response"
       ],
-      "atlas": [],
-      "cwe": [
-        "CWE-306"
+      "mappings": {
+        "owasp_asi": [
+          "ASI03",
+          "ASI05"
+        ],
+        "mitre_atlas": [],
+        "cwe": [
+          "CWE-306"
+        ]
+      },
+      "references": [
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-49596"
+        }
       ]
     },
     {
-      "id": "ATD-T0007",
-      "tactic": "ATD-TA1",
+      "atd_id": "ATD-T0007",
+      "schema_version": "0.1.0",
       "title": "RCE from a malicious upstream MCP server",
-      "mechanism": "A client is RCE'd via a crafted authorization_endpoint URL in an untrusted server's response.",
+      "tactic": "ATD-TA1",
+      "abstraction": "base",
+      "status": "experimental",
       "severity": "critical",
-      "evidence": {
-        "kind": "cve",
-        "label": "CVE-2025-6514",
-        "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-6514"
+      "description": "A client is RCE'd via a crafted authorization_endpoint URL in an untrusted server's response.",
+      "detection_surface": [
+        "tool_input",
+        "tool_response"
+      ],
+      "mappings": {
+        "owasp_asi": [
+          "ASI04",
+          "ASI05"
+        ],
+        "mitre_atlas": [
+          "AML.T0010.005"
+        ],
+        "cwe": [
+          "CWE-78"
+        ]
       },
-      "asi": [
-        "ASI04",
-        "ASI05"
-      ],
-      "atlas": [
-        "AML.T0010.005"
-      ],
-      "cwe": [
-        "CWE-78"
+      "references": [
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-6514"
+        }
       ]
     },
     {
-      "id": "ATD-T0008",
-      "tactic": "ATD-TA1",
+      "atd_id": "ATD-T0008",
+      "schema_version": "0.1.0",
       "title": "DNS-rebinding to a localhost MCP server",
-      "mechanism": "A malicious page rebinds DNS to reach an unauthenticated localhost MCP server cross-origin.",
-      "severity": "high",
-      "evidence": {
-        "kind": "cve",
-        "label": "CVE-2025-66416",
-        "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-66416"
-      },
-      "asi": [
-        "ASI07",
-        "ASI03"
-      ],
-      "atlas": [],
-      "cwe": [
-        "CWE-1188"
-      ]
-    },
-    {
-      "id": "ATD-T0009",
       "tactic": "ATD-TA1",
+      "abstraction": "base",
+      "status": "experimental",
+      "severity": "high",
+      "description": "A malicious page rebinds DNS to reach an unauthenticated localhost MCP server cross-origin.",
+      "detection_surface": [
+        "tool_input",
+        "tool_response"
+      ],
+      "mappings": {
+        "owasp_asi": [
+          "ASI07",
+          "ASI03"
+        ],
+        "mitre_atlas": [],
+        "cwe": [
+          "CWE-1188"
+        ]
+      },
+      "references": [
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-66416"
+        }
+      ]
+    },
+    {
+      "atd_id": "ATD-T0009",
+      "schema_version": "0.1.0",
       "title": "Session ID / auth token placed in a URL query string",
-      "mechanism": "A credential in the query string leaks via server logs, proxies, CDNs, history, and Referer.",
+      "tactic": "ATD-TA1",
+      "abstraction": "base",
+      "status": "experimental",
       "severity": "medium",
-      "evidence": {
-        "kind": "research",
-        "label": "Vulnerable MCP Project (Equixly)",
-        "url": "https://vulnerablemcp.info/"
+      "description": "A credential in the query string leaks via server logs, proxies, CDNs, history, and Referer.",
+      "detection_surface": [
+        "tool_input",
+        "tool_response"
+      ],
+      "mappings": {
+        "owasp_asi": [
+          "ASI03",
+          "ASI07"
+        ],
+        "mitre_atlas": [],
+        "cwe": [
+          "CWE-598"
+        ]
       },
-      "asi": [
-        "ASI03",
-        "ASI07"
+      "references": [
+        {
+          "type": "research",
+          "url": "https://vulnerablemcp.info/"
+        }
       ],
-      "atlas": [],
-      "cwe": [
-        "CWE-598"
-      ],
-      "atrRule": "ATR-2026-00580"
+      "atr_rule": "ATR-2026-00580"
     },
     {
-      "id": "ATD-T0010",
-      "tactic": "ATD-TA2",
+      "atd_id": "ATD-T0010",
+      "schema_version": "0.1.0",
       "title": "Serialized-object smuggling through an LLM response field",
-      "mechanism": "Injected output carries a serialization marker; deserialization rehydrates it as trusted and exfiltrates secrets.",
-      "severity": "critical",
-      "evidence": {
-        "kind": "cve",
-        "label": "CVE-2025-68664",
-        "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-68664"
-      },
-      "asi": [
-        "ASI06",
-        "ASI01"
-      ],
-      "atlas": [
-        "AML.T0051.001"
-      ],
-      "cwe": [
-        "CWE-502"
-      ]
-    },
-    {
-      "id": "ATD-T0011",
       "tactic": "ATD-TA2",
-      "title": "Persistent memory / context-store poisoning",
-      "mechanism": "Attacker-controlled content is written into data the agent later reads back as trusted context.",
-      "severity": "high",
-      "evidence": {
-        "kind": "research",
-        "label": "MITRE ATLAS — Context Poisoning",
-        "url": "https://atlas.mitre.org/"
-      },
-      "asi": [
-        "ASI06"
-      ],
-      "atlas": [
-        "AML.T0080"
-      ],
-      "cwe": [
-        "CWE-349"
-      ]
-    },
-    {
-      "id": "ATD-T0012",
-      "tactic": "ATD-TA3",
-      "title": "Indirect prompt injection via tool / API response",
-      "mechanism": "Malicious text in returned tool data overrides the agent's plan and redirects its actions.",
-      "severity": "high",
-      "evidence": {
-        "kind": "research",
-        "label": "InjecAgent, arXiv 2403.02691",
-        "url": "https://arxiv.org/abs/2403.02691"
-      },
-      "asi": [
-        "ASI01"
-      ],
-      "atlas": [
-        "AML.T0051.001",
-        "AML.T0099"
-      ],
-      "cwe": [
-        "CWE-1427"
-      ],
-      "atrRule": "ATR-2026-00584"
-    },
-    {
-      "id": "ATD-T0013",
-      "tactic": "ATD-TA3",
-      "title": "System-prompt / guardrail extraction to plan evasion",
-      "mechanism": "Crafted queries coerce the agent to reveal its hidden system prompt, exposing control logic.",
-      "severity": "medium",
-      "evidence": {
-        "kind": "research",
-        "label": "MITRE ATLAS — Extract LLM System Prompt",
-        "url": "https://atlas.mitre.org/"
-      },
-      "asi": [
-        "ASI01",
-        "ASI09"
-      ],
-      "atlas": [
-        "AML.T0056"
-      ],
-      "cwe": [
-        "CWE-200"
-      ]
-    },
-    {
-      "id": "ATD-T0014",
-      "tactic": "ATD-TA4",
-      "title": "Confused-deputy token passthrough in an MCP server",
-      "mechanism": "A server forwards a held token to a downstream API without audience validation, escalating privilege.",
-      "severity": "high",
-      "evidence": {
-        "kind": "research",
-        "label": "MCP Authorization spec (confused-deputy)",
-        "url": "https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization"
-      },
-      "asi": [
-        "ASI03"
-      ],
-      "atlas": [],
-      "cwe": [
-        "CWE-441"
-      ]
-    },
-    {
-      "id": "ATD-T0015",
-      "tactic": "ATD-TA5",
-      "title": "Agent reads .env / secret files without consent",
-      "mechanism": "An agent tool reads credential files (.env, credentials, .npmrc) outside any user-approved scope.",
-      "severity": "high",
-      "evidence": {
-        "kind": "research",
-        "label": "ModelContextProtocol-Security advisory",
-        "url": "https://github.com/modelcontextprotocol-security/vulnerability-db"
-      },
-      "asi": [
-        "ASI02",
-        "ASI06"
-      ],
-      "atlas": [
-        "AML.T0053"
-      ],
-      "cwe": [
-        "CWE-538"
-      ],
-      "atrRule": "ATR-2026-00583"
-    },
-    {
-      "id": "ATD-T0016",
-      "tactic": "ATD-TA5",
-      "title": "Hallucinated-dependency squatting (slopsquatting)",
-      "mechanism": "The model recommends a fabricated package name an attacker pre-registers, pulling code into the agent env.",
-      "severity": "medium",
-      "evidence": {
-        "kind": "research",
-        "label": "MITRE ATLAS — Publish Hallucinated Entities",
-        "url": "https://atlas.mitre.org/"
-      },
-      "asi": [
-        "ASI04",
-        "ASI08"
-      ],
-      "atlas": [
-        "AML.T0060",
-        "AML.T0062"
-      ],
-      "cwe": [
-        "CWE-1427"
-      ]
-    },
-    {
-      "id": "ATD-T0017",
-      "tactic": "ATD-TA6",
-      "title": "Path-traversal blacklist bypass via non-canonical paths",
-      "mechanism": "Exact-string path checks are bypassed with ../, /./, redundant slashes to reach sensitive files.",
-      "severity": "medium",
-      "evidence": {
-        "kind": "cve",
-        "label": "CVE-2025-66689",
-        "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-66689"
-      },
-      "asi": [
-        "ASI02",
-        "ASI03"
-      ],
-      "atlas": [
-        "AML.T0053"
-      ],
-      "cwe": [
-        "CWE-22"
-      ],
-      "atrRule": "ATR-2026-00578"
-    },
-    {
-      "id": "ATD-T0018",
-      "tactic": "ATD-TA6",
-      "title": "MCP filesystem sandbox escape via symlink following",
-      "mechanism": "A symlink inside an allowed directory resolves to an out-of-scope path, granting system file access.",
-      "severity": "high",
-      "evidence": {
-        "kind": "cve",
-        "label": "CVE-2025-53109",
-        "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-53109"
-      },
-      "asi": [
-        "ASI02",
-        "ASI05"
-      ],
-      "atlas": [
-        "AML.T0053"
-      ],
-      "cwe": [
-        "CWE-59"
-      ]
-    },
-    {
-      "id": "ATD-T0019",
-      "tactic": "ATD-TA6",
-      "title": "Prompt-injection-to-RCE via an agent's file-write capability",
-      "mechanism": "Injected instructions drive the agent to write a startup/config file that yields persistent code execution.",
+      "abstraction": "base",
+      "status": "experimental",
       "severity": "critical",
-      "evidence": {
-        "kind": "research",
-        "label": "Pillar Security — Antigravity (no CVE assigned)",
-        "url": "https://www.pillar.security/blog/prompt-injection-leads-to-rce-and-sandbox-escape-in-antigravity"
+      "description": "Injected output carries a serialization marker; deserialization rehydrates it as trusted and exfiltrates secrets.",
+      "detection_surface": [
+        "memory_op"
+      ],
+      "mappings": {
+        "owasp_asi": [
+          "ASI06",
+          "ASI01"
+        ],
+        "mitre_atlas": [
+          "AML.T0051.001"
+        ],
+        "cwe": [
+          "CWE-502"
+        ]
       },
-      "asi": [
-        "ASI05",
-        "ASI01"
-      ],
-      "atlas": [
-        "AML.T0053",
-        "AML.T0051.001"
-      ],
-      "cwe": [
-        "CWE-94"
+      "references": [
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-68664"
+        }
       ]
     },
     {
-      "id": "ATD-T0020",
-      "tactic": "ATD-TA7",
+      "atd_id": "ATD-T0011",
+      "schema_version": "0.1.0",
+      "title": "Persistent memory / context-store poisoning",
+      "tactic": "ATD-TA2",
+      "abstraction": "base",
+      "status": "experimental",
+      "severity": "high",
+      "description": "Attacker-controlled content is written into data the agent later reads back as trusted context.",
+      "detection_surface": [
+        "memory_op"
+      ],
+      "mappings": {
+        "owasp_asi": [
+          "ASI06"
+        ],
+        "mitre_atlas": [
+          "AML.T0080"
+        ],
+        "cwe": [
+          "CWE-349"
+        ]
+      },
+      "references": [
+        {
+          "type": "research",
+          "url": "https://atlas.mitre.org/"
+        }
+      ]
+    },
+    {
+      "atd_id": "ATD-T0012",
+      "schema_version": "0.1.0",
+      "title": "Indirect prompt injection via tool / API response",
+      "tactic": "ATD-TA3",
+      "abstraction": "base",
+      "status": "experimental",
+      "severity": "high",
+      "description": "Malicious text in returned tool data overrides the agent's plan and redirects its actions.",
+      "detection_surface": [
+        "content",
+        "tool_response"
+      ],
+      "mappings": {
+        "owasp_asi": [
+          "ASI01"
+        ],
+        "mitre_atlas": [
+          "AML.T0051.001",
+          "AML.T0099"
+        ],
+        "cwe": [
+          "CWE-1427"
+        ]
+      },
+      "references": [
+        {
+          "type": "research",
+          "url": "https://arxiv.org/abs/2403.02691"
+        }
+      ],
+      "atr_rule": "ATR-2026-00584"
+    },
+    {
+      "atd_id": "ATD-T0013",
+      "schema_version": "0.1.0",
+      "title": "System-prompt / guardrail extraction to plan evasion",
+      "tactic": "ATD-TA3",
+      "abstraction": "base",
+      "status": "experimental",
+      "severity": "medium",
+      "description": "Crafted queries coerce the agent to reveal its hidden system prompt, exposing control logic.",
+      "detection_surface": [
+        "content",
+        "tool_response"
+      ],
+      "mappings": {
+        "owasp_asi": [
+          "ASI01",
+          "ASI09"
+        ],
+        "mitre_atlas": [
+          "AML.T0056"
+        ],
+        "cwe": [
+          "CWE-200"
+        ]
+      },
+      "references": [
+        {
+          "type": "research",
+          "url": "https://atlas.mitre.org/"
+        }
+      ]
+    },
+    {
+      "atd_id": "ATD-T0014",
+      "schema_version": "0.1.0",
+      "title": "Confused-deputy token passthrough in an MCP server",
+      "tactic": "ATD-TA4",
+      "abstraction": "base",
+      "status": "experimental",
+      "severity": "high",
+      "description": "A server forwards a held token to a downstream API without audience validation, escalating privilege.",
+      "detection_surface": [
+        "tool_input"
+      ],
+      "mappings": {
+        "owasp_asi": [
+          "ASI03"
+        ],
+        "mitre_atlas": [],
+        "cwe": [
+          "CWE-441"
+        ]
+      },
+      "references": [
+        {
+          "type": "research",
+          "url": "https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization"
+        }
+      ]
+    },
+    {
+      "atd_id": "ATD-T0015",
+      "schema_version": "0.1.0",
+      "title": "Agent reads .env / secret files without consent",
+      "tactic": "ATD-TA5",
+      "abstraction": "base",
+      "status": "experimental",
+      "severity": "high",
+      "description": "An agent tool reads credential files (.env, credentials, .npmrc) outside any user-approved scope.",
+      "detection_surface": [
+        "tool_input",
+        "tool_response"
+      ],
+      "mappings": {
+        "owasp_asi": [
+          "ASI02",
+          "ASI06"
+        ],
+        "mitre_atlas": [
+          "AML.T0053"
+        ],
+        "cwe": [
+          "CWE-538"
+        ]
+      },
+      "references": [
+        {
+          "type": "research",
+          "url": "https://github.com/modelcontextprotocol-security/vulnerability-db"
+        }
+      ],
+      "atr_rule": "ATR-2026-00583"
+    },
+    {
+      "atd_id": "ATD-T0016",
+      "schema_version": "0.1.0",
+      "title": "Hallucinated-dependency squatting (slopsquatting)",
+      "tactic": "ATD-TA5",
+      "abstraction": "base",
+      "status": "experimental",
+      "severity": "medium",
+      "description": "The model recommends a fabricated package name an attacker pre-registers, pulling code into the agent env.",
+      "detection_surface": [
+        "tool_input",
+        "tool_response"
+      ],
+      "mappings": {
+        "owasp_asi": [
+          "ASI04",
+          "ASI08"
+        ],
+        "mitre_atlas": [
+          "AML.T0060",
+          "AML.T0062"
+        ],
+        "cwe": [
+          "CWE-1427"
+        ]
+      },
+      "references": [
+        {
+          "type": "research",
+          "url": "https://atlas.mitre.org/"
+        }
+      ]
+    },
+    {
+      "atd_id": "ATD-T0017",
+      "schema_version": "0.1.0",
+      "title": "Path-traversal blacklist bypass via non-canonical paths",
+      "tactic": "ATD-TA6",
+      "abstraction": "base",
+      "status": "experimental",
+      "severity": "medium",
+      "description": "Exact-string path checks are bypassed with ../, /./, redundant slashes to reach sensitive files.",
+      "detection_surface": [
+        "tool_input",
+        "trace"
+      ],
+      "mappings": {
+        "owasp_asi": [
+          "ASI02",
+          "ASI03"
+        ],
+        "mitre_atlas": [
+          "AML.T0053"
+        ],
+        "cwe": [
+          "CWE-22"
+        ]
+      },
+      "references": [
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-66689"
+        }
+      ],
+      "atr_rule": "ATR-2026-00578"
+    },
+    {
+      "atd_id": "ATD-T0018",
+      "schema_version": "0.1.0",
+      "title": "MCP filesystem sandbox escape via symlink following",
+      "tactic": "ATD-TA6",
+      "abstraction": "base",
+      "status": "experimental",
+      "severity": "high",
+      "description": "A symlink inside an allowed directory resolves to an out-of-scope path, granting system file access.",
+      "detection_surface": [
+        "tool_input",
+        "trace"
+      ],
+      "mappings": {
+        "owasp_asi": [
+          "ASI02",
+          "ASI05"
+        ],
+        "mitre_atlas": [
+          "AML.T0053"
+        ],
+        "cwe": [
+          "CWE-59"
+        ]
+      },
+      "references": [
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-53109"
+        }
+      ]
+    },
+    {
+      "atd_id": "ATD-T0019",
+      "schema_version": "0.1.0",
+      "title": "Prompt-injection-to-RCE via an agent's file-write capability",
+      "tactic": "ATD-TA6",
+      "abstraction": "base",
+      "status": "experimental",
+      "severity": "critical",
+      "description": "Injected instructions drive the agent to write a startup/config file that yields persistent code execution.",
+      "detection_surface": [
+        "tool_input",
+        "trace"
+      ],
+      "mappings": {
+        "owasp_asi": [
+          "ASI05",
+          "ASI01"
+        ],
+        "mitre_atlas": [
+          "AML.T0053",
+          "AML.T0051.001"
+        ],
+        "cwe": [
+          "CWE-94"
+        ]
+      },
+      "references": [
+        {
+          "type": "research",
+          "url": "https://www.pillar.security/blog/prompt-injection-leads-to-rce-and-sandbox-escape-in-antigravity"
+        }
+      ]
+    },
+    {
+      "atd_id": "ATD-T0020",
+      "schema_version": "0.1.0",
       "title": "Agent Card poisoning to capture A2A task routing",
-      "mechanism": "A rogue A2A agent advertises an instruction-laden Agent Card so the orchestrator routes tasks to it.",
-      "severity": "high",
-      "evidence": {
-        "kind": "research",
-        "label": "Trustwave SpiderLabs — Agent-in-the-Middle",
-        "url": "https://www.levelblue.com/blogs/spiderlabs-blog/agent-in-the-middle-abusing-agent-cards-in-the-agent-2-agent-protocol-to-win-all-the-tasks"
-      },
-      "asi": [
-        "ASI07",
-        "ASI10"
-      ],
-      "atlas": [
-        "AML.T0051.001"
-      ],
-      "cwe": [
-        "CWE-345"
-      ]
-    },
-    {
-      "id": "ATD-T0021",
       "tactic": "ATD-TA7",
-      "title": "Cross-agent injection propagation (cascading compromise)",
-      "mechanism": "One compromised agent emits content that injects the next downstream agent, cascading through the swarm.",
+      "abstraction": "base",
+      "status": "experimental",
       "severity": "high",
-      "evidence": {
-        "kind": "research",
-        "label": "InjecAgent + multi-agent control-flow hijack",
-        "url": "https://arxiv.org/abs/2403.02691"
+      "description": "A rogue A2A agent advertises an instruction-laden Agent Card so the orchestrator routes tasks to it.",
+      "detection_surface": [
+        "inter_agent_msg"
+      ],
+      "mappings": {
+        "owasp_asi": [
+          "ASI07",
+          "ASI10"
+        ],
+        "mitre_atlas": [
+          "AML.T0051.001"
+        ],
+        "cwe": [
+          "CWE-345"
+        ]
       },
-      "asi": [
-        "ASI08",
-        "ASI07",
-        "ASI10"
-      ],
-      "atlas": [
-        "AML.T0051.001",
-        "AML.T0080"
-      ],
-      "cwe": [
-        "CWE-1427"
+      "references": [
+        {
+          "type": "research",
+          "url": "https://www.levelblue.com/blogs/spiderlabs-blog/agent-in-the-middle-abusing-agent-cards-in-the-agent-2-agent-protocol-to-win-all-the-tasks"
+        }
       ]
     },
     {
-      "id": "ATD-T0022",
-      "tactic": "ATD-TA8",
+      "atd_id": "ATD-T0021",
+      "schema_version": "0.1.0",
+      "title": "Cross-agent injection propagation (cascading compromise)",
+      "tactic": "ATD-TA7",
+      "abstraction": "base",
+      "status": "experimental",
+      "severity": "high",
+      "description": "One compromised agent emits content that injects the next downstream agent, cascading through the swarm.",
+      "detection_surface": [
+        "inter_agent_msg"
+      ],
+      "mappings": {
+        "owasp_asi": [
+          "ASI08",
+          "ASI07",
+          "ASI10"
+        ],
+        "mitre_atlas": [
+          "AML.T0051.001",
+          "AML.T0080"
+        ],
+        "cwe": [
+          "CWE-1427"
+        ]
+      },
+      "references": [
+        {
+          "type": "research",
+          "url": "https://arxiv.org/abs/2403.02691"
+        }
+      ]
+    },
+    {
+      "atd_id": "ATD-T0022",
+      "schema_version": "0.1.0",
       "title": "Trace tampering / non-tamper-evident agent audit logs",
-      "mechanism": "An agent logs reasoning but not the actual tool call, or logs are mutable — defeating after-the-fact audit.",
+      "tactic": "ATD-TA8",
+      "abstraction": "base",
+      "status": "experimental",
       "severity": "medium",
-      "evidence": {
-        "kind": "research",
-        "label": "EU AI Act Art.12 logging / observability gap",
-        "url": "https://artificialintelligenceact.eu/article/12/"
-      },
-      "asi": [
-        "ASI10"
+      "description": "An agent logs reasoning but not the actual tool call, or logs are mutable — defeating after-the-fact audit.",
+      "detection_surface": [
+        "trace"
       ],
-      "atlas": [],
-      "cwe": [
-        "CWE-778"
+      "mappings": {
+        "owasp_asi": [
+          "ASI10"
+        ],
+        "mitre_atlas": [],
+        "cwe": [
+          "CWE-778"
+        ]
+      },
+      "references": [
+        {
+          "type": "research",
+          "url": "https://artificialintelligenceact.eu/article/12/"
+        }
       ]
     },
     {
-      "id": "ATD-T0023",
-      "tactic": "ATD-TA9",
+      "atd_id": "ATD-T0023",
+      "schema_version": "0.1.0",
       "title": "Adversarial transaction steering of a purchasing agent",
-      "mechanism": "Injected content in a listing/page steers an autonomous-commerce agent to overpay or leak payment authority.",
+      "tactic": "ATD-TA9",
+      "abstraction": "base",
+      "status": "experimental",
       "severity": "medium",
-      "evidence": {
-        "kind": "aspirational",
-        "label": "Forward-looking — no public instance yet"
-      },
-      "asi": [
-        "ASI01",
-        "ASI02",
-        "ASI09"
+      "description": "Injected content in a listing/page steers an autonomous-commerce agent to overpay or leak payment authority.",
+      "detection_surface": [
+        "payment_mandate"
       ],
-      "atlas": [],
-      "cwe": [
-        "CWE-1427"
+      "mappings": {
+        "owasp_asi": [
+          "ASI01",
+          "ASI02",
+          "ASI09"
+        ],
+        "mitre_atlas": [],
+        "cwe": [
+          "CWE-1427"
+        ]
+      },
+      "references": [
+        {
+          "type": "vendor",
+          "url": "https://cloud.google.com/blog/products/ai-machine-learning/announcing-agents-to-payments-ap2-protocol"
+        }
       ]
     },
     {
-      "id": "ATD-T0024",
-      "tactic": "ATD-TA9",
+      "atd_id": "ATD-T0024",
+      "schema_version": "0.1.0",
       "title": "Payment-mandate forgery in an agent-to-agent handshake",
-      "mechanism": "A rogue agent spoofs delegated payment authority or mandate scope in an agentic-commerce exchange.",
+      "tactic": "ATD-TA9",
+      "abstraction": "base",
+      "status": "experimental",
       "severity": "medium",
-      "evidence": {
-        "kind": "aspirational",
-        "label": "Forward-looking — protocols (AP2-class) emerging"
-      },
-      "asi": [
-        "ASI03",
-        "ASI07"
+      "description": "A rogue agent spoofs delegated payment authority or mandate scope in an agentic-commerce exchange.",
+      "detection_surface": [
+        "payment_mandate"
       ],
-      "atlas": [],
-      "cwe": [
-        "CWE-345"
+      "mappings": {
+        "owasp_asi": [
+          "ASI03",
+          "ASI07"
+        ],
+        "mitre_atlas": [],
+        "cwe": [
+          "CWE-345"
+        ]
+      },
+      "references": [
+        {
+          "type": "vendor",
+          "url": "https://fidoalliance.org/fido-alliance-to-develop-standards-for-trusted-ai-agent-interactions/"
+        }
       ]
     }
   ]


### PR DESCRIPTION
Makes ATD discoverable and contributable, and adds the deterministic schema gate behind it.

Nav
- ATD is now the lead top-nav item (it was only reachable at /atd).

Contribution front-door
- Two GitHub issue forms: submit an ATD technique, and map a tool / request interop. Submissions enter a review queue; nothing auto-publishes. The technique form requires a real evidence URL (CVE/advisory/paper) or an explicit aspirational marker, and asks contributors not to paste working exploit payloads.

Schema gate
- scripts/validate-atd.ts (ajv 2020-12) validates every published technique in website/public/atd/atd-techniques.json against the normative JSON Schema, plus catalog invariants (unique ids, known tactics). Exits non-zero on any failure.
- .github/workflows/atd-validate.yml runs it on PRs touching the ATD enumeration.

Consistency fix
- Reconciled the published atd-techniques.json to the normative schema shape (atd_id / detection_surface / mappings / references), with aspirational TA9 entries carrying a real forward-looking reference. Validated 24/24.

This is Phase 1 of the contribution model: human-gated submission with machine validation. Agent-to-agent contribution stays out until the hardening in the security blueprint is in place.
