### PR TITLE
Reconcile remaining minor inconsistencies from the site audit

### DIFF
--- a/website/app/[locale]/contribute/page.tsx
+++ b/website/app/[locale]/contribute/page.tsx
@@ -236,8 +236,8 @@ export default async function ContributePage({ params }: { params: Promise<{ loc
         <div className="border border-fog p-6 mb-12">
           <p className="text-sm text-stone leading-relaxed mb-3">
             {zh
-              ? "Spec(ATR-SPEC-v1)是所有相容引擎的契約。改動 spec 不像加規則那麼直接 — 流程是:先開 RFC issue 標題以 [RFC] 開頭,描述要改什麼、為什麼;留 7 天公開評論窗口讓所有 implementer 看到並回饋;接下來才接受 PR。Breaking change(SemVer 主版號)需要額外 30 天提前公告。"
-              : "The spec (ATR-SPEC-v1) is the contract between all conforming engines. Spec changes are not as direct as rule additions — the process is: open an RFC issue with title prefixed [RFC] describing what you want to change and why; leave a 7-day public comment window so every implementer sees it and can respond; then submit the PR. Breaking changes (SemVer major bump) require an additional 30-day advance notice."}
+              ? "Spec(ATR-SPEC-v1,目前 v3.0.0-alpha.1 Working Draft)是所有相容引擎的契約。改動 spec 不像加規則那麼直接 — 流程是:先開 RFC issue 標題以 [RFC] 開頭,描述要改什麼、為什麼;留 14 天公開評論窗口(複雜提案延長至 30 天)讓所有 implementer 看到並回饋;接下來才接受 PR。Breaking change(SemVer 主版號)需要額外 30 天提前公告。"
+              : "The spec (ATR-SPEC-v1, currently v3.0.0-alpha.1 Working Draft) is the contract between all conforming engines. Spec changes are not as direct as rule additions — the process is: open an RFC issue with title prefixed [RFC] describing what you want to change and why; leave a 14-day public comment window (extended to 30 for complex proposals) so every implementer sees it and can respond; then submit the PR. Breaking changes (SemVer major bump) require an additional 30-day advance notice."}
           </p>
           <p className="text-sm text-stone leading-relaxed mb-3">
             {zh

--- a/website/app/[locale]/red-team/page.tsx
+++ b/website/app/[locale]/red-team/page.tsx
@@ -186,7 +186,7 @@ const ATTRIBUTION_STATS: AttributionStat[] = [
     number: "0 FP",
     label: "Required across 3,551 benign samples",
     detail:
-      "6-check quality gate: own-TP must match + 1,784 benign + 157 research-mention + 1,611 cross-rule conflict-free + own true_negative coverage. Rules that fire on the paper describing the attack don't ship.",
+      "6-check quality gate: own-TP must match + 431 benign + 1,352 extended + 157 research-mention + 1,611 cross-rule conflict-free + own true_negative coverage. Rules that fire on the paper describing the attack don't ship.",
   },
 ];
 
@@ -495,8 +495,8 @@ export default async function RedTeamPage({
                   </p>
                   <p className="text-sm text-paper/60">
                     {zh
-                      ? "Gate = 自己 TP 必須 100% 命中 + 1,784 樣本 benign corpus 0 FP + 157 樣本 research-mention 0 FP + 跨規則 0 衝突。"
-                      : "Gate = your TPs must match 100% + 1,784-sample benign corpus 0 FP + 157-sample research-mention 0 FP + 0 cross-rule conflicts."}
+                      ? "Gate = 自己 TP 必須 100% 命中 + 1,783 樣本 benign+extended corpus 0 FP + 157 樣本 research-mention 0 FP + 跨規則 0 衝突。"
+                      : "Gate = your TPs must match 100% + 1,783-sample benign+extended corpus 0 FP + 157-sample research-mention 0 FP + 0 cross-rule conflicts."}
                   </p>
                 </div>
               </div>

--- a/website/app/[locale]/research/page.tsx
+++ b/website/app/[locale]/research/page.tsx
@@ -219,6 +219,7 @@ export default async function ResearchPage({ params }: { params: Promise<{ local
             </div>
           </div>
           <div className="bg-paper p-6">
+            {/* SKILL.md benchmark snapshot (v2.0.0, 498 samples): Layer A 24 + Layer C 8 = 32 malicious, both 100% detected. Pinned numbers — re-sync if the benchmark is re-run. */}
             <div className="font-data text-xs text-stone tracking-[2px] uppercase mb-4">
               {locale === "zh" ? "按攻擊層分析" : "By Attack Layer"}
             </div>


### PR DESCRIPTION
Final cleanup of the three low-severity items from the deep site audit.

- red-team: the "0 FP across 3,551 benign samples" gate breakdown now matches the
  authoritative terminal-demo decomposition (431 benign + 1,352 extended + 157
  research-mention + 1,611 cross-rule = 3,551).
- research: pinned the SKILL.md per-layer benchmark snapshot with a comment so it
  cannot silently drift.
- contribute: surfaced the current spec-document version (v3.0.0-alpha.1 Working
  Draft) and reconciled the spec comment window with the charter (7 -> 14 days).

next build green, all 1376 static pages.