### PR TITLE
fix(cli,trace): support agent_trace rules in validate/test + fix predicate eval

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -15,7 +15,7 @@ import { homedir } from 'node:os';
 import { fileURLToPath } from 'node:url';
 import { ATREngine } from './engine.js';
 import { loadRuleFile, loadRulesFromDirectory, validateRule } from './loader.js';
-import type { AgentEvent, ATRMatch, ATRRule } from './types.js';
+import type { AgentEvent, ATRMatch, ATRRule, ATRTrace } from './types.js';
 import { generateBadgeSvg, generateBadgeEndpoint, lookupPackageScan, generateBadgeMarkdown } from './badge.js';
 import { cmdScanUnified } from './cli/scan-handler.js';
 
@@ -462,6 +462,28 @@ function buildEventFromTestCase(
   fields['content'] = content;
   fields['agent_message'] = content;
 
+  // v1.1 trace-method rules evaluate over a span DAG (OpenInference), not text.
+  // When the rule declares method: trace and the test input is a JSON trace
+  // ({"spans":[...]}), parse it into event.trace so the engine's trace
+  // evaluator can run. Without this, trace rules can never satisfy their own
+  // declared true_positives: the harness would otherwise feed the raw JSON as
+  // text to the pattern fallback, whose regex expects a pre-computed synthetic
+  // verdict field that is absent from a raw trace.
+  let trace: ATRTrace | undefined;
+  if (rule.detection?.method === 'trace') {
+    let parsed: unknown =
+      rawInput && typeof rawInput === 'object' && !Array.isArray(rawInput) ? rawInput : undefined;
+    if (parsed === undefined) {
+      try {
+        parsed = JSON.parse(input);
+      } catch {
+        parsed = undefined; // input is not a JSON trace; leave trace unset
+      }
+    }
+    if (parsed && typeof parsed === 'object' && Array.isArray((parsed as { spans?: unknown }).spans)) {
+      trace = parsed as ATRTrace;
+    }
+  }
 
   return {
     type,
@@ -470,6 +492,7 @@ function buildEventFromTestCase(
     fields,
     sessionId: 'test-session',
     agentId: 'test-agent',
+    ...(trace ? { trace } : {}),
   };
 }
 

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -105,6 +105,7 @@ export function validateRule(rule: unknown): { valid: boolean; errors: string[] 
       'llm_io', 'tool_call', 'mcp_exchange', 'agent_behavior',
       'multi_agent_comm', 'context_window', 'memory_access',
       'skill_lifecycle', 'skill_permission', 'skill_chain',
+      'agent_trace',
     ];
     if (typeof agentSource['type'] === 'string' && !validTypes.includes(agentSource['type'])) {
       errors.push(`Invalid agent_source.type: ${agentSource['type']}`);

--- a/src/trace-evaluator.ts
+++ b/src/trace-evaluator.ts
@@ -37,10 +37,26 @@ function resolvePlaceholder(value: unknown, candidateSpan: ATRSpan): unknown {
 
 /** Read dotted-path attribute, e.g., "tool.args.target_conversation_id" */
 function readAttributePath(attrs: Record<string, unknown>, path: string): unknown {
-  // Try literal-key first (covers cases like "session.id" stored as a literal key with a dot)
+  // Fast path: exact literal key (covers "session.id" stored as a dotted literal key).
   if (path in attrs) return attrs[path];
-  // Then walk dotted path
   const parts = path.split(".");
+  // Greedy: match the longest leading literal-key prefix, then descend into the
+  // remainder. Handles span attributes that MIX literal dotted keys (e.g.
+  // "tool.args") with nested objects (e.g. { target_conversation_id }), which a
+  // plain part-by-part walk from the root cannot traverse.
+  for (let n = parts.length; n >= 1; n--) {
+    const prefix = parts.slice(0, n).join(".");
+    if (prefix in attrs) {
+      const head = attrs[prefix];
+      const rest = parts.slice(n);
+      if (rest.length === 0) return head;
+      if (head !== null && typeof head === "object") {
+        return readAttributePath(head as Record<string, unknown>, rest.join("."));
+      }
+      return undefined;
+    }
+  }
+  // Fallback: plain nested walk from the root (fully-nested attribute objects).
   let cur: unknown = attrs;
   for (const part of parts) {
     if (cur === null || cur === undefined) return undefined;
@@ -61,29 +77,49 @@ function evaluatePredicate(predicate: unknown, value: unknown): boolean {
     return value === predicate;
   }
   const pred = predicate as Record<string, unknown>;
-  // Compound predicate object: { in: [...] } / { not_equals: X } / etc.
-  if (Array.isArray(pred["in"]) && (pred["in"] as unknown[]).includes(value)) return true;
-  if (Array.isArray(pred["in"]) && !(pred["in"] as unknown[]).includes(value)) return false;
-  if (Array.isArray(pred["not_in"])) {
-    return !(pred["not_in"] as unknown[]).includes(value);
+  // Compound predicate object: EVERY recognised operator present must hold (AND).
+  // e.g. { exists: true, not_equals: X } means "the attribute exists AND differs
+  // from X" (spec §8.3). Evaluating operators independently with first-match
+  // early-return is a bug: { exists: true, not_equals: X } against an absent
+  // attribute would wrongly pass on not_equals (undefined !== X) without ever
+  // checking exists.
+  let sawOperator = false;
+  if ("in" in pred) {
+    sawOperator = true;
+    if (!Array.isArray(pred["in"]) || !(pred["in"] as unknown[]).includes(value)) return false;
   }
-  if ("equals" in pred) return value === pred["equals"];
-  if ("not_equals" in pred) return value !== pred["not_equals"];
+  if ("not_in" in pred) {
+    sawOperator = true;
+    if (!Array.isArray(pred["not_in"]) || (pred["not_in"] as unknown[]).includes(value)) return false;
+  }
+  if ("equals" in pred) {
+    sawOperator = true;
+    if (value !== pred["equals"]) return false;
+  }
+  if ("not_equals" in pred) {
+    sawOperator = true;
+    if (value === pred["not_equals"]) return false;
+  }
   if ("exists" in pred) {
+    sawOperator = true;
     const requiredExists = Boolean(pred["exists"]);
-    return requiredExists ? value !== undefined : value === undefined;
+    if (requiredExists ? value === undefined : value !== undefined) return false;
   }
   if ("regex" in pred && typeof pred["regex"] === "string") {
+    sawOperator = true;
     try {
       const re = new RegExp(pred["regex"] as string);
-      return typeof value === "string" && re.test(value);
+      if (!(typeof value === "string" && re.test(value))) return false;
     } catch {
       return false;
     }
   }
-  if (Object.keys(pred).length === 0) return true;
-  // Unknown predicate object — strict: return false rather than assume.
-  return false;
+  if (!sawOperator) {
+    // No recognised operator: empty object matches anything; otherwise strict-fail
+    // rather than assume.
+    return Object.keys(pred).length === 0;
+  }
+  return true;
 }
 
 /** Check if a span matches a shape. Handles literal values + predicate maps + placeholders. */


### PR DESCRIPTION
The CLI validate/test path could not exercise method:trace rules, so a trace
rule's own embedded true_positives never triggered and the "ATR Rule Quality"
CI gate failed for any PR that touched one. This is a pre-existing tooling gap,
independent of any rule content.

Changes (src only; no rule files touched):

loader: accept agent_source.type "agent_trace" (was absent from the validTypes
allow-list, so `atr validate` rejected every trace rule).

cli buildEventFromTestCase: when detection.method is trace and the test input is
a JSON trace ({"spans":[...]}), parse it into event.trace so the engine's trace
evaluator runs. The engine already routes method:trace to evaluateTraceRule when
event.trace is present; the test harness just never populated it.

trace-evaluator readAttributePath: resolve dotted paths against span attributes
that mix literal dotted keys (e.g. "tool.args") with nested objects, via greedy
longest-literal-prefix matching plus descent. Previously
"tool.args.target_conversation_id" resolved to undefined.

trace-evaluator evaluatePredicate: a compound predicate map now requires all
operators to hold (AND) instead of returning on the first match. So
{exists: true, not_equals: X} now means "exists AND differs" per spec section
8.3, fixing over-matches against absent or equal attributes.

Verification:
- All 5 trace rules validate; ATR-2026-00548/00549/00550/00551 pass 10/10.
- ATR-2026-00552 is 8/10; the 2 remaining failures are a separate
  invariant-composite gap, unchanged by this commit (8/10 before and after).
- 50/50 evaluator + engine + sequence unit tests pass.
- Canonical validator (tests/validate-rules.ts) 651/0; tsc --noEmit clean.

Unblocks the "ATR Rule Quality" gate for trace rules (e.g. the mapping fix in
the cross-conversation-memory-write rule).
