### PR TITLE
feat(atd): align ATD page to ATR CIS — logo, masthead, typography

### DIFF
--- a/website/app/[locale]/atd/page.tsx
+++ b/website/app/[locale]/atd/page.tsx
@@ -234,36 +234,36 @@ export default async function ATDPage({
       lang={locale === "zh" ? "zh-Hant" : "en"}
     >
       <header
-        className="atd-cover mb-10 md:mb-12"
+        className="atd-masthead mb-10 md:mb-12"
         lang={locale === "zh" ? "zh-Hant" : "en"}
       >
-        <p className="atd-kicker">
+        {/* ATD logo — enumeration bracket [ATD] in ATR palette (ink mark, blue dots) */}
+        <div className="atd-logo" aria-label="ATD">
+          <svg width="168" height="56" viewBox="0 0 168 56" role="img" aria-label="ATD" style={{ display: "block" }}>
+            <path d="M26 11 L13 11 L13 45 L26 45" fill="none" stroke="#07142A" strokeWidth="2.6" strokeLinecap="round" strokeLinejoin="round" />
+            <path d="M142 11 L155 11 L155 45 L142 45" fill="none" stroke="#07142A" strokeWidth="2.6" strokeLinecap="round" strokeLinejoin="round" />
+            <text x="84" y="38" textAnchor="middle" style={{ fontFamily: "var(--font-data)", fontWeight: 700, fontSize: "31px", letterSpacing: "1px" }} fill="#07142A">ATD</text>
+            <circle cx="38" cy="48" r="2.1" fill="#2563EB" />
+            <circle cx="46" cy="48" r="2.1" fill="#2563EB" />
+            <circle cx="54" cy="48" r="2.1" fill="#2563EB" />
+          </svg>
+        </div>
+
+        <p className="atd-eyebrow">
           {locale === "zh"
             ? "開放標準 · 草案 RFC · 徵求協作者 · ATR 之伴隨標準"
             : "Open standard · draft RFC · call for collaborators · companion to ATR"}
         </p>
 
-        {/* C logo — enumeration bracket [ATD], paper strokes + brass dots */}
-        <div className="atd-emblem" aria-label="ATD wordmark">
-          <svg width="186" height="66" viewBox="0 0 186 66" role="img" aria-label="ATD" style={{ display: "block" }}>
-            <path d="M28 13 L14 13 L14 53 L28 53" fill="none" stroke="#EDEBE4" strokeWidth="2.6" strokeLinecap="round" strokeLinejoin="round" />
-            <path d="M158 13 L172 13 L172 53 L158 53" fill="none" stroke="#EDEBE4" strokeWidth="2.6" strokeLinecap="round" strokeLinejoin="round" />
-            <text x="93" y="45" textAnchor="middle" style={{ fontFamily: "var(--font-data)", fontWeight: 600, fontSize: "36px", letterSpacing: "1.5px" }} fill="#FBFAF6">ATD</text>
-            <circle cx="42" cy="56" r="2.3" fill="#B8924A" />
-            <circle cx="51" cy="56" r="2.3" fill="#B8924A" />
-            <circle cx="60" cy="56" r="2.3" fill="#B8924A" />
-          </svg>
-        </div>
-
         <h1>Agentic Threat Detection</h1>
-        <hr className="atd-rule" />
+
         <p className="atd-sub">
           {locale === "zh"
             ? "agent 原生威脅的開放、可執行偵測標準 —— OWASP、MITRE ATLAS、CWE、AVID 之下會跑的那一層。"
             : "The open, executable detection standard for agent-native threats — the runnable layer beneath OWASP, MITRE ATLAS, CWE and AVID."}
         </p>
 
-        <div className="atd-status not-prose" role="note">
+        <div className="doc-status not-prose" role="note">
           <strong>{status}</strong>
           <span className="pipe">·</span>
           <span><span className="opacity-70">{locale === "zh" ? "版本" : "Version"}</span> {ATD_VERSION}</span>

--- a/website/app/globals.css
+++ b/website/app/globals.css
@@ -548,88 +548,47 @@ html:not(.js-ready) .speed-line {
   white-space: nowrap;
 }
 
-/* ===== ATD — standards "cover" masthead (gravitas) ===== */
-.atd-cover {
-  background: var(--navy-ink);
-  color: #EDEBE4;
-  border-radius: 16px;
-  padding: 2.6rem 2.6rem 2.1rem;
-  position: relative;
-  overflow: hidden;
+/* ===== ATD masthead — CIS-native (paper, Inter Tight display, ATR palette) ===== */
+.atd-masthead {
+  max-width: 52rem;
 }
-.atd-cover::before {
-  content: "";
-  position: absolute;
-  inset: 0;
-  border-radius: 16px;
-  border: 1px solid rgba(184, 146, 74, 0.28);
-  pointer-events: none;
-}
-.atd-kicker {
-  font-family: var(--font-data), ui-monospace, monospace;
-  font-size: 0.72rem;
-  letter-spacing: 0.24em;
-  text-transform: uppercase;
-  color: #B8924A;
+.atd-logo {
   margin-bottom: 1.5rem;
 }
-.atd-emblem { margin-bottom: 1.4rem; }
-.atd-cover h1 {
-  font-family: var(--font-spec), Georgia, "Times New Roman", serif;
-  font-size: clamp(2.1rem, 5vw, 3.2rem);
-  line-height: 1.04;
-  font-weight: 600;
-  color: #FBFAF6;
-  letter-spacing: -0.012em;
-  margin: 0 0 0.5rem;
-}
-.atd-cover[lang="zh-Hant"] h1 { font-family: var(--font-spec-tc), serif; }
-.atd-rule {
-  width: 60px;
-  height: 2px;
-  background: #B8924A;
-  margin: 1.1rem 0 1.2rem;
-  border: 0;
-}
-.atd-cover .atd-sub {
-  font-family: var(--font-body), system-ui, sans-serif;
-  font-size: 1.06rem;
-  line-height: 1.55;
-  color: #C7D2E2;
-  max-width: 42em;
-  margin: 0 0 1.6rem;
-}
-.atd-status {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.55rem 0.7rem;
-  align-items: center;
+.atd-eyebrow {
   font-family: var(--font-data), ui-monospace, monospace;
-  font-size: 0.74rem;
-  color: #93A6C2;
+  font-size: 0.72rem;
+  letter-spacing: 0.2em;
+  line-height: 1.7;
+  text-transform: uppercase;
+  color: var(--stone);
+  margin: 0 0 1rem;
+  max-width: 44ch;
 }
-.atd-status strong { color: #E7C887; font-weight: 600; }
-.atd-status .pipe { color: rgba(147, 166, 194, 0.4); }
-.atd-status a { color: #9DB8E8; text-decoration: none; }
-.atd-status a:hover { text-decoration: underline; }
+.atd-masthead h1 {
+  font-family: var(--font-display), system-ui, sans-serif;
+  font-size: clamp(2.3rem, 6vw, 3.6rem);
+  line-height: 1.04;
+  font-weight: 800;
+  letter-spacing: -0.022em;
+  color: var(--navy-ink);
+  margin: 0 0 1rem;
+  text-wrap: balance;
+  max-width: 20ch;
+}
+.atd-masthead .atd-sub {
+  font-family: var(--font-body), system-ui, sans-serif;
+  font-size: clamp(1.02rem, 2.2vw, 1.25rem);
+  line-height: 1.6;
+  color: var(--graphite);
+  max-width: 50ch;
+  text-wrap: pretty;
+  margin: 0 0 1.5rem;
+}
 
-/* Formal spec body — serif prose for the document-of-record feel */
-.atd-doc .spec-body p,
-.atd-doc .spec-body li {
-  font-family: var(--font-spec), Georgia, "Times New Roman", serif;
-  font-size: 1.02rem;
-  line-height: 1.72;
-}
-.atd-doc[lang="zh-Hant"] .spec-body p,
-.atd-doc[lang="zh-Hant"] .spec-body li {
-  font-family: var(--font-spec-tc), serif;
-}
+/* ATD doc inherits .spec-document CIS (serif body, Inter Tight headings);
+   keep mono only for data blocks */
 .atd-doc .spec-body pre,
 .atd-doc .spec-body code,
 .atd-doc .spec-body table { font-family: var(--font-data), ui-monospace, monospace; }
 .atd-doc .spec-body table { font-size: 0.9rem; }
-.atd-doc section h2 {
-  font-family: var(--font-spec), Georgia, serif;
-  letter-spacing: -0.01em;
-}
-.atd-doc[lang="zh-Hant"] section h2 { font-family: var(--font-spec-tc), serif; }

--- a/website/public/atd/atd-logo.svg
+++ b/website/public/atd/atd-logo.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="336" height="112" viewBox="0 0 168 56" role="img" aria-label="ATD — Agentic Threat Detection">
+  <title>ATD — Agentic Threat Detection</title>
+  <path d="M26 11 L13 11 L13 45 L26 45" fill="none" stroke="#07142A" stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M142 11 L155 11 L155 45 L142 45" fill="none" stroke="#07142A" stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round"/>
+  <text x="84" y="38" text-anchor="middle" font-family="ui-monospace, 'JetBrains Mono', 'SFMono-Regular', Menlo, monospace" font-weight="700" font-size="31" letter-spacing="1" fill="#07142A">ATD</text>
+  <circle cx="38" cy="48" r="2.1" fill="#2563EB"/>
+  <circle cx="46" cy="48" r="2.1" fill="#2563EB"/>
+  <circle cx="54" cy="48" r="2.1" fill="#2563EB"/>
+</svg>


### PR DESCRIPTION
Polishes the ATD standards page so it reads as a first-class ATR property rather than a separate brand.

What changed
- Masthead converted from a bespoke navy serif cover card to the ATR standards-page idiom: paper background, Inter Tight (font-display) display h1 in navy-ink — identical treatment to the homepage hero and /spec.
- Proper ATD logo: enumeration-bracket [ATD] mark in the ATR palette (ink mark, blue dots). Also shipped standalone at /public/atd/atd-logo.svg for reuse.
- Removed the foreign brass/gold accent (#B8924A / #E7C887) the cover introduced. ATR CIS is ink / paper / blue only.
- Status strip now uses the shared .doc-status class (pixel-identical to /spec) instead of a one-off navy/gold variant.
- Headings and body now inherit .spec-document CIS (Inter Tight headings, Source Serif document-of-record body); removed the .atd-doc serif heading override that broke consistency with every other page.
- Line-breaks: text-wrap balance on the title, pretty on the subtitle, and sane max-width measures (eyebrow 44ch, subtitle 50ch) so copy wraps cleanly at every width.

Verification
- tsc --noEmit clean
- no orphan references to the removed classes/colors
- Vercel preview deploy will render the authoritative build