### PR TITLE
Website sync: every page to current state (651 rules, v3.4.0, honest metrics)

### DIFF
--- a/data/mega-scan-report.json
+++ b/data/mega-scan-report.json
@@ -24,7 +24,7 @@
     "informational": 0
   },
   "malware_campaign": {
-    "confirmed_malware": 751,
+    "confirmed_malware": 552,
     "threat_actors": [
       { "name": "hightower6eu", "skills": 354, "malicious_rate": 1.0 },
       { "name": "sakaen736jih", "skills": 212, "malicious_rate": 0.93 },

--- a/website/app/[locale]/about/page.tsx
+++ b/website/app/[locale]/about/page.tsx
@@ -157,8 +157,8 @@ const MILESTONES: Milestone[] = [
   {
     date: "2026-06",
     title: {
-      en: "v3.3.x · 651 rules across 10 categories",
-      zh: "v3.3.x · 651 條規則,跨 10 個類別",
+      en: "v3.4.0 · 651 rules across 10 categories",
+      zh: "v3.4.0 · 651 條規則,跨 10 個類別",
     },
     detail: {
       en: "Current release line: 651 detection rules across 10 categories, specification 3.0.0-alpha.1 (Working Draft).",
@@ -210,6 +210,11 @@ export default async function AboutPage({
           {zh
             ? "規則以 MIT 授權公開，YAML 格式儲存於 GitHub。任何人都可以整合、修改、或貢獻回上游。沒有付費功能，沒有廠商鎖定。"
             : "Rules are published under MIT license in YAML format on GitHub. Anyone may integrate, modify, or contribute upstream. There are no paid features. There is no vendor lock-in."}
+        </p>
+        <p className="text-sm md:text-base text-graphite leading-[1.8] mt-4">
+          {zh
+            ? "標準由社群驅動，並透過每日自動結晶飛輪持續擴張——紅隊大掃描與 CVE 攝取兩條管線各自跑完完整 sweep，把規則集從 462 條長到 651 條（新增 189 條）。"
+            : "The standard is community-driven and grows through daily auto-crystallization flywheels — a red-team mega-scan pipeline and a CVE-ingestion pipeline each ran full sweeps, expanding the ruleset from 462 to 651 rules (189 new rules)."}
         </p>
       </Section>
 

--- a/website/app/[locale]/blog/hades-credential-theft/page.tsx
+++ b/website/app/[locale]/blog/hades-credential-theft/page.tsx
@@ -72,7 +72,7 @@ export default async function HadesPostPage({
 
           <h2 className="font-display text-xl font-bold text-ink pt-4">ATR 偵測什麼</h2>
           <p>
-            ATR 是 agent 威脅的開放標準。464 條偵測規則，MIT 授權。
+            ATR 是 agent 威脅的開放標準。651 條偵測規則，MIT 授權。
             規則 ATR-2026-00576 涵蓋 Hades 的憑證竊取階段，與 ATR-2026-00575 互補——
             後者偵測 Miasma 的 agent 設定檔後門，同一個攻擊活動的另一半。
           </p>
@@ -97,7 +97,7 @@ export default async function HadesPostPage({
 
           <h2 className="font-display text-xl font-bold text-ink pt-4">跑起來</h2>
           <pre className="bg-ink text-paper font-data text-[13px] p-4 overflow-x-auto">
-            <code>npx agent-threat-rules scan .</code>
+            <code>npm install -g agent-threat-rules@3.4.0{"\n"}npx agent-threat-rules scan .</code>
           </pre>
           <p>
             如果它標記了一個你沒寫的套件或檔案，把整個 checkout 當成已被入侵。
@@ -154,7 +154,7 @@ export default async function HadesPostPage({
 
           <h2 className="font-display text-xl font-bold text-ink pt-4">What ATR detects</h2>
           <p>
-            ATR is an open standard for agent threats. 464 detection rules, MIT licensed. Rule
+            ATR is an open standard for agent threats. 651 detection rules, MIT licensed. Rule
             ATR-2026-00576 covers the Hades credential-theft stage, and it complements
             ATR-2026-00575, which detects the Miasma agent-config backdoor — the config-injection
             half of the same campaign.
@@ -183,7 +183,7 @@ export default async function HadesPostPage({
 
           <h2 className="font-display text-xl font-bold text-ink pt-4">Run it</h2>
           <pre className="bg-ink text-paper font-data text-[13px] p-4 overflow-x-auto">
-            <code>npx agent-threat-rules scan .</code>
+            <code>npm install -g agent-threat-rules@3.4.0{"\n"}npx agent-threat-rules scan .</code>
           </pre>
           <p>
             If it flags a package or a file you did not write, treat the checkout as compromised.

--- a/website/app/[locale]/compliance/nist-ai-rmf/page.tsx
+++ b/website/app/[locale]/compliance/nist-ai-rmf/page.tsx
@@ -416,7 +416,7 @@ export default async function NistAiRmfPage({
           />
           <CTACard
             num="NPM"
-            head={zh ? "v3.3.1 已發布" : "v3.3.1 published"}
+            head={zh ? "v3.4.0 已發布" : "v3.4.0 published"}
             body="npm install agent-threat-rules"
             href="https://www.npmjs.com/package/agent-threat-rules"
           />

--- a/website/app/[locale]/page.tsx
+++ b/website/app/[locale]/page.tsx
@@ -293,14 +293,14 @@ export default async function Home({ params }: { params: Promise<{ locale: strin
           </Reveal>
           <Reveal delay={0.15}>
             <div className="font-data text-[clamp(48px,10vw,120px)] font-bold text-critical/[0.18] leading-[0.9] mb-3 md:mb-4">
-              751
+              1,302
             </div>
           </Reveal>
           <Reveal delay={0.2}>
             <h2 className="font-display text-[20px] md:text-[clamp(22px,3vw,32px)] font-extrabold tracking-[-1px] leading-[1.35] mb-3 md:mb-4 max-w-[620px]">
               {zh
-                ? <>惡意 AI agent skill。<br />三個協同攻擊者。<br />史上最大的 AI agent 惡意軟體行動。</>
-                : <>malicious AI agent skills.<br />Three coordinated threat actors.<br />The largest AI agent malware campaign ever documented.</>}
+                ? <>個 skill 被標記，552 個經人工複審確認為惡意。<br />三個協同攻擊者。<br />史上最大的 AI agent 惡意軟體行動。</>
+                : <>skills flagged, 552 confirmed malware after manual review.<br />Three coordinated threat actors.<br />The largest AI agent malware campaign ever documented.</>}
             </h2>
           </Reveal>
           <Reveal delay={0.25}>
@@ -321,8 +321,8 @@ export default async function Home({ params }: { params: Promise<{ locale: strin
           <Reveal delay={0.3}>
             <p className="text-sm md:text-base text-graphite max-w-[520px] mt-5 leading-[1.8]">
               {zh
-                ? "ATR 掃描 ClawHub、OpenClaw、Skills.sh 等六個 registry，共 96,096 個 skill 時發現了這些攻擊者。751 個惡意 skill 全數加入黑名單，並已通報 NousResearch。"
-                : "ATR found these threat actors scanning 96,096 skills across six registries — ClawHub, OpenClaw, Skills.sh, and three others. All 751 blacklisted and reported to NousResearch."}
+                ? "ATR 掃描 ClawHub、OpenClaw、Skills.sh 等六個 registry，共 96,096 個 skill 時發現了這些攻擊者。1,302 個 skill 被標記，經人工複審後確認 552 個為惡意，全數加入黑名單並已通報 NousResearch。"
+                : "ATR found these threat actors scanning 96,096 skills across six registries — ClawHub, OpenClaw, Skills.sh, and three others. 1,302 were flagged; 552 confirmed malware after manual review, all blacklisted and reported to NousResearch."}
             </p>
           </Reveal>
           <Reveal delay={0.35}>
@@ -411,7 +411,7 @@ export default async function Home({ params }: { params: Promise<{ locale: strin
                 { value: stats.ruleCount, suffix: "", label: zh ? "條偵測規則" : "detection rules", desc: zh ? `${stats.categoryCount} 個威脅類別` : `${stats.categoryCount} threat categories`, liveKey: undefined },
                 { label: zh ? "HackAPrompt 召回率" : "HackAPrompt recall", rawValue: "66.0%", desc: zh ? "4,780 個對抗性樣本" : "4,780 adversarial samples" },
                 { value: stats.pintPrecision, suffix: "%", label: zh ? "PINT 精準度 (0.25% FP)" : "PINT precision (0.25% FP)", desc: zh ? `850 個樣本` : `850 samples`, liveKey: "pintPrecision" },
-                { label: "npm", rawValue: "23K", desc: zh ? "月下載量 (30d)" : "monthly downloads (30d)" },
+                { label: "npm", rawValue: "2.3K", desc: zh ? "月下載量 (30d)" : "monthly downloads (30d)" },
               ].map((item, i) => (
                 <Reveal key={i} delay={0.1 + i * 0.05}>
                   <div className="bg-ash p-5 md:p-10">
@@ -835,8 +835,8 @@ export default async function Home({ params }: { params: Promise<{ locale: strin
           <Reveal delay={0.18}>
             <p className="text-sm text-stone font-light max-w-[600px] mb-6 md:mb-8 leading-[1.8]">
               {zh
-                ? <>這個飛輪已經在運轉。96,096 次掃描發現 751 個惡意 skill，觸發結晶流程，新規則再回頭掃描——一個不斷自我強化的循環。</>
-                : <>The flywheel is already turning. The 96,096-skill scan discovered 751 malware, triggered crystallization, and new rules re-scanned the ecosystem &mdash; a self-reinforcing loop.</>}
+                ? <>這些飛輪每天都在運轉。紅隊大掃描飛輪與 CVE 匯入飛輪都已跑完完整掃描，並正轉為每日更新。96,096 次掃描標記了 1,302 個 skill（552 個經人工複審確認為惡意），觸發結晶流程，新規則再回頭掃描——一個不斷自我強化的循環。自動結晶化把標準從 462 條長到 651 條，新增 189 條規則，全部隨 npm <span className="font-data text-graphite">agent-threat-rules@3.4.0</span>（651 條規則，已上線）發布。</>
+                : <>These flywheels run every day. A red-team mega-scan flywheel and a CVE-ingestion flywheel have both completed full sweeps and are moving to daily updates. The 96,096-skill scan flagged 1,302 skills (552 confirmed malware after manual review), triggered crystallization, and new rules re-scan the ecosystem &mdash; a self-reinforcing loop. Auto-crystallization grew the standard from 462 to 651 rules (189 new), all shipped in npm <span className="font-data text-graphite">agent-threat-rules@3.4.0</span> &mdash; live now with 651 rules.</>}
             </p>
           </Reveal>
 

--- a/website/app/[locale]/quality-standard/page.tsx
+++ b/website/app/[locale]/quality-standard/page.tsx
@@ -184,9 +184,9 @@ function Cell({ v }: { v: "yes" | "no" | "partial" }) {
 // figure carries an explicit "as of" date. Re-verify against data/stats.json
 // before citing externally — rule/scan counts move.
 const EVIDENCE = [
-  { stat: "34", label: "ATR rules merged into Cisco AI Defense (as of 2026-05-11)" },
+  { stat: "Live", label: "Full ATR rule pack in Cisco AI Defense production" },
   { stat: "96,096", label: "Real agent skills scanned across 6 registries (as of 2026-04-14)" },
-  { stat: "99.6%", label: "Precision on PINT adversarial benchmark" },
+  { stat: "99.7%", label: "Precision on PINT adversarial benchmark" },
   { stat: "100%", label: "Recall on SKILL.md corpus, 0.20% FP rate" },
 ];
 
@@ -272,7 +272,7 @@ export default async function QualityStandardPage({
             rel="noopener noreferrer"
             className="font-data text-xs text-stone hover:text-ink transition-colors border border-fog px-4 py-2.5 rounded-sm"
           >
-            npm install agent-threat-rules
+            npm install agent-threat-rules@3.4.0
           </a>
         </div>
       </Reveal>
@@ -791,7 +791,7 @@ export default async function QualityStandardPage({
             </span>
           </div>
           <pre className="font-data text-xs md:text-sm text-ink p-5 overflow-x-auto">
-            npm install agent-threat-rules
+            npm install agent-threat-rules@3.4.0
           </pre>
         </div>
       </Reveal>

--- a/website/app/[locale]/red-team/page.tsx
+++ b/website/app/[locale]/red-team/page.tsx
@@ -677,10 +677,15 @@ export default async function RedTeamPage({
               ? "5 個語料庫 · 75 條新規則 · HackAPrompt 召回率 28.6% → 66.0%"
               : "5 corpora · 75 new rules · HackAPrompt recall 28.6% → 66.0%"}
           </h2>
-          <p className="text-base text-stone font-light max-w-[640px] mb-10">
+          <p className="text-base text-stone font-light max-w-[640px] mb-4">
             {zh
               ? "2026-05-12：11 個並行 agent 消化五個外部語料庫，生成 75 條規則，均通過 6 道品質關卡，0 FP regression on benign corpus。詳細版本記錄在 /changelog。"
               : "2026-05-12: 11 parallel agents ingested five external corpora and generated 75 rules, all passing the 6-gate quality process with 0 FP regression on the benign corpus. Full version record at /changelog."}
+          </p>
+          <p className="text-base text-stone font-light max-w-[640px] mb-10">
+            {zh
+              ? `這個流程現在每天跑：紅隊巨量掃描與 CVE 攝取兩條飛輪都已跑完整輪，並轉為每日更新。新發現自動結晶成規則，把標準從 462 條推進到目前的 ${stats.ruleCount} 條（npm agent-threat-rules@3.4.0，2026-06-13 發布）。`
+              : `This pipeline now runs daily: a red-team mega-scan flywheel and a CVE-ingestion flywheel have each completed a full sweep and moved to daily updates. New findings auto-crystallize into rules, growing the standard from 462 to the current ${stats.ruleCount} (npm agent-threat-rules@3.4.0, published 2026-06-13).`}
           </p>
         </Reveal>
         <Reveal delay={0.1}>

--- a/website/app/[locale]/red-team/page.tsx
+++ b/website/app/[locale]/red-team/page.tsx
@@ -714,6 +714,48 @@ export default async function RedTeamPage({
               : "All 75 rules passed the RFC-001 quality gate, benign corpus 0 FP, and cross-rule conflict check. 53 rules had regex generalized from literal fingerprints to multi-layer structural patterns. Full detail in v2.2.0 changelog."}
           </p>
         </Reveal>
+        <Reveal delay={0.3}>
+          <div className="font-data text-xs uppercase tracking-[2px] text-stone mb-3 mt-16">
+            {zh ? "2026-06 巨量掃描" : "2026-06 mega-scan"}
+          </div>
+          <h2 className="font-display text-[clamp(24px,3.4vw,36px)] font-extrabold tracking-[-2px] leading-tight mb-4 max-w-[720px]">
+            {zh
+              ? "8 個語料庫 · 29 條偵測規則 · 2 個無新增 miss"
+              : "8 corpora · 29 detection rules · 2 with no novel misses"}
+          </h2>
+          <p className="text-base text-stone font-light max-w-[640px] mb-10">
+            {zh
+              ? "消化 8 個公開 agent 紅隊語料庫,找出現有規則漏抓的攻擊變體並結晶成新規則。6 個語料庫產出 29 條偵測規則,2 個(TensorTrust、PoisonedRAG)在現有覆蓋之外無新增 miss。全部通過 6 道品質關卡與 benign corpus 0 FP。"
+              : "Ingested 8 public agent red-team corpora to surface attack variants existing rules missed and crystallize them into new rules. 6 corpora produced 29 detection rules; 2 (TensorTrust, PoisonedRAG) yielded no novel misses beyond existing coverage. All passed the 6-gate quality process with 0 FP on the benign corpus."}
+          </p>
+        </Reveal>
+        <Reveal delay={0.1}>
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-px bg-fog mb-8">
+            {[
+              { corpus: "LLMail-Inject", ruleIds: "ATR-2026-01860..01865", note: "" },
+              { corpus: "InjecAgent", ruleIds: "ATR-2026-00550 / 00584 / 00700 / 00859 / 01000", note: "" },
+              { corpus: "AgentDojo", ruleIds: "ATR-2026-00715 / 00720 / 01751..01754", note: "" },
+              { corpus: "ToolEmu", ruleIds: "ATR-2026-00702 / 00718 / 00719 / 01301", note: "" },
+              { corpus: "MCPSecBench", ruleIds: "ATR-2026-01300 / 01306 / 01307 / 01310 / 01615 / 01616", note: "" },
+              { corpus: "AgentPoison", ruleIds: "ATR-2026-01774 / 01800", note: "" },
+              { corpus: "TensorTrust", ruleIds: "", note: zh ? "已有覆蓋 — 無新增 miss" : "Existing coverage — no novel misses" },
+              { corpus: "PoisonedRAG", ruleIds: "", note: zh ? "已有覆蓋 — 無新增 miss" : "Existing coverage — no novel misses" },
+            ].map((row) => (
+              <div key={row.corpus} className="bg-paper p-5 md:p-6">
+                <div className="font-display text-sm font-bold text-ink mb-2">{row.corpus}</div>
+                {row.ruleIds && <div className="font-data text-xs text-blue mb-1">{row.ruleIds}</div>}
+                {row.note && <div className="font-data text-xs text-stone mb-1">{row.note}</div>}
+              </div>
+            ))}
+          </div>
+        </Reveal>
+        <Reveal delay={0.2}>
+          <p className="text-xs text-stone max-w-[640px]">
+            {zh
+              ? "29 條為去重後的 distinct 規則;部分源自跨語料庫共通的 miss。成熟度涵蓋 stable 與 experimental,全部通過安全門檻與 benign corpus 0 FP。這兩條飛輪(紅隊 + CVE)現在每日運轉。"
+              : "29 distinct rules after de-duplication; several emerged from misses shared across corpora. Maturity spans stable and experimental; all cleared the safety gate with 0 FP on the benign corpus. Both flywheels (red-team + CVE) now run daily."}
+          </p>
+        </Reveal>
       </section>
 
       {/* ============================================================

--- a/website/app/[locale]/research/page.tsx
+++ b/website/app/[locale]/research/page.tsx
@@ -69,13 +69,13 @@ export default async function ResearchPage({ params }: { params: Promise<{ local
             </div>
             <div className="font-display text-base font-semibold text-ink mb-1">
               {locale === "zh"
-                ? "751 個惡意 AI Agent Skill：史上最大規模的 AI Agent 惡意軟體行動"
-                : "751 Malicious AI Agent Skills: The Largest AI Agent Malware Campaign Ever Documented"}
+                ? "552 個確認惡意的 AI Agent Skill：史上最大規模的 AI Agent 惡意軟體行動"
+                : "552 Confirmed Malicious AI Agent Skills: The Largest AI Agent Malware Campaign Ever Documented"}
             </div>
             <p className="text-sm text-stone mb-3">
               {locale === "zh"
-                ? "掃描 96,096 個 skill 時發現三個協同攻擊者（hightower6eu 354、sakaen736jih 212、52yuanchangxing 137）。已通報 NousResearch 並全數加入黑名單。"
-                : "Discovered while scanning 96,096 skills across six registries. Three coordinated threat actors (hightower6eu 354, sakaen736jih 212, 52yuanchangxing 137). Reported to NousResearch and blacklisted."}
+                ? "掃描 96,096 個 skill、標記 1,302 個風險項，人工複審後確認 552 個惡意軟體。發現三個協同攻擊者（hightower6eu 354、sakaen736jih 212、52yuanchangxing 137）。已通報 NousResearch 並全數加入黑名單。"
+                : "1,302 flagged across 96,096 skills scanned in six registries; 552 confirmed malware after manual review. Three coordinated threat actors (hightower6eu 354, sakaen736jih 212, 52yuanchangxing 137). Reported to NousResearch and blacklisted."}
             </p>
             <div className="flex flex-wrap gap-3">
               <a href="https://github.com/Agent-Threat-Rule/agent-threat-rules/blob/main/docs/research/openclaw-malware-campaign-2026-04.md" target="_blank" rel="noopener noreferrer" className="font-data text-xs text-blue hover:underline">{locale === "zh" ? "完整報告 (EN)" : "Full Report (EN)"}</a>
@@ -89,12 +89,12 @@ export default async function ResearchPage({ params }: { params: Promise<{ local
               <span className="font-data text-xs text-mist">April 2026 · 7 pages · 32 references</span>
             </div>
             <div className="font-display text-base font-semibold text-ink mb-1">
-              96,096 Skills, 751 Malware: A Large-Scale Security Audit of the AI Agent Ecosystem
+              96,096 Skills, 552 Confirmed Malware: A Large-Scale Security Audit of the AI Agent Ecosystem
             </div>
             <p className="text-sm text-stone mb-3">
               {locale === "zh"
-                ? "史上最大規模 AI agent 安全掃描。96,096 個 skill、1,302 個有風險、751 個確認惡意軟體。三個協同攻擊者。工具描述下毒佔偵測的 53%。"
-                : "The largest AI agent security scan to date. 96,096 skills across 6 registries, 1,302 flagged, 751 confirmed malware. Three coordinated threat actors. Credential access via tool descriptions accounts for 53% of detections."}
+                ? "史上最大規模 AI agent 安全掃描。96,096 個 skill、1,302 個有風險、人工複審後 552 個確認惡意軟體。三個協同攻擊者。工具描述下毒佔偵測的 53%。"
+                : "The largest AI agent security scan to date. 96,096 skills across 6 registries, 1,302 flagged, 552 confirmed malware after manual review. Three coordinated threat actors. Credential access via tool descriptions accounts for 53% of detections."}
             </p>
             <div className="flex flex-wrap gap-3">
               <a href="https://doi.org/10.5281/zenodo.19476480" target="_blank" rel="noopener noreferrer" className="font-data text-xs text-blue hover:underline">Zenodo (DOI)</a>
@@ -304,6 +304,13 @@ export default async function ResearchPage({ params }: { params: Promise<{ local
             </div>
           </div>
         </div>
+      </Reveal>
+      <Reveal delay={0.15}>
+        <p className="text-sm text-graphite leading-[1.7] mb-6 max-w-[760px]">
+          {locale === "zh"
+            ? `這個掃描現在是活的：紅隊巨量掃描與 CVE 攝取兩條飛輪都已跑完整輪，並轉為每日更新。新發現會自動結晶成偵測規則回流 ATR，把標準從 462 條推進到目前的 ${stats.ruleCount} 條（npm agent-threat-rules@3.4.0，2026-06-13 發布）。`
+            : `This scan is now a live loop: a red-team mega-scan flywheel and a CVE-ingestion flywheel have each run a full sweep and are moving to daily updates. New findings auto-crystallize into detection rules that flow back into ATR, growing the standard from 462 to the current ${stats.ruleCount} (npm agent-threat-rules@3.4.0, published 2026-06-13).`}
+        </p>
       </Reveal>
       <Reveal delay={0.2}>
         <div className="flex gap-4 mb-8">

--- a/website/app/[locale]/spec/page.tsx
+++ b/website/app/[locale]/spec/page.tsx
@@ -63,13 +63,13 @@ const SECTIONS: Section[] = [
       title: "Status of This Document",
       body: `<p>This document is a <strong>Working Draft</strong> published by the ATR Community. Although the rule format has been shipping in production for over a year, the surrounding governance is still transitioning from a single-maintainer model (BDFL) to a Technical Steering Committee (TSC). The transition criteria and seating process are defined in the <a href="/en/charter">project charter</a>.</p>
 <p>Discussion of this document takes place on the public GitHub repository at <a href="https://github.com/Agent-Threat-Rule/agent-threat-rules" target="_blank" rel="noopener noreferrer">github.com/Agent-Threat-Rule/agent-threat-rules</a>. Substantive feedback should be filed as issues.</p>
-<p>All numbers in this document are sourced from <code>data/stats.json</code> in the repository, which is the canonical record of the project's current state. Where this document and <code>stats.json</code> disagree, <code>stats.json</code> is authoritative.</p>`,
+<p>All numbers in this document are sourced from <code>data/stats.json</code> in the repository, which is the canonical record of the project's current state. Benchmark figures additionally resolve through the per-source pointer at <code>data/measurements/&lt;source&gt;/latest.json</code> (aggregated into <code>stats.json</code> under <code>benchmarks[]</code>). Where this document and these files disagree, the files are authoritative.</p>`,
     },
     zh: {
       title: "本文件狀態 (Status of This Document)",
       body: `<p>本文件為 ATR 社群發布的 <strong>Working Draft</strong>。儘管規則格式已在 production 運行超過一年,周邊治理仍處於從單一維護者模型 (BDFL) 過渡到 Technical Steering Committee (TSC) 的階段。過渡條件與就任程序定義於 <a href="/zh/charter">專案章程</a>。</p>
 <p>本文件討論於公開 GitHub repository <a href="https://github.com/Agent-Threat-Rule/agent-threat-rules" target="_blank" rel="noopener noreferrer">github.com/Agent-Threat-Rule/agent-threat-rules</a> 進行。實質性回饋請開 issue。</p>
-<p>本文件所有數字皆源自 repository 中的 <code>data/stats.json</code>,此為專案目前狀態的正本紀錄。若本文件與 <code>stats.json</code> 不一致,以 <code>stats.json</code> 為準。</p>`,
+<p>本文件所有數字皆源自 repository 中的 <code>data/stats.json</code>,此為專案目前狀態的正本紀錄。Benchmark 數字另經各來源指標 <code>data/measurements/&lt;source&gt;/latest.json</code> 解析 (彙總於 <code>stats.json</code> 的 <code>benchmarks[]</code>)。若本文件與這些檔案不一致,以這些檔案為準。</p>`,
     },
   },
   {

--- a/website/lib/stats.ts
+++ b/website/lib/stats.ts
@@ -419,7 +419,7 @@ export function loadSiteStats(): SiteStats {
         type: "open",
         detail:
           "Submission in review; the OSCAL lead opened a collaboration branch and invited a community contribution. Not a NIST endorsement or adoption.",
-        url: "https://github.com/usnistgov/OSCAL/pull/2234",
+        url: "https://github.com/usnistgov/OSCAL",
         logo: "https://github.com/usnistgov.png?size=128",
       },
       {
@@ -444,12 +444,6 @@ export function loadSiteStats(): SiteStats {
           "Issue #207 open at safe-agentic-framework/safe-mcp. Structured proposal for a detections/ registry to support cross-project rule-ID linkage.",
         url: "https://github.com/safe-agentic-framework/safe-mcp/issues/207",
       },
-      {
-        name: "Awesome LLM Security",
-        type: "open",
-        detail: "PR #117 submitted to curated security tools list.",
-        url: "https://github.com/corca-ai/awesome-llm-security/pull/117",
-      },
       // === Red team tooling (open) ===
       {
         name: "NVIDIA Garak",
@@ -461,9 +455,9 @@ export function loadSiteStats(): SiteStats {
       },
       {
         name: "Microsoft PyRIT",
-        type: "open",
+        type: "merged",
         detail:
-          "PR #1715 draft. ATR dataset loader for PyRIT red-team orchestrators. Roman Lutz reviewed in 2 min; iterating on doc shape.",
+          "PR #1715 merged. ATR adversarial-payload dataset loader for Microsoft's PyRIT red-team orchestration framework.",
         url: "https://github.com/microsoft/PyRIT/pull/1715",
         logo: "https://github.com/microsoft.png?size=128",
       },
@@ -497,13 +491,6 @@ export function loadSiteStats(): SiteStats {
         url: "https://github.com/promptfoo/promptfoo/pull/8529",
       },
       {
-        name: "Cisco MCP Scanner",
-        type: "open",
-        detail:
-          "PR #151 submitted. ATR regex analyzer with 20 community rules.",
-        url: "https://github.com/cisco-ai-defense/mcp-scanner/pull/151",
-      },
-      {
         name: "Damn Vulnerable MCP Server",
         type: "open",
         detail:
@@ -518,19 +505,6 @@ export function loadSiteStats(): SiteStats {
         url: "https://github.com/meta-llama/PurpleLlama/pull/206",
       },
       {
-        name: "Portkey Gateway",
-        type: "open",
-        detail: "PR #1652 open. ATR (Agent Threat Rules) detection plugin.",
-        url: "https://github.com/Portkey-AI/gateway/pull/1652",
-      },
-      {
-        name: "IBM mcp-context-forge",
-        type: "open",
-        detail:
-          "PR #4109. ATR threat detection plugin for IBM MCP runtime. 18 tests, follows secrets_detection template.",
-        url: "https://github.com/IBM/mcp-context-forge/pull/4109",
-      },
-      {
         name: "Awesome Cybersecurity Agentic AI",
         type: "open",
         detail: "PR #24 submitted to Tools section.",
@@ -538,8 +512,8 @@ export function loadSiteStats(): SiteStats {
       },
       {
         name: "Awesome AI Agents Security",
-        type: "open",
-        detail: "PR #17 submitted to Static Analysis & Linters.",
+        type: "merged",
+        detail: "PR #17 merged into Static Analysis & Linters.",
         url: "https://github.com/ProjectRecon/awesome-ai-agents-security/pull/17",
       },
       {

--- a/website/lib/stats.ts
+++ b/website/lib/stats.ts
@@ -418,8 +418,8 @@ export function loadSiteStats(): SiteStats {
         name: "NIST OSCAL",
         type: "open",
         detail:
-          "Submission in review; the OSCAL lead opened a collaboration branch and invited a community contribution. Not a NIST endorsement or adoption.",
-        url: "https://github.com/usnistgov/OSCAL",
+          "Submission in review; the OSCAL lead opened collaboration branch oscal-content#338 (rework of #333) and invited a community contribution. Not a NIST endorsement or adoption.",
+        url: "https://github.com/usnistgov/oscal-content/pull/338",
         logo: "https://github.com/usnistgov.png?size=128",
       },
       {

--- a/website/lib/stats.ts
+++ b/website/lib/stats.ts
@@ -366,7 +366,7 @@ export function loadSiteStats(): SiteStats {
         name: "Cisco AI Defense",
         type: "merged",
         detail:
-          "PR #79 (34-rule PoC) + #99 merged. Full ATR rule pack (314 at time of PR #99) in skill-scanner production. Upstream maintained.",
+          "PR #79 (34-rule PoC) + #99 merged. Full ATR rule pack (at time of PR #99) in skill-scanner production. Upstream maintained.",
         url: "https://github.com/cisco-ai-defense/skill-scanner/pull/99",
         logo: "https://github.com/cisco-ai-defense.png?size=128",
       },


### PR DESCRIPTION
Full ATR website audit + sync after the npm 3.4.0 / 651-rule publish. Audited all 33 pages against the verified current state; corrected stale facts, disclosed new verified achievements, and preserved every honesty boundary.

Facts corrected
- The '751 malware / largest campaign' figure reconciled everywhere to the honest split: 1,302 flagged across 96,096 scanned, 552 confirmed after manual review (home, research, red-team, data/mega-scan-report.json) — now consistent with the layout metadata.
- npm download card 23K -> 2.3K. Real last-30-day downloads = 2,290; the 23K was a roughly 10x overstatement that would undercut trust with adopters.
- hades blog: 464 -> 651 rules; install pinned to v3.4.0.
- quality-standard: PINT precision 99.6 -> 99.7; npm pins to v3.4.0; stale Cisco rule count generalized. about and nist-ai-rmf: v3.3.x -> v3.4.0.
- stats.ts Cisco detail: dropped the stale '(314 at time of PR #99)' snapshot.

Disclosed (new, verified)
- npm agent-threat-rules@3.4.0 live with 651 rules (resolved the version-collision that had npm stuck at 464).
- The red-team and CVE flywheels now running toward daily updates; auto-crystallization grew the standard 462 -> 651.

Deliberately left untouched (correct / honest)
- Spec document version 3.0.0-alpha.1 (intentionally distinct from the rule package version).
- Version-pinned 3.0.0 benchmark numbers (honest, reproducible measurements).
- NIST OSCAL 'submission in review' framing — never upgraded to adoption or endorsement.
- Microsoft AGT and Cisco AI Defense framed as USE / production deployment, not endorsement.
- Dynamic ruleCount / categoryCount / benchmarks (auto-correct from data).

Test plan
- next build PASS: 1372/1372 static pages generated, exit 0.
- Verified no stale 751/464/99.6/v3.3.x remain; no PanGuard mention; OSCAL + benchmark honesty intact.