### PR TITLE
docs(atd): surface the live ATD catalog in README and on the site

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,14 @@ ATR is publishing proposal-stage standardization scaffolding ahead of OASIS Open
 
 See [`STANDARDIZATION-STATUS.md`](STANDARDIZATION-STATUS.md) for the full status matrix mapping every new artifact to `{STABLE IN PRODUCTION, PROPOSED, SKELETON, PRELIMINARY}` and timeline for OASIS submission, community comment, and ratification.
 
+## ATD — Agentic Threat Detection
+
+ATD is ATR's technique catalog: an enumeration of agent-runtime attack *techniques* — the "what" — each mapped to MITRE ATLAS, OWASP ASI, and CWE. ATR *rules* are the "how" that detect them. ATD is to ATR what MITRE ATLAS is to a detection ruleset: a knowledge layer that names every known agent-runtime threat, whether or not an executable rule exists for it yet.
+
+- **Live catalog (machine-readable):** <https://agentthreatrule.org/atd>
+- **80 techniques across 9 tactics**, every one mapped to an upstream framework (or with a documented gap); a subset carry a live ATR detection rule, the rest are documented — a technique needs verifiable provenance, not a rule.
+- **Schema gate:** every PR runs `scripts/validate-atd.ts` (validates each technique against the normative `website/public/atd/atd-technique.schema.json`) and `scripts/atd/verify-atd-mappings.ts` (verifies every cited MITRE ATLAS id against the authoritative catalog).
+
 ## Table of Contents
 
 - [1. Background](#1-background)

--- a/website/app/[locale]/page.tsx
+++ b/website/app/[locale]/page.tsx
@@ -807,6 +807,11 @@ export default async function Home({ params }: { params: Promise<{ locale: strin
               {zh ? "查看完整覆蓋對照表 →" : "View full coverage mapping →"}
             </Link>
           </Reveal>
+          <Reveal delay={0.28}>
+            <Link href={`${prefix}/atd`} className="font-data text-xs md:text-sm text-blue hover:underline inline-block mt-3 md:ml-6">
+              {zh ? "ATD：可執行的 agent 威脅技法目錄 →" : "ATD: the executable agent-threat technique catalog →"}
+            </Link>
+          </Reveal>
         </div>
       </section>
 

--- a/website/components/Footer.tsx
+++ b/website/components/Footer.tsx
@@ -25,6 +25,9 @@ export function Footer({ locale }: { locale: Locale }) {
               <Link href={`${prefix}/spec`} className="text-sm text-stone hover:text-ink transition-colors">
                 {zh ? "完整規格" : "Specification"}
               </Link>
+              <Link href={`${prefix}/atd`} className="text-sm text-stone hover:text-ink transition-colors">
+                {zh ? "ATD 技法目錄" : "ATD techniques"}
+              </Link>
               <Link href={`${prefix}/conformance`} className="text-sm text-stone hover:text-ink transition-colors">
                 {zh ? "符規" : "Conformance"}
               </Link>


### PR DESCRIPTION
ATD (Agentic Threat Detection) shipped at 80 techniques (#160) but was only reachable from the top nav. This surfaces it:

- **README** — a concise ATD section: ATD is ATR's technique catalog (the "what" to ATR's "how"), mapped to MITRE ATLAS / OWASP ASI / CWE, gated by \`validate-atd\` + \`verify-atd-mappings\`, with a link to the live machine-readable catalog.
- **Footer** — an "ATD techniques" link under Specification.
- **Homepage** — a link from the Standards Coverage section to the executable technique catalog.

No data/schema changes (atd-validate not triggered). Verified locally: typecheck + website build (real npm ci) both green.