### PR TITLE
Deep site audit: fix stale ecosystem data, dead links, overclaims

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -68,8 +68,8 @@ Adopters whose adoption is itself a public-good interoperability artefact
 ### NIST AI RMF — community OSCAL catalog (submission in review)
 - **Org**: ATR maintainers (community contribution; NOT a NIST publication)
 - **Type**: reference
-- **Integration**: Community-authored OSCAL catalog covering NIST AI RMF (72 controls + 31 cross-reference links), CC0-licensed, self-published at Agent-Threat-Rule/ai-rmf-oscal-catalog. The catalog has been submitted to the NIST OSCAL team as PR usnistgov/oscal-content#333; the PR is OPEN, the NIST OSCAL maintainer has flagged that scope alignment needs rework, and the ATR maintainers are awaiting NIST direction. Listed here for transparency about the submission, NOT as evidence of NIST endorsement.
-- **Evidence**: <https://github.com/usnistgov/oscal-content/pull/333>
+- **Integration**: Community-authored OSCAL catalog covering NIST AI RMF (72 controls + 31 cross-reference links), CC0-licensed, self-published at Agent-Threat-Rule/ai-rmf-oscal-catalog. The catalog was submitted to the NIST OSCAL team; the initial PR usnistgov/oscal-content#333 was closed and reopened as a scope-aligned rework, usnistgov/oscal-content#338 (currently OPEN, in review). The ATR maintainers are awaiting NIST direction. Listed here for transparency about the submission, NOT as evidence of NIST endorsement.
+- **Evidence**: <https://github.com/usnistgov/oscal-content/pull/338>
 - **Since**: 2026-05-10 (community catalog published; PR opened 2026-05-21)
 - **Status**: in-review
 
@@ -140,32 +140,8 @@ Listed when the integration code has been merged or released.
 - **Org**: NVIDIA
 - **Type**: rule-import
 - **Integration**: ATR detector plugin for the garak red-teaming framework
-- **Evidence**: <https://github.com/NVIDIA/garak/pull/1276>
+- **Evidence**: <https://github.com/NVIDIA/garak/pull/1676>
 - **Since**: 2026-05-20
-- **Status**: in-review
-
-### IBM mcp-context-forge
-- **Org**: IBM
-- **Type**: sidecar-proxy
-- **Integration**: ATR threat-detection plugin for the MCP context-forge proxy
-- **Evidence**: <https://github.com/IBM/mcp-context-forge/pull/4109>
-- **Since**: 2026-05-09
-- **Status**: in-review
-
-### Portkey AI Gateway
-- **Org**: Portkey AI
-- **Type**: sidecar-proxy
-- **Integration**: ATR detection plugin in the Portkey gateway plugin architecture
-- **Evidence**: <https://github.com/Portkey-AI/gateway/pull/1652>
-- **Since**: 2026-05-16
-- **Status**: in-review
-
-### Semgrep
-- **Org**: Semgrep Inc. (community contribution)
-- **Type**: adapter
-- **Integration**: YAML rule-format adapter that translates Semgrep rule conventions to ATR conformance for skill-manifest + MCP-tool security
-- **Evidence**: Semgrep upstream PR (open as of 2026-05-10)
-- **Since**: 2026-05-10
 - **Status**: in-review
 
 ### aaif-goose
@@ -174,7 +150,7 @@ Listed when the integration code has been merged or released.
 - **Integration**: PreToolUse hook denial integrates ATR rule evaluation at the tool-call boundary
 - **Evidence**: <https://github.com/aaif-goose/goose/pull/9304>
 - **Since**: 2026-05-19
-- **Status**: in-review
+- **Status**: shipped
 
 ### SigmaHQ
 - **Org**: SigmaHQ
@@ -182,7 +158,7 @@ Listed when the integration code has been merged or released.
 - **Integration**: Cross-listing in the Sigma tools directory; agent-threat-rules listed as a sibling detection-rule format
 - **Evidence**: <https://github.com/SigmaHQ/sigma/pull/6015>
 - **Since**: 2026-05-09
-- **Status**: in-review
+- **Status**: shipped
 
 ---
 
@@ -216,14 +192,6 @@ discoverability.
 - **Since**: 2026-05-16
 - **Status**: in-review
 
-### Puliczek/awesome-mcp-security
-- **Org**: Puliczek (independent)
-- **Type**: reference
-- **Integration**: ATR listed in MCP threat-detection tools
-- **Evidence**: Puliczek/awesome-mcp-security
-- **Since**: 2026-04-21
-- **Status**: in-review
-
 ---
 
 ## Tier 4 — Commercial implementations
@@ -240,6 +208,11 @@ docs.*
 
 ## Removed entries
 
-None to date. If an adopter is moved out of an active tier due to project
-archival or removal of ATR support, the entry is moved here with a
-one-line note and the original "Since" date is preserved.
+If an adopter is moved out of an active tier due to project archival, removal
+of ATR support, a closed/unmerged PR, or unverifiable evidence, the entry is
+noted here with the reason and the original "Since" date preserved.
+
+- **IBM mcp-context-forge** (was Tier 2 · since 2026-05-09) — evidence PR IBM/mcp-context-forge#4109 was closed without merge. Removed 2026-06-14.
+- **Portkey AI Gateway** (was Tier 2 · since 2026-05-16) — evidence PR Portkey-AI/gateway#1652 was closed without merge. Removed 2026-06-14.
+- **Semgrep** (was Tier 2 · since 2026-05-10) — no merged PR or verifiable evidence link could be located. Removed 2026-06-14.
+- **Puliczek/awesome-mcp-security** (was Tier 3 · since 2026-04-21) — ATR is not present in the project README; listing could not be verified. Removed 2026-06-14.

