### PR TITLE
fix(website): sync stale version/rule-count to current (v3.3.1 / 651)

### DIFF
--- a/website/app/[locale]/compliance/nist-ai-rmf/page.tsx
+++ b/website/app/[locale]/compliance/nist-ai-rmf/page.tsx
@@ -416,8 +416,8 @@ export default async function NistAiRmfPage({
           />
           <CTACard
             num="NPM"
-            head={zh ? "v3.1.1 已發布" : "v3.1.1 published"}
-            body="npm install agent-threat-rules@3.1.1"
+            head={zh ? "v3.3.1 已發布" : "v3.3.1 published"}
+            body="npm install agent-threat-rules"
             href="https://www.npmjs.com/package/agent-threat-rules"
           />
           <CTACard

--- a/website/app/[locale]/partner-sync/page.tsx
+++ b/website/app/[locale]/partner-sync/page.tsx
@@ -68,7 +68,7 @@ Authorization: Bearer <partner-key>`}
       "tags": "..."
     }
   ],
-  "meta": { "total": 462, "etag": "W/\\"462-2026-04-17T00:03:42Z\\"" }
+  "meta": { "total": 651, "etag": "W/\\"651-2026-06-14T00:00:00Z\\"" }
 }`}
         </pre>
       </section>


### PR DESCRIPTION
Two user-facing strings still referenced the old release. The rest of the site already pulls the rule/category counts dynamically from data/stats.json (homepage, hero, stats band) and the about timeline was already updated to v3.3.x / 651.

Fixed
- compliance/nist-ai-rmf NPM card: header v3.1.1 -> v3.3.1 (matches npm latest); install command unpinned to npm install agent-threat-rules so a copy-paste never installs a stale pin again.
- partner-sync API response example: meta.total 462 -> 651, etag refreshed to match.

Deliberately unchanged
- Spec version 3.0.0-alpha.1 (separate specification track, not the npm version).
- research page 'Since v3.1.0 ... semantic judge' (historical feature-introduction fact).
- Dated changelog entries and benchmark/scan figures (96,096 / 751 / garak recall) — historical, carry their own as-of dates.

Verified: tsc --noEmit clean; no residual v3.1.1 / @3.1.1 / total 462 anywhere under app or components.