### PR TITLE
fix: correct PINT benchmark corpus attribution in stats.json

### DIFF
--- a/stats.json
+++ b/stats.json
@@ -41,7 +41,7 @@
       "precision": 99.6,
       "fpRate": 0.25,
       "samples": 850,
-      "source": "Invariant Labs PINT adversarial corpus"
+      "source": "Self-built PINT-format corpus (deepset + Lakera Gandalf)"
     },
     "hackaprompt": {
       "recall": 66.2,


### PR DESCRIPTION
The `benchmarks.pint.source` field was mislabeled "Invariant Labs PINT adversarial corpus".

The 850-sample corpus is self-built from public datasets — deepset/prompt-injections + Lakera/gandalf_ignore_instructions (see `src/eval/pint-corpus.ts`). It is not an Invariant Labs benchmark, and not Lakera's official private PINT benchmark.

This aligns `stats.json` with `README.md` ("PINT-format (deepset + Lakera Gandalf)") and the corpus loader.

Change: one line in `stats.json`.
`"Invariant Labs PINT adversarial corpus"` -> `"Self-built PINT-format corpus (deepset + Lakera Gandalf)"`