### PR TITLE
fix(ci): lowercase GHCR image name so docker-publish builds + document docker run

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -20,11 +20,13 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Lowercase image name (GHCR requires lowercase)
+        run: echo "IMAGE=ghcr.io/${GITHUB_REPOSITORY,,}" >> "$GITHUB_ENV"
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
           context: .
           push: true
           tags: |
-            ghcr.io/${{ github.repository }}:latest
-            ghcr.io/${{ github.repository }}:${{ github.ref_name }}
+            ${{ env.IMAGE }}:latest
+            ${{ env.IMAGE }}:${{ github.ref_name }}

--- a/README.md
+++ b/README.md
@@ -132,6 +132,14 @@ pip install pyatr
 
 Results render in the GitHub Security tab via SARIF v2.1.0.
 
+### Docker
+
+```bash
+docker run --rm -v "$PWD:/scan" ghcr.io/agent-threat-rule/agent-threat-rules scan .
+```
+
+Zero-install scan of the current directory; the image bundles the CLI and pulls the latest published rules from npm.
+
 ## 4. Usage
 
 ### Command-line


### PR DESCRIPTION
Triggering docker-publish revealed it fails on every run: it tags ghcr.io/${{ github.repository }} = ghcr.io/Agent-Threat-Rule/... and GHCR rejects uppercase repo names ('repository name must be lowercase'). Combined with GITHUB_TOKEN-created releases not firing the release trigger, that's why no Docker image ever shipped.

- Lowercase the image name via ${GITHUB_REPOSITORY,,}.
- Document the docker run usage in the README (was undocumented).

After merge: re-run docker-publish (workflow_dispatch) to push the first image, then flip the GHCR package to public.

Test plan
- [x] root cause reproduced (build error: repository name must be lowercase)
- [ ] re-run docker-publish after merge -> image on GHCR
- [ ] set package visibility public -> docker run works unauthenticated