### PR TITLE
docs: pin GitHub Action example to @v3 (was stale @v1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ pip install pyatr
 
 ```yaml
 # .github/workflows/atr-scan.yml
-- uses: Agent-Threat-Rule/agent-threat-rules@v1
+- uses: Agent-Threat-Rule/agent-threat-rules@v3
   with:
     path: '.'
     severity: 'medium'

--- a/docs/contribution-paths.md
+++ b/docs/contribution-paths.md
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: Agent-Threat-Rule/agent-threat-rules@v1
+      - uses: Agent-Threat-Rule/agent-threat-rules@v3
 ```
 
 That's it. Every PR gets scanned against 113 detection rules.


### PR DESCRIPTION
The composite GitHub Action (root action.yml, listed on the Marketplace as atr-scan) had every onboarding example pinned to @v1 — a tag frozen at 2026-04-09, two months and several hardening passes behind the current action.yml (SARIF validation, path-traversal guard, severity-input checks, Security-tab upload). Anyone copy-pasting the snippet got the stale wrapper, which is a likely contributor to the action's near-zero external adoption.

Changes
- Created a floating v3 major tag pointing at v3.3.1 (additive; no existing tag rewritten).
- README and docs/contribution-paths examples now pin @v3.
- The dated 2026-04 scan report keeps @v1 as a historical artifact.

Not done here (left for an explicit call)
- Re-pointing the published v1 tag to latest would rescue any existing @v1 pins, but it rewrites a shared published artifact and external adoption of the action is currently zero, so the cost/benefit favors leaving v1 frozen.

Test plan
- [x] git ls-remote shows refs/tags/v3 -> v3.3.1 commit
- [x] no remaining @v1 in README / contribution-paths
