### PR TITLE
fix(rules): correct ASI06/AML.T0080 mappings on ATR-2026-00551

### DIFF
--- a/rules/privilege-escalation/ATR-2026-00551-cross-conversation-memory-write.yaml
+++ b/rules/privilege-escalation/ATR-2026-00551-cross-conversation-memory-write.yaml
@@ -31,12 +31,11 @@ severity: critical
 references:
   owasp_agentic:
     - "ASI04:2026 - Unauthorized Resource Access"
-    - "ASI09:2026 - Memory Poisoning"
+    - "ASI06:2026 - Memory and Context Poisoning"
   owasp_llm:
     - "LLM03:2025 - Training Data Poisoning"
   mitre_atlas:
-    - "AML.T0018 - Backdoor ML Model"
-    - "AML.T0020 - Poison Training Data"
+    - "AML.T0080 - AI Agent Context Poisoning"
   research:
     - "AgentArmor: Type-System for Agent Trace Analysis (arXiv:2508.01249)"
     - "Compositional Privacy Risks in Multi-Agent Systems (arXiv:2509.14284)"


### PR DESCRIPTION
Cross-conversation memory write is a memory and context poisoning case; its
upstream framework mappings were pointing at the wrong entries.

owasp_agentic: ASI09:2026 - Memory Poisoning -> ASI06:2026 - Memory and
Context Poisoning. ASI06 is the OWASP Agentic Top 10 2026 ID for memory and
context poisoning.

mitre_atlas: drop AML.T0018 (Backdoor ML Model) and AML.T0020 (Poison
Training Data) -- both pre-agent ML supply-chain / training-data techniques
-- in favour of AML.T0080 (AI Agent Context Poisoning), the agent-memory
parent technique. Name verified against MITRE ATLAS v5.6.0.

Aligns with ATD-T0011 (asi: ASI06, atlas: AML.T0080).

Validation: npm run validate 471/0; embedded test cases 10/10 (5 TP + 5 TN);
audit:mappings clean.