--- a/website/app/[locale]/blog/hades-credential-theft/page.tsx
+++ b/website/app/[locale]/blog/hades-credential-theft/page.tsx
@@ -72,7 +72,7 @@ export default async function HadesPostPage({
 
           <h2 className="font-display text-xl font-bold text-ink pt-4">ATR 偵測什麼</h2>
           <p>
-            ATR 是 agent 威脅的開放標準。651 條偵測規則，MIT 授權。
+            ATR 是 agent 威脅的開放標準。652 條偵測規則，MIT 授權。
             規則 ATR-2026-00576 涵蓋 Hades 的憑證竊取階段，與 ATR-2026-00575 互補——
             後者偵測 Miasma 的 agent 設定檔後門，同一個攻擊活動的另一半。
           </p>
@@ -154,7 +154,7 @@ export default async function HadesPostPage({
 
           <h2 className="font-display text-xl font-bold text-ink pt-4">What ATR detects</h2>
           <p>
-            ATR is an open standard for agent threats. 651 detection rules, MIT licensed. Rule
+            ATR is an open standard for agent threats. 652 detection rules, MIT licensed. Rule
             ATR-2026-00576 covers the Hades credential-theft stage, and it complements
             ATR-2026-00575, which detects the Miasma agent-config backdoor — the config-injection
             half of the same campaign.

--- a/website/app/[locale]/compliance/page.tsx
+++ b/website/app/[locale]/compliance/page.tsx
@@ -126,7 +126,7 @@ export default async function CompliancePage({
               {zh ? "下載合規映射包 (GitHub Releases) →" : "Download compliance mapping (GitHub Releases) →"}
             </a>
             <a
-              href="https://github.com/Agent-Threat-Rule/agent-threat-rules/blob/main/docs/compliance/"
+              href="https://github.com/Agent-Threat-Rule/agent-threat-rules/tree/main/docs"
               target="_blank"
               rel="noopener noreferrer"
               className="font-data text-xs text-blue hover:underline text-center"
@@ -189,7 +189,7 @@ export default async function CompliancePage({
               : "ATR's compliance mappings are not marketing claims. Each rule's YAML contains specific compliance metadata citing the exact regex or token that detects the attack — not a generic claim of 'alignment with framework'."}
           </p>
           <a
-            href="https://github.com/Agent-Threat-Rule/agent-threat-rules/tree/main/data/rules"
+            href="https://github.com/Agent-Threat-Rule/agent-threat-rules/tree/main/rules"
             target="_blank"
             rel="noopener noreferrer"
             className="font-data text-xs text-blue hover:underline"

--- a/website/app/[locale]/compliance/page.tsx
+++ b/website/app/[locale]/compliance/page.tsx
@@ -196,6 +196,19 @@ export default async function CompliancePage({
           >
             {zh ? "在 GitHub 查看 raw rule YAML →" : "Browse raw rule YAML on GitHub →"}
           </a>
+          <p className="text-sm text-graphite leading-[1.7] mt-4 mb-3">
+            {zh
+              ? "認為某條對應有誤？這是開放標準——歡迎 fork、挑戰，並提 PR 或開 issue 修正任何 mapping。"
+              : "Think a mapping is wrong? This is an open standard — fork it, challenge it, and open a PR or issue to correct any mapping."}
+          </p>
+          <a
+            href="https://github.com/Agent-Threat-Rule/agent-threat-rules/issues/new"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="font-data text-xs text-blue hover:underline"
+          >
+            {zh ? "開 issue 挑戰某條對應 →" : "Open an issue to challenge a mapping →"}
+          </a>
         </div>
       </Reveal>
 

--- a/website/app/[locale]/contribute/page.tsx
+++ b/website/app/[locale]/contribute/page.tsx
@@ -328,17 +328,31 @@ export default async function ContributePage({ params }: { params: Promise<{ loc
         </div>
       </Reveal>
 
-      {/* ── How Threat Cloud Crystallization Works ── */}
+      {/* ── Optional: Threat Cloud reference service ── */}
+      <Reveal>
+        <div className="font-data text-xs font-medium text-stone tracking-[2px] uppercase mb-3">
+          {zh ? "選用:Threat Cloud 參考服務" : "Optional: Threat Cloud reference service"}
+        </div>
+      </Reveal>
+      <Reveal delay={0.1}>
+        <div className="border border-fog p-6 mb-6 text-sm text-stone leading-relaxed">
+          <p>
+            {zh
+              ? "Threat Cloud 是 ATR 維護者運營的選用參考服務,並非標準的一部分。標準本體是規格加上 MIT 授權的規則,透過 npm / PyPI / 純 YAML 完全可離線使用;Threat Cloud 只提供 hosted 便利(規則同步、威脅提交),不用它也能達到同樣結果。"
+              : "Threat Cloud is an optional reference service operated by the ATR maintainers — not part of the standard. The standard is the spec plus the MIT-licensed rules, fully usable offline via npm / PyPI / raw YAML. Threat Cloud only adds hosted convenience (rule sync, threat submission); the same outcomes are reachable without it."}
+          </p>
+        </div>
+      </Reveal>
       <Reveal>
         <div className="border border-fog mb-10">
           <div className="px-6 py-4 border-b border-fog bg-ash">
             <h2 className="font-display text-base font-semibold">
-              {zh ? "Threat Cloud 結晶流程" : "How Threat Cloud Crystallization Works"}
+              {zh ? "Threat Cloud 自動化管線(選用便利層)" : "The Threat Cloud auto-pipeline (optional convenience layer)"}
             </h2>
             <p className="text-sm text-stone mt-1">
               {zh
-                ? "傳統規則需要數週撰寫、審查、發布。Threat Cloud 目標數小時。"
-                : "Traditional rules take weeks to write, review, and ship. Threat Cloud targets hours."}
+                ? "規則的權威產生路徑是上面「送出後會發生什麼」描述的社群/維護者流程(issue → bot 草案 PR → 維護者寫 regex → safety gate → merge → npm publish)。下面是 Threat Cloud 維護者運營的選用自動化版本,目標把同樣流程壓到數小時 — 用不用它,標準與規則都不變。"
+                : "The canonical way rules get made is the community/maintainer workflow described in \"What happens after you contribute\" above (issue → bot draft PR → maintainer writes regex → safety gate → merge → npm publish). Below is the optional, maintainer-operated automated version Threat Cloud runs to target hours for that same flow — the standard and the rules are identical whether or not you use it."}
             </p>
           </div>
           <div className="p-5 md:p-6">

--- a/website/app/[locale]/glossary/page.tsx
+++ b/website/app/[locale]/glossary/page.tsx
@@ -142,8 +142,8 @@ const ENTRIES: GlossaryEntry[] = [
   },
   {
     term: "Threat Cloud",
-    en: "An auto-review backend for community-submitted rules. Runs the crystallization pipeline and safety gates. (Reference implementation, not part of the normative standard.)",
-    zh: "對社群提交規則的自動審查後端。執行 crystallization pipeline 與安全閘 (safety gate)。(參考實作,非規範標準的一部分。)",
+    en: "An optional reference service operated by the ATR maintainers — not part of the standard. The standard is the spec plus the MIT-licensed rules, fully usable offline via npm / PyPI / raw YAML. Threat Cloud only adds hosted convenience (rule sync, threat submission); the same outcomes are reachable without it. Technically, it is an auto-review backend for community-submitted rules, running the crystallization pipeline and safety gates.",
+    zh: "Threat Cloud 是 ATR 維護者運營的選用參考服務,並非標準的一部分。標準本體是規格加上 MIT 授權的規則,透過 npm / PyPI / 純 YAML 完全可離線使用;Threat Cloud 只提供 hosted 便利(規則同步、威脅提交),不用它也能達到同樣結果。技術上,它是對社群提交規則的自動審查後端,執行 crystallization pipeline 與安全閘 (safety gate)。",
   },
 ];
 

--- a/website/app/[locale]/governance/page.tsx
+++ b/website/app/[locale]/governance/page.tsx
@@ -166,11 +166,11 @@ export default async function GovernancePage({
             {
               kind: zh ? "修改 spec(ATR-SPEC-v1)" : "Spec amendment (ATR-SPEC-v1)",
               quorum: zh
-                ? "RFC issue 先開 + 7 天公開評論窗口 + 2 名維護者核可"
-                : "RFC issue opened first + 7-day public comment window + 2 maintainer approvals",
+                ? "RFC issue 先開 + 14 天公開評論窗口(複雜提案延長至 30 天)+ 2 名維護者核可"
+                : "RFC issue opened first + 14-day public comment window (extended to 30 for complex proposals) + 2 maintainer approvals",
               detail: zh
-                ? "spec 是所有相容引擎的契約。任何 spec 變動都要先以 issue 形式提出 RFC、開 7 天評論窗讓所有 implementer 看到,然後才接受 PR。在目前 BDFL 階段,「2 名核可」將由首席維護者加上一名外部 reviewer(待指定後)滿足。TSC 成立後改為 TSC 過半數核可。"
-                : "The spec is the contract between all conforming engines. Any spec change is opened first as an RFC issue with a 7-day public comment window so every implementer sees it, then the PR is accepted. Under the current BDFL phase the 'two approvals' bar will be satisfied by the lead maintainer plus one external reviewer once designated. When the TSC is formed the bar becomes a TSC majority.",
+                ? "spec 是所有相容引擎的契約。任何 spec 變動都要先以 issue 形式提出 RFC、開 14 天公開評論窗口(複雜提案延長至 30 天)讓所有 implementer 看到,然後才接受 PR。在目前 BDFL 階段,「2 名核可」將由首席維護者加上一名外部 reviewer(待指定後)滿足。TSC 成立後改為 TSC 過半數核可。"
+                : "The spec is the contract between all conforming engines. Any spec change is opened first as an RFC issue with a 14-day public comment window (extended to 30 for complex proposals) so every implementer sees it, then the PR is accepted. Under the current BDFL phase the 'two approvals' bar will be satisfied by the lead maintainer plus one external reviewer once designated. When the TSC is formed the bar becomes a TSC majority.",
             },
             {
               kind: zh ? "breaking change(SemVer 主版號)" : "Breaking change (SemVer major bump)",

--- a/website/app/[locale]/integrate/page.tsx
+++ b/website/app/[locale]/integrate/page.tsx
@@ -136,11 +136,11 @@ export default async function IntegratePage({ params }: { params: Promise<{ loca
               },
               {
                 level: "L3",
-                title: locale === "zh" ? "雙向" : "Bidirectional",
+                title: locale === "zh" ? "雙向（選用）" : "Bidirectional (optional)",
                 who: locale === "zh" ? "安全平台、企業 SOC" : "Security platforms, enterprise SOC",
-                how: locale === "zh" ? "嵌入 + 上報威脅到 Threat Cloud" : "Embed + report threats to Threat Cloud",
-                what: locale === "zh" ? "你的端點變成全球感測器，你也收到全球情報" : "Your endpoints become global sensors, you receive global intel",
-                update: locale === "zh" ? "TC 即時推送 + npm update" : "TC real-time push + npm update",
+                how: locale === "zh" ? "嵌入 + 選用接上 Threat Cloud 參考服務" : "Embed + optionally connect Threat Cloud reference service",
+                what: locale === "zh" ? "選用便利:上報威脅與同步規則;不接也能用標準完整運作" : "Optional convenience: submit threats and sync rules; the standard works fully without it",
+                update: locale === "zh" ? "npm update（接上 TC 可加即時推送）" : "npm update (TC adds real-time push if connected)",
               },
             ].map((tier) => (
               <div key={tier.level} className="bg-paper p-5 md:p-6">
@@ -360,7 +360,7 @@ jobs:
             <div className="grid grid-cols-1 md:grid-cols-2 gap-px bg-fog">
               {[
                 { label: locale === "zh" ? "覆蓋範圍" : "Coverage", atr: locale === "zh" ? `${stats.ruleCount} 條規則，${stats.cveCount} 個 CVE 對應，${stats.categoryCount} 個威脅類別` : `${stats.ruleCount} rules, ${stats.cveCount} CVEs mapped, ${stats.categoryCount} threat categories`, own: locale === "zh" ? "需要自行建立規則庫" : "You build your own rule set" },
-                { label: locale === "zh" ? "新攻擊反應" : "New attack response", atr: locale === "zh" ? "Threat Cloud 結晶，目標數小時內產出規則" : "Threat Cloud crystallization, targeting hours", own: locale === "zh" ? "取決於你團隊的頻寬" : "Depends on your team's bandwidth" },
+                { label: locale === "zh" ? "新攻擊反應" : "New attack response", atr: locale === "zh" ? "社群與 CI 流程持續新增規則,目標數小時內產出(選用的 Threat Cloud 可加速回報)" : "Community + CI pipeline add rules continuously, targeting hours (optional Threat Cloud can speed up reporting)", own: locale === "zh" ? "取決於你團隊的頻寬" : "Depends on your team's bandwidth" },
                 { label: locale === "zh" ? "繞過測試" : "Evasion testing", atr: locale === "zh" ? "64 種已記錄的繞過技術，規則附帶 evasion_tests" : "64 documented evasion techniques, with per-rule evasion_tests", own: locale === "zh" ? "需要額外投入時間建立" : "Requires dedicated effort to build" },
                 { label: locale === "zh" ? "OWASP / MITRE 對應" : "OWASP / MITRE mapping", atr: locale === "zh" ? "內建。Agentic 10/10 + 每條規則對應 MITRE ATLAS" : "Pre-built. 10/10 Agentic + MITRE ATLAS per rule", own: locale === "zh" ? "數小時的手動對應工作" : "Hours of manual mapping work" },
                 { label: locale === "zh" ? "維護成本" : "Maintenance", atr: locale === "zh" ? "社群維護。MIT 授權。零成本。" : "Community-maintained. MIT. Zero cost.", own: locale === "zh" ? "需要持續的人力投入" : "Requires ongoing engineering effort" },
@@ -416,11 +416,11 @@ jobs:
         </div>
       </Reveal>
 
-      {/* Trusted By */}
+      {/* Integrated by */}
       <Reveal>
         <div className="mt-12 mb-px">
           <div className="font-data text-xs text-stone tracking-[2px] uppercase mb-5">
-            {locale === "zh" ? "已被採用" : "Trusted By"}
+            {locale === "zh" ? "生態整合" : "Integrated by"}
           </div>
           <div className="grid grid-cols-2 md:grid-cols-4 gap-px bg-fog">
             {[
@@ -438,19 +438,26 @@ jobs:
         </div>
       </Reveal>
 
-      {/* Threat Reporting API — upstream contribution */}
+      {/* Threat Cloud — optional reference service */}
       <Reveal>
         <div className="mt-12 border border-fog">
           <div className="px-6 py-4 border-b border-fog bg-[#0B0B0F]">
             <h2 className="font-display text-lg font-semibold text-white">
-              {locale === "zh" ? "上報威脅 — 讓你的端點成為全球感測器" : "Report Threats — Turn Your Endpoints Into Global Sensors"}
+              {locale === "zh" ? "Threat Cloud — 選用參考服務" : "Threat Cloud — Optional Reference Service"}
             </h2>
           </div>
           <div className="p-6 space-y-6">
+            <div className="bg-ash border border-fog px-4 py-3 rounded-sm">
+              <p className="text-sm text-graphite leading-[1.8] max-w-[640px]">
+                {locale === "zh"
+                  ? "Threat Cloud 是 ATR 維護者運營的選用參考服務,並非標準的一部分。標準本體是規格加上 MIT 授權的規則,透過 npm / PyPI / 純 YAML 完全可離線使用;Threat Cloud 只提供 hosted 便利(規則同步、威脅提交),不用它也能達到同樣結果。"
+                  : "Threat Cloud is an optional reference service operated by the ATR maintainers — not part of the standard. The standard is the spec plus the MIT-licensed rules, fully usable offline via npm / PyPI / raw YAML. Threat Cloud only adds hosted convenience (rule sync, threat submission); the same outcomes are reachable without it."}
+              </p>
+            </div>
             <p className="text-sm text-stone leading-[1.8] max-w-[560px]">
               {locale === "zh"
-                ? "你的掃描器發現了新威脅？上報到 Threat Cloud，ATR 會自動結晶成偵測規則，審核通過後分發給全世界。你發現的威脅，保護所有人。"
-                : "Your scanner found a new threat? Report it to Threat Cloud. ATR crystallizes it into a detection rule, reviews it, and distributes it globally. Your discovery protects everyone."}
+                ? "若你選擇接上:掃描器發現新威脅時可上報到 Threat Cloud,維護者會將其結晶成偵測規則,審核通過後合併進 MIT 規則集分發。以下是接上的技術文件——完全選用。"
+                : "If you choose to connect it: when your scanner finds a new threat, you can submit it to Threat Cloud, where maintainers crystallize it into a detection rule, review it, and merge it into the MIT rule set for distribution. The technical docs below cover connecting it — entirely optional."}
             </p>
 
             <div className="space-y-4">

--- a/website/app/[locale]/partner-sync/page.tsx
+++ b/website/app/[locale]/partner-sync/page.tsx
@@ -15,16 +15,37 @@ export default function PartnerSyncPage() {
     <main className="mx-auto max-w-3xl px-6 py-16">
       <h1 className="text-3xl font-bold">Partner Live Sync</h1>
       <p className="mt-2 text-neutral-400">
-        Live pull of ATR confirmed rules from Threat Cloud. Partner-tier API key required.
+        An optional hosted convenience for live-polling ATR confirmed rules. Partner-tier API key
+        required. The standard itself — the spec plus the MIT-licensed rules — is fully usable
+        offline without this service.
       </p>
+
+      <section className="mt-10 space-y-3">
+        <h2 className="text-xl font-semibold">The standard comes first — this is optional</h2>
+        <p className="rounded border border-neutral-800 bg-neutral-900/50 p-4 text-sm text-neutral-300">
+          Threat Cloud is an optional reference service operated by the ATR maintainers — not part
+          of the standard. The standard is the spec plus the MIT-licensed rules, fully usable
+          offline via npm / PyPI / raw YAML. Threat Cloud only adds hosted convenience (rule sync,
+          threat submission); the same outcomes are reachable without it.
+        </p>
+        <p>
+          Start with the open, offline path:{' '}
+          <code className="rounded bg-neutral-800 px-1">npm install agent-threat-rules</code>,{' '}
+          <code className="rounded bg-neutral-800 px-1">pip install pyatr</code>, or pull the raw
+          YAML rules directly. That path needs no key, no network at runtime, and no dependency on
+          any hosted service. This partner endpoint is one optional convenience layered on top.
+        </p>
+      </section>
 
       <section className="mt-10 space-y-3">
         <h2 className="text-xl font-semibold">Who this is for</h2>
         <p>
-          Security platforms, model vendors, and enterprise SOC teams that embed ATR rules into
-          their own detection stack and want to minimise npm-publish lag. For casual users,{' '}
+          Security platforms, model vendors, and enterprise SOC teams that already embed the ATR
+          rules into their own detection stack via npm / PyPI / YAML, and want to minimise
+          npm-publish lag on top of that. For most users, the offline{' '}
           <code className="rounded bg-neutral-800 px-1">npm install agent-threat-rules</code> or{' '}
-          <code className="rounded bg-neutral-800 px-1">pip install pyatr</code> is the right path.
+          <code className="rounded bg-neutral-800 px-1">pip install pyatr</code> path is the right
+          one — this endpoint is not required to use the standard.
         </p>
       </section>
 
@@ -116,10 +137,11 @@ done`}
       <section className="mt-10 space-y-3">
         <h2 className="text-xl font-semibold">Why this exists</h2>
         <p className="text-neutral-400">
-          npm publish cycles give ~10-minute latency from TC canary-pass to a released package.
-          That is fine for most. Partners that want to tie rule updates to their own deploy
-          cadence, or who cannot re-install npm packages on every flywheel cycle, use this
-          endpoint instead.
+          npm publish cycles give ~10-minute latency before a confirmed rule lands in a released
+          package. That is fine for most, and the offline npm / PyPI / YAML path remains the
+          canonical way to consume the standard. Partners that want to tie rule updates to their
+          own deploy cadence, or who cannot re-install npm packages on every cycle, can opt into
+          this hosted endpoint as a convenience — nothing here is exclusive to it.
         </p>
       </section>
     </main>

--- a/website/app/[locale]/partner-sync/page.tsx
+++ b/website/app/[locale]/partner-sync/page.tsx
@@ -68,7 +68,7 @@ Authorization: Bearer <partner-key>`}
       "tags": "..."
     }
   ],
-  "meta": { "total": 651, "etag": "W/\\"651-2026-06-14T00:00:00Z\\"" }
+  "meta": { "total": 652, "etag": "W/\\"652-2026-06-14T00:00:00Z\\"" }
 }`}
         </pre>
       </section>

--- a/website/app/[locale]/quality-standard/page.tsx
+++ b/website/app/[locale]/quality-standard/page.tsx
@@ -253,7 +253,7 @@ export default async function QualityStandardPage({
           readers know this document covers §RFC-001 of the spec family. */}
       <Reveal delay={0.25}>
         <div className="mb-6">
-          <DocumentStatus locale={locale} sectionHref="/rfc-001" />
+          <DocumentStatus locale={locale} sectionHref="/spec" />
         </div>
       </Reveal>
       <Reveal delay={0.3}>

--- a/website/app/[locale]/red-team/page.tsx
+++ b/website/app/[locale]/red-team/page.tsx
@@ -87,12 +87,12 @@ const RED_TEAM_TOOLS: RedTeamTool[] = [
   {
     name: "Microsoft PyRIT",
     org: "Microsoft AI Red Team",
-    status: "in-review",
+    status: "corpus",
     homepage: "https://github.com/microsoft/PyRIT",
     prUrl: "https://github.com/microsoft/PyRIT/pull/1715",
     hook: "The toolkit Microsoft uses internally to red-team production LLM products. Roman Lutz leads.",
     what_atr_did:
-      "Added an ATR dataset loader exposing the rule corpus as PyRIT attack sources. Roman reviewed within 2 min on first push; iterating on doc shape.",
+      "Added an ATR dataset loader exposing the rule corpus as PyRIT attack sources; PR #1715 merged 2026-05-27.",
   },
   {
     name: "HackAPrompt",

--- a/website/app/[locale]/research/page.tsx
+++ b/website/app/[locale]/research/page.tsx
@@ -411,11 +411,36 @@ export default async function ResearchPage({ params }: { params: Promise<{ local
               <>No external citations recorded yet. If your paper, technical report, or product documentation cites ATR, please let us know via <a href="https://github.com/Agent-Threat-Rule/agent-threat-rules/issues/new" target="_blank" rel="noopener noreferrer" className="text-blue hover:underline">GitHub issue</a>.</>
             )}
           </p>
-          <p className="text-xs text-mist mt-3 leading-[1.7]">
-            {locale === "zh"
-              ? "Cite as: Lin, Kuan-Hsin (2026). The Collapse of Trust. DOI: 10.5281/zenodo.19178002"
-              : "Cite as: Lin, Kuan-Hsin (2026). The Collapse of Trust. DOI: 10.5281/zenodo.19178002"}
-          </p>
+          <div className="mt-4 pt-4 border-t border-fog space-y-3">
+            <div>
+              <div className="font-data text-xs text-stone tracking-[2px] uppercase mb-1">
+                {locale === "zh" ? "引用此標準" : "Cite the standard"}
+              </div>
+              <p className="text-xs text-mist leading-[1.7]">
+                {locale === "zh"
+                  ? "Cite as: Agent Threat Rules (ATR) Project (2026). Agent Threat Rules: An open detection standard for AI agent threats. DOI: 10.5281/zenodo.19178002"
+                  : "Cite as: Agent Threat Rules (ATR) Project (2026). Agent Threat Rules: An open detection standard for AI agent threats. DOI: 10.5281/zenodo.19178002"}
+              </p>
+            </div>
+            <div>
+              <div className="font-data text-xs text-stone tracking-[2px] uppercase mb-1">
+                {locale === "zh" ? "原始論文" : "Originating paper"}
+              </div>
+              <p className="text-xs text-mist leading-[1.7]">
+                {locale === "zh"
+                  ? "Cite as: Lin, Kuan-Hsin (2026). The Collapse of Trust. DOI: 10.5281/zenodo.19178002"
+                  : "Cite as: Lin, Kuan-Hsin (2026). The Collapse of Trust. DOI: 10.5281/zenodo.19178002"}
+              </p>
+            </div>
+            <div className="flex flex-wrap gap-3 pt-1">
+              <a href={`/${locale}/citations`} className="font-data text-xs text-blue hover:underline">
+                {locale === "zh" ? "BibTeX / 引用格式" : "BibTeX / citation formats"} &rarr;
+              </a>
+              <a href="https://github.com/Agent-Threat-Rule/agent-threat-rules/blob/main/CITATION.cff" target="_blank" rel="noopener noreferrer" className="font-data text-xs text-blue hover:underline">
+                {locale === "zh" ? "機器可讀引用 (CITATION.cff)" : "Machine-readable citation (CITATION.cff)"}
+              </a>
+            </div>
+          </div>
         </div>
       </Reveal>
 

--- a/website/app/[locale]/sovereign-ai-defense/page.tsx
+++ b/website/app/[locale]/sovereign-ai-defense/page.tsx
@@ -403,22 +403,16 @@ atr migrate --source snort --input ./rules.snort --output ./atr-out`}</code>
             desc={zh ? "PR #33 已合併（2026-05-11）· 完整 ATR 規則集於 Norton/Avast/LifeLock 母集團的 Sage 風險評分層" : "PR #33 merged (2026-05-11) · Full ATR rule pack in the Sage risk-scoring layer under the Norton/Avast/LifeLock parent"}
           />
           <TractionRow
-            org="IBM"
-            status="Open PR"
-            statusClass="bg-ash text-stone"
-            desc={zh ? "mcp-context-forge · IBM MCP runtime ATR plugin" : "mcp-context-forge · ATR plugin for IBM MCP runtime"}
-          />
-          <TractionRow
             org="OWASP"
             status={zh ? "Review 中" : "Under Review"}
             statusClass="bg-ash text-stone"
-            desc={zh ? "LLM Top 10 官方專案 PR · 標準引用路徑" : "LLM Top 10 official project PR · standards-track reference"}
+            desc={zh ? "LLM Top 10 專案 PR · 審查中" : "PR to the LLM Top 10 project · under review"}
           />
         </div>
         <p className="text-xs md:text-sm text-stone mt-5">
           {zh
-            ? `0 → ${ruleCount} 條規則 · 2 個生產環境（Microsoft、Cisco）外加 Gen Digital Sage（已合併）· 標準同儕引用 · 20+ adopters 在 ADOPTERS.md · MIT 永久授權 · `
-            : `0 → ${ruleCount} rules · 2 in production (Microsoft, Cisco) plus Gen Digital Sage (merged) · peer-standard references · 20+ adopters in ADOPTERS.md · MIT licensed · `}
+            ? `0 → ${ruleCount} 條規則 · 2 個生產環境（Microsoft、Cisco）外加 Gen Digital Sage（已合併）· 標準同儕引用 · 完整採用者清單見 ADOPTERS.md · MIT 永久授權 · `
+            : `0 → ${ruleCount} rules · 2 in production (Microsoft, Cisco) plus Gen Digital Sage (merged) · peer-standard references · full adopter list in ADOPTERS.md · MIT licensed · `}
           <a href="https://doi.org/10.5281/zenodo.19178002" className="text-blue hover:underline">
             DOI 10.5281/zenodo.19178002
           </a>

--- a/website/app/[locale]/threats/page.tsx
+++ b/website/app/[locale]/threats/page.tsx
@@ -14,7 +14,7 @@ export function generateStaticParams() {
 export const metadata: Metadata = {
   title: "Threat Feed - ATR",
   description:
-    "Public blacklist of flagged AI agent skills. 1,302 flagged, 552 confirmed malware. Updated from ATR ecosystem scans and Threat Cloud reports.",
+    "Public blacklist of flagged AI agent skills. 1,302 flagged, 552 confirmed malware. Generated from open ATR ecosystem scans; Threat Cloud is an optional reference service that can also feed reports.",
 };
 
 interface BlacklistData {
@@ -271,8 +271,17 @@ export default async function ThreatsPage({ params }: { params: Promise<{ locale
       <Reveal delay={0.5}>
         <p className="text-xs text-mist mt-6 leading-[1.8] max-w-[480px]">
           {zh
-            ? <>此清單由 ATR 生態系掃描自動產生，<br className="sm:hidden" />並與 Threat Cloud 同步。<br />被標記不代表一定是惡意 — <br className="sm:hidden" />請查看具體規則判斷風險。<br />回報誤報：GitHub Issue。</>
-            : <>This list is generated from ATR ecosystem scans<br className="sm:hidden" /> and synced with Threat Cloud.<br />Being flagged does not guarantee malice — <br className="sm:hidden" />check the specific rules for risk assessment.<br />Report false positives via GitHub Issues.</>}
+            ? <>此清單由開放的 ATR 生態系掃描自動產生，<br className="sm:hidden" />並以 MIT 授權的規則為本體。<br />被標記不代表一定是惡意 — <br className="sm:hidden" />請查看具體規則判斷風險。<br />回報誤報：GitHub Issue。</>
+            : <>This list is generated from open ATR ecosystem scans,<br className="sm:hidden" /> built on the MIT-licensed rules.<br />Being flagged does not guarantee malice — <br className="sm:hidden" />check the specific rules for risk assessment.<br />Report false positives via GitHub Issues.</>}
+        </p>
+      </Reveal>
+
+      {/* Threat Cloud — optional reference service (not part of the standard) */}
+      <Reveal delay={0.55}>
+        <p className="text-xs text-mist mt-4 leading-[1.8] max-w-[480px]">
+          {zh
+            ? "Threat Cloud 是 ATR 維護者運營的選用參考服務，並非標準的一部分。標準本體是規格加上 MIT 授權的規則，透過 npm / PyPI / 純 YAML 完全可離線使用；Threat Cloud 只提供 hosted 便利（規則同步、威脅提交），不用它也能達到同樣結果。"
+            : "Threat Cloud is an optional reference service operated by the ATR maintainers — not part of the standard. The standard is the spec plus the MIT-licensed rules, fully usable offline via npm / PyPI / raw YAML. Threat Cloud only adds hosted convenience (rule sync, threat submission); the same outcomes are reachable without it."}
         </p>
       </Reveal>
     </div>

--- a/website/app/[locale]/threats/page.tsx
+++ b/website/app/[locale]/threats/page.tsx
@@ -188,8 +188,8 @@ export default async function ThreatsPage({ params }: { params: Promise<{ locale
           <Reveal delay={0.1}>
             <p className="text-sm text-graphite mb-6 max-w-[480px] leading-[1.8]">
               {zh
-                ? <>這些 skill 通過 ATR {stats.ruleCount} 條規則掃描，<br className="sm:hidden" />零 CRITICAL / HIGH 發現。<br />安全使用。</>
-                : <>These skills passed ATR&apos;s {stats.ruleCount}-rule scan<br className="sm:hidden" /> with zero CRITICAL / HIGH findings.<br />Safe to use.</>}
+                ? <>這些 skill 在最新一次 ATR {stats.ruleCount} 條規則掃描中,<br className="sm:hidden" />零 CRITICAL / HIGH 發現。</>
+                : <>These skills had zero CRITICAL / HIGH findings<br className="sm:hidden" /> in the latest ATR {stats.ruleCount}-rule scan.</>}
             </p>
           </Reveal>
           <Reveal delay={0.2}>

--- a/website/app/[locale]/wall/page.tsx
+++ b/website/app/[locale]/wall/page.tsx
@@ -181,7 +181,7 @@ export default async function WallPage({ params }: { params: Promise<{ locale: s
               desc: zh
                 ? "找到繞過 ATR 規則的方法？這是最有價值的貢獻。每個回報都讓規則更強。"
                 : "Found a way to bypass an ATR rule? This is the most valuable contribution. Every report makes the rules stronger.",
-              href: "https://github.com/Agent-Threat-Rule/agent-threat-rules/issues/new?template=evasion-report.md",
+              href: "https://github.com/Agent-Threat-Rule/agent-threat-rules/issues/new?template=evasion-report.yml",
               time: "15 min",
               impact: zh ? "最高" : "Highest",
             },
@@ -191,7 +191,7 @@ export default async function WallPage({ params }: { params: Promise<{ locale: s
               desc: zh
                 ? "ATR 規則標記了正常內容？回報幫助我們維持 99.7% 精準度。"
                 : "ATR rule flagged something benign? Your report helps maintain 99.7% precision.",
-              href: "https://github.com/Agent-Threat-Rule/agent-threat-rules/issues/new?template=false-positive.md",
+              href: "https://github.com/Agent-Threat-Rule/agent-threat-rules/issues/new?template=false-positive.yml",
               time: "20 min",
               impact: zh ? "高" : "High",
             },
@@ -212,7 +212,7 @@ export default async function WallPage({ params }: { params: Promise<{ locale: s
               desc: zh
                 ? "發現新的 AI agent 攻擊手法？在 Discussions 裡分享，可能會變成新規則。"
                 : "Found a new AI agent attack technique? Share it in Discussions. It may become a new rule.",
-              href: "https://github.com/Agent-Threat-Rule/agent-threat-rules/discussions/categories",
+              href: "https://github.com/Agent-Threat-Rule/agent-threat-rules/discussions",
               time: "10 min",
               impact: zh ? "中" : "Medium",
             },


### PR DESCRIPTION
A deep per-page audit (9 grouped agents that live-verified every flagged link and PR via gh/curl) found 29 issues. This PR fixes the objective ones; framing/positioning items are left for a follow-up decision.

Ecosystem source of truth (ADOPTERS.md):
- garak evidence #1276 (404) corrected to #1676
- NIST OSCAL #333 (closed) corrected to #338 (the open rework)
- aaif-goose/goose and SigmaHQ moved in-review to shipped (PRs are merged)
- removed IBM mcp-context-forge (#4109 closed), Portkey gateway (#1652 closed),
  Semgrep (no verifiable evidence), Puliczek/awesome-mcp-security (ATR not in
  their README). All four recorded in the Removed-entries section.

Dead / wrong links (every one verified 404 then 200 after fix):
- compliance: two GitHub paths corrected
- quality-standard: DocumentStatus anchor /rfc-001 to /spec
- wall: discussions URL + two issue-template extensions (.md to .yml)

Stale numbers:
- hades blog + partner-sync example: 651 to 652
- sovereign traction: dropped an unbacked "20+ adopters" count

Claim boundaries:
- sovereign: removed IBM traction row; reworded OWASP LLM Top 10 row
- red-team: Microsoft PyRIT in-review to merged (PR #1715)
- threats: replaced a "Safe to use" guarantee with the evidence-bounded
  observation (zero CRITICAL/HIGH findings in the latest scan)

Test plan
- [x] next build green, all 1376 static pages
- [x] every changed GitHub link re-verified live
- [ ] follow-up: vendor-neutral framing decisions (Threat Cloud surfacing,
      governance body language, machine-readable citation block)