### PR TITLE
docs: sync README, mapping docs, and website to v3.5.0 / 652 rules

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -3,7 +3,7 @@ message: "If you use ATR in academic work or security research, please cite it a
 title: "ATR: Agent Threat Rules — Open Detection Standard for AI Agent Threats"
 abstract: >
   ATR is an open-source detection rule set for AI agent threats, analogous to
-  Sigma for SIEM or YARA for malware. It provides 651 rules across 10 threat
+  Sigma for SIEM or YARA for malware. It provides 652 rules across 10 threat
   categories (prompt injection, tool poisoning, context exfiltration, skill
   compromise, model abuse, data poisoning, privilege escalation, excessive
   autonomy, model security), mapped to OWASP Agentic Top 10 (10/10), SAFE-MCP
@@ -20,8 +20,8 @@ authors:
 repository-code: "https://github.com/Agent-Threat-Rule/agent-threat-rules"
 url: "https://agentthreatrule.org"
 license: MIT
-version: "3.4.0"
-date-released: "2026-06-13"
+version: "3.5.0"
+date-released: "2026-06-16"
 identifiers:
   - type: doi
     value: "10.5281/zenodo.19178002"

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ AI Agent 威脅偵測規則的開放格式
 [![GitHub Marketplace](https://img.shields.io/badge/Marketplace-ATR%20Scan-2ea44f?style=flat-square&logo=github)](https://github.com/marketplace/actions/atr-scan)
 [![License: MIT](https://img.shields.io/badge/license-MIT-brightgreen?style=flat-square)](LICENSE)
 [![DOI](https://img.shields.io/badge/DOI-10.5281%2Fzenodo.19178002-blue?style=flat-square)](https://doi.org/10.5281/zenodo.19178002)
-[![Rules](https://img.shields.io/badge/rules-651-blue?style=flat-square)](#5-specification)
+[![Rules](https://img.shields.io/badge/rules-652-blue?style=flat-square)](#5-specification)
 [![Categories](https://img.shields.io/badge/categories-10-blue?style=flat-square)](#7-coverage)
 [![OWASP Agentic](https://img.shields.io/badge/OWASP_Agentic_Top_10-10%2F10-brightgreen?style=flat-square)](#7-coverage)
 [![SAFE-MCP](https://img.shields.io/badge/SAFE--MCP-91.8%25-brightgreen?style=flat-square)](#7-coverage)
@@ -46,7 +46,7 @@ ATR is publishing proposal-stage standardization scaffolding ahead of OASIS Open
 - [`certification/`](certification/) — proposed ATR-Certified™ program guide
 - [`engines/`](engines/) — Python and Go reference impl interface contracts (TypeScript is the existing engine at `src/`)
 
-**All scaffolding is tagged PROPOSED v1.0 / v2.0 and is NOT ratified.** The 9-seat TSC has not been formed. The trust marks are not registered. Existing v1.1 governance ([`GOVERNANCE.md`](GOVERNANCE.md)) continues to operate. The rule format, npm package, TypeScript engine API, and all 651 rules are unchanged — existing ecosystem integrations (Microsoft AGT, Cisco AI Defense, MISP CIRCL, OWASP A-S-R-H, precize, Sage) work without modification.
+**All scaffolding is tagged PROPOSED v1.0 / v2.0 and is NOT ratified.** The 9-seat TSC has not been formed. The trust marks are not registered. Existing v1.1 governance ([`GOVERNANCE.md`](GOVERNANCE.md)) continues to operate. The rule format, npm package, TypeScript engine API, and all 652 rules are unchanged — existing ecosystem integrations (Microsoft AGT, Cisco AI Defense, MISP CIRCL, OWASP A-S-R-H, precize, Sage) work without modification.
 
 See [`STANDARDIZATION-STATUS.md`](STANDARDIZATION-STATUS.md) for the full status matrix mapping every new artifact to `{STABLE IN PRODUCTION, PROPOSED, SKELETON, PRELIMINARY}` and timeline for OASIS submission, community comment, and ratification.
 
@@ -203,6 +203,18 @@ matches = engine.evaluate(AgentEvent(content="...", event_type="llm_input"))
 | MCP server | Live integration with Claude Code, Cursor, Windsurf, and other MCP clients |
 | Splunk / Elastic export | SIEM rule pack for runtime detection |
 
+### Detection lanes (v3.5.0)
+
+Each rule carries a maturity-driven **lane**, so a consumer can trade recall for precision instead of running every rule at one fixed threshold:
+
+| Lane | Fires | Intended use | FP on a 65K-sample benign gate |
+|---|---|---|---:|
+| `enforce` | `stable` rules behind an embedding `confirm` guard | Auto-block | ~0.24% |
+| `alert` | `stable` + `test` | Analyst / correlation | — |
+| `hunt` | all rules except `deprecated` | Advisory / eval (**default**) | ~9% |
+
+Lanes are opt-in and fully backward-compatible: the default is `hunt`, so existing integrations behave exactly as before. Selecting `enforce` raises precision by firing only the most mature rules — and therefore catches fewer attacks. Report false-positive rates lane-keyed (`enforce` ~0.24% / `hunt` ~9% on the 65K-sample benign gate), not as a single overall figure. That gate is a separate corpus from the per-source measurements in [§8 Evaluation](#8-evaluation).
+
 ## 5. Specification
 
 | Artifact | Path | Purpose |
@@ -294,7 +306,7 @@ ATR maps its rules onto established frameworks so adopters can answer "we deploy
 
 | Framework | Coverage | Mapping document |
 |---|---|---|
-| [OWASP Agentic Top 10 (2026)](https://genai.owasp.org/resource/owasp-top-10-for-agentic-applications-for-2026/) | 10/10 categories, 488 mappings across 403 tagged rules | [docs/OWASP-AGENTIC-MAPPING.md](docs/OWASP-AGENTIC-MAPPING.md) |
+| [OWASP Agentic Top 10 (2026)](https://genai.owasp.org/resource/owasp-top-10-for-agentic-applications-for-2026/) | 10/10 categories, 866 mappings across 652 tagged rules | [docs/OWASP-AGENTIC-MAPPING.md](docs/OWASP-AGENTIC-MAPPING.md) |
 | [SAFE-MCP (OpenSSF)](https://github.com/safe-agentic-framework/safe-mcp) | 78/85 techniques (91.8%) | [docs/SAFE-MCP-MAPPING.md](docs/SAFE-MCP-MAPPING.md) |
 | [OWASP LLM Top 10 (2025)](https://owasp.org/www-project-top-10-for-large-language-model-applications/) | Per-rule references | Per-rule `references.owasp_llm` field |
 | [MITRE ATLAS](https://atlas.mitre.org/) | Per-rule references | Per-rule `references.mitre_atlas` field |
@@ -308,14 +320,14 @@ ATR maps its rules onto established frameworks so adopters can answer "we deploy
 | Prompt Injection | 223 | Instruction override, persona hijacking, encoded payloads (base-N, ROT, Unicode tags, zalgo, ecoji), CJK attacks, latent injection, glitch tokens, leakreplay |
 | Agent Manipulation | 106 | DAN family, AutoDAN, DanInTheWild, tense framing, grandma roleplay, doctor-XML puppetry, goal hijacking, Sybil consensus, lambda+eval RCE |
 | Skill Compromise | 45 | Typosquatting, context poisoning, subcommand overflow, rug pull, supply-chain attacks, credential-exfil combos, HuggingFace unsafe artifacts |
-| Context Exfiltration | 103 | API-key generation/completion, system-prompt theft, credential harvesting, env-var exfil, markdown-URL exfil, XSS in tool response, cross-user memory leakage |
+| Context Exfiltration | 104 | API-key generation/completion, system-prompt theft, credential harvesting, env-var exfil, markdown-URL exfil, XSS in tool response, cross-user memory leakage |
 | Tool Poisoning | 65 | Malicious MCP responses, consent bypass, hidden LLM instructions, schema contradictions, ANSI escape elicitation, vector-store filter injection |
 | Privilege Escalation | 35 | Scope creep, delayed execution bypass, admin function access, shell escape, SQL injection in admin endpoints, autostart file write |
 | Model Abuse | 37 | Malware code generation (malwaregen), EICAR/GTUBE signatures, AV-evasion gen |
 | Excessive Autonomy | 29 | Runaway loops, resource exhaustion, unauthorized financial actions |
 | Model Security | 3 | Behavior extraction, malicious fine-tuning data |
 | Data Poisoning | 5 | RAG / knowledge-base tampering, memory manipulation, persistence-aware override |
-| **Total** | **651** |  |
+| **Total** | **652** |  |
 
 ### CVE coverage (selected)
 

--- a/data/stats.json
+++ b/data/stats.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.1.1",
+  "version": "3.5.0",
   "generatedAt": "2026-06-01T05:01:56.657Z",
   "rules": {
     "total": 652,

--- a/docs/ETSI-TS-104223-MAPPING.md
+++ b/docs/ETSI-TS-104223-MAPPING.md
@@ -4,7 +4,7 @@ Version: 0.1.0 (INTERNAL DRAFT — not published)
 Status: Draft alignment mapping for ETSI TS 104 223 V1.1.1 and the UK NCSC/DSIT AI Cyber Security Code of Practice
 Date: 2026-06-12
 Editor: Adam Lin (林冠辛) <adam@agentthreatrule.org>
-Mapped corpus: Agent Threat Rules v3.3.1 (over 640 rules / 10 categories; disk == data/stats.json on 2026-06-12)
+Mapped corpus: Agent Threat Rules v3.5.0 (652 rules / 10 categories; disk == data/stats.json on 2026-06-16)
 Reference frameworks:
   - ETSI TS 104 223 V1.1.1 (2025-04) "Securing Artificial Intelligence (SAI); Baseline Cyber Security Requirements for AI Models and Systems"
   - UK AI Cyber Security Code of Practice (DSIT / NCSC), "Code of practice for the cyber security of AI"

--- a/docs/FINOS-AI-GOVERNANCE-MAPPING.md
+++ b/docs/FINOS-AI-GOVERNANCE-MAPPING.md
@@ -4,7 +4,7 @@ Version: 0.1.0 (INTERNAL DRAFT — not published, not submitted)
 Status: Draft for future FINOS AI Governance Framework Informative Reference / PR basis (human review gate before any upstream submission)
 Date: 2026-06-12
 Editor: Adam Lin (林冠辛) <adam@agentthreatrule.org>
-Mapped corpus: Agent Threat Rules v3.1.x (over 640 rules / 10 categories, disk==stats.json verified 2026-06-12)
+Mapped corpus: Agent Threat Rules v3.5.0 (652 rules / 10 categories, disk==stats.json verified 2026-06-16)
 Reference framework: FINOS AI Governance Framework v2 (published 2025-10-20), Risk Catalogue
 Reference framework license: CC-BY-4.0 (finos/ai-governance-framework). Risk and
 mitigation text quoted below is reproduced under that license.

--- a/docs/FIVE-EYES-MAPPING.md
+++ b/docs/FIVE-EYES-MAPPING.md
@@ -1,6 +1,6 @@
 # ATR → Five Eyes "Careful Adoption of Agentic AI Services" Mapping
 
-- **ATR corpus version:** v3.1.1, 651 rules across 10 detection-rule categories
+- **ATR corpus version:** v3.5.0, 652 rules across 10 detection-rule categories
 - **Five Eyes guidance:** "Careful Adoption of Agentic AI Services", published 2026-04-30 on media.defense.gov, jointly authored by CISA (US) + NSA (US) + ASD-ACSC (Australia) + CCCS (Canada) + NCSC-UK + NCSC-NZ
 - **Document date:** 2026-06-05
 - **Maintainer:** Adam Lin (adam@agentthreatrule.org)
@@ -18,7 +18,7 @@ The Five Eyes joint guidance ships 5 named risk categories (Privilege, Design an
 
 The guidance's recommended response is to "Strengthen collaboration between stakeholders to keep pace with evolving threats to agentic AI systems" and "Coordinate with major AI developers and government organisations to compile and maintain threat information."
 
-ATR v3.1.1 ships 462 rules with 6-framework compliance metadata (OWASP Agentic Top 10 + OWASP LLM Top 10 + MITRE ATLAS + NIST AI RMF + EU AI Act + ISO/IEC 42001) and is already merged into Microsoft Agent Governance Toolkit (PR #1277 / 287-rule weekly auto-sync + PR #908 + #1981 the copilot-swe-agent regression-test loop), Microsoft PyRIT (PR #1715 merged 2026-05-27 by Roman Lutz), Cisco AI Defense skill-scanner (PR #99 / 314 rules), MISP via CIRCL Luxembourg (galaxy PR #1207 / 336 rules + taxonomies PR #323), and precize/Agentic-AI-Top10-Vulnerability (third-party community repo, PR #14 + #18). This document maps each Five Eyes category to specific ATR rule clusters and is honest about what ATR does not cover.
+ATR v3.5.0 ships 652 rules with 6-framework compliance metadata (OWASP Agentic Top 10 + OWASP LLM Top 10 + MITRE ATLAS + NIST AI RMF + EU AI Act + ISO/IEC 42001) and is already merged into Microsoft Agent Governance Toolkit (PR #1277 / 287-rule weekly auto-sync + PR #908 + #1981 the copilot-swe-agent regression-test loop), Microsoft PyRIT (PR #1715 merged 2026-05-27 by Roman Lutz), Cisco AI Defense skill-scanner (PR #99 / 314 rules), MISP via CIRCL Luxembourg (galaxy PR #1207 / 336 rules + taxonomies PR #323), and precize/Agentic-AI-Top10-Vulnerability (third-party community repo, PR #14 + #18). This document maps each Five Eyes category to specific ATR rule clusters and is honest about what ATR does not cover.
 
 The mapping does not claim Five Eyes endorsement of ATR. It is provided as a community detection-rule starter set for operators implementing the guidance.
 
@@ -245,6 +245,6 @@ This is exactly the position ATR occupies. ATR is the open, MIT-licensed, agenti
 - [x] 5-category section headings confirmed verbatim: "Privilege risks", "Design and configuration risks", "Behaviour risks", "Structural risks", "Accountability risks" (British spelling).
 - [x] Per-category descriptions replaced with verbatim quotes from the PDF.
 - [x] "Defend against future risks → Expand threat intelligence through collaboration" section quoted verbatim (highest-leverage hook for ATR).
-- [x] Rule-ID list pinned to v3.1.1 / 462 rules / 2026-06-05.
+- [x] Rule-ID list pinned to v3.5.0 / 652 rules / 2026-06-16.
 - [ ] Generate auto-`docs/five-eyes-mapping.json` from this markdown (mapping script pending).
 - [ ] Have a second reviewer sanity-check the strength rating (STRONG / MODERATE / LIMITED) per category.

--- a/docs/MITRE-ATLAS-MAPPING.md
+++ b/docs/MITRE-ATLAS-MAPPING.md
@@ -4,7 +4,7 @@ Version: 0.1.0 (INTERNAL DRAFT — not published)
 Status: Draft alignment mapping for MITRE ATLAS v5.6.0
 Date: 2026-06-14
 Editor: Adam Lin (林冠辛) <adam@agentthreatrule.org>
-Mapped corpus: Agent Threat Rules (over 650 rules / 10 categories; disk == data/stats.json reconciled 2026-06-14)
+Mapped corpus: Agent Threat Rules v3.5.0 (652 rules / 10 categories; disk == data/stats.json reconciled 2026-06-16)
 Reference framework: MITRE ATLAS (Adversarial Threat Landscape for Artificial-Intelligence Systems), `dist/ATLAS.yaml` on mitre-atlas/atlas-data, v5.6.0 — 16 tactics, 101 top-level techniques (271 including sub-techniques), counted from the full machine-readable `dist/ATLAS.yaml`.
 
 ---

--- a/docs/OWASP-AGENTIC-MAPPING.md
+++ b/docs/OWASP-AGENTIC-MAPPING.md
@@ -1,7 +1,7 @@
 # ATR -> OWASP Agentic Top 10 (2026) Mapping
 
 Last updated: 2026-06-14
-ATR version: v3.4.0 (652 rules with OWASP Agentic tags)
+ATR version: v3.5.0 (652 rules with OWASP Agentic tags)
 OWASP framework: Agentic Top 10 v1.0 (December 2025)
 
 ## Summary
@@ -9,7 +9,7 @@ OWASP framework: Agentic Top 10 v1.0 (December 2025)
 - Categories covered: **10/10**
 - Total rule -> category mappings: **866**
 - Tagged ATR rules: **652** of 652 total rules in repo
-- ATR version: `v3.4.0` -- OWASP Agentic Top 10: `v1.0 (December 2025)`
+- ATR version: `v3.5.0` -- OWASP Agentic Top 10: `v1.0 (December 2025)`
 
 Strength tiers: **STRONG** >= 8 rules · **MODERATE** 4-7 rules · **LIMITED** 1-3 rules.
 

--- a/docs/OWASP-AGENTIC-MATURITY-MAPPING.md
+++ b/docs/OWASP-AGENTIC-MATURITY-MAPPING.md
@@ -4,7 +4,7 @@ Version: 0.1.0 (INTERNAL DRAFT — not published)
 Status: Draft alignment note for the OWASP Agentic adoption maturity model
 Date: 2026-06-14
 Editor: Adam Lin (林冠辛) <adam@agentthreatrule.org>
-Mapped corpus: Agent Threat Rules (650+ rules / 10 categories)
+Mapped corpus: Agent Threat Rules v3.5.0 (652 rules / 10 categories)
 Reference: "State of Agentic AI Security and Governance" (v2.01), OWASP GenAI Security Project, June 2026 — https://genai.owasp.org/resource/state-of-agentic-ai-security-and-governance/
 
 ---

--- a/docs/OWASP-AISVS-MAPPING.md
+++ b/docs/OWASP-AISVS-MAPPING.md
@@ -4,7 +4,7 @@ Version: 0.1.0 (INTERNAL DRAFT — not published, not submitted)
 Status: Draft for future OWASP AISVS Informative Reference / PR basis (human review gate before any upstream submission)
 Date: 2026-06-12
 Editor: Adam Lin (林冠辛) <adam@agentthreatrule.org>
-Mapped corpus: Agent Threat Rules v3.1.x (over 640 rules / 10 categories, disk==stats.json verified 2026-06-12)
+Mapped corpus: Agent Threat Rules v3.5.0 (652 rules / 10 categories, disk==stats.json verified 2026-06-16)
 Reference framework: OWASP AI Security Verification Standard (AISVS) 1.0, chapters C9, C10, C13
 Reference framework license: CC BY-SA 4.0 (OWASP/AISVS README). Requirement text
 quoted below is reproduced under that license; this mapping is a derivative

--- a/docs/OWASP-AST10-MAPPING.md
+++ b/docs/OWASP-AST10-MAPPING.md
@@ -1,7 +1,7 @@
 # ATR → OWASP Agentic Skills Top 10 (AST10) Mapping
 
 Last updated: 2026-06-06 (header refreshed)
-ATR corpus: v3.1.1, 651 rules (10 categories, including skill-compromise)
+ATR corpus: v3.5.0, 652 rules (10 categories, including skill-compromise)
 OWASP framework: Agentic Skills Top 10 (AST10), March 2026
 
 > Coverage note: the per-category ATR rule citations below were last fully

--- a/docs/SAFE-MCP-MAPPING.md
+++ b/docs/SAFE-MCP-MAPPING.md
@@ -1,7 +1,7 @@
 # ATR → SAFE-MCP Technique Mapping
 
 Last updated: 2026-06-06 (header refreshed)
-ATR corpus: v3.1.1, 651 rules (10 categories)
+ATR corpus: v3.5.0, 652 rules (10 categories)
 SAFE-MCP version: latest (85 techniques, 47 mitigations)
 
 > Coverage note: the per-technique ATR rule citations in this document were last

--- a/docs/owasp-agentic-mapping.json
+++ b/docs/owasp-agentic-mapping.json
@@ -1,6 +1,6 @@
 {
   "generated_at": "2026-06-14",
-  "atr_version": "v3.4.0",
+  "atr_version": "v3.5.0",
   "owasp_agentic_version": "v1.0 (December 2025)",
   "total_rules_in_repo": 652,
   "total_tagged_rules": 652,

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "agent-threat-rules",
   "version": "3.5.0",
   "type": "module",
-  "description": "Open detection standard -- like Sigma, but for AI agents. 651 rules for prompt injection, tool poisoning, context exfiltration, and MCP attacks. Shipped in Cisco AI Defense. 98% recall on NVIDIA garak.",
+  "description": "Open detection standard -- like Sigma, but for AI agents. 652 rules for prompt injection, tool poisoning, context exfiltration, and MCP attacks. Shipped in Cisco AI Defense. 98% recall on NVIDIA garak.",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "bin": {

--- a/spec/mappings/atr-to-nist-csf-2.0.md
+++ b/spec/mappings/atr-to-nist-csf-2.0.md
@@ -4,7 +4,7 @@ Version: 1.1.0
 Status: Draft for NIST IR 8596 Informative Reference submission
 Date: 2026-06-14
 Editor: Adam Lin (林冠辛) <adam@agentthreatrule.org>
-Mapped corpus: Agent Threat Rules v3.4.0 (651 rules / 10 categories; per data/stats.json 2026-06-14)
+Mapped corpus: Agent Threat Rules v3.5.0 (652 rules / 10 categories; per data/stats.json 2026-06-16)
 Reference framework: NIST CSF 2.0 (NIST CSWP 29, February 2024)
 
 ---

--- a/stats.json
+++ b/stats.json
@@ -1,14 +1,14 @@
 {
   "$comment": "Single source of truth for ATR project numbers. Any user-facing surface (README, CITATION.cff, panguard.ai, docs site, schema.org JSON-LD, Zenodo metadata) MUST read from this file via scripts/sync-stats.ts. Hand-edits to derived files will be overwritten on next sync. Bump version + ruleCount here, then run `npm run sync:stats`. CI does this automatically on rules-merge release. ruleCount.total counts files matching `^id: ATR-` (excludes drafts/templates); CI in publish-on-rules-merge.yml uses the identical method to avoid drift.",
-  "version": "3.4.0",
-  "previousVersion": "3.3.1",
-  "lastUpdated": "2026-06-13",
+  "version": "3.5.0",
+  "previousVersion": "3.4.0",
+  "lastUpdated": "2026-06-16",
   "ruleCount": {
-    "total": 651,
+    "total": 652,
     "stable": 59,
     "experimental": 554,
     "draft": 37,
-    "deprecated": 1,
+    "deprecated": 2,
     "comment": "total = stable + experimental + draft + deprecated. Validated by `find rules -name '*.yaml' -type f -exec grep -l '^id: ATR-' {} \\;` in scripts/sync-stats.ts. Status breakdown counted via `grep -rh '^status:' rules/ --include='*.yaml' | sort | uniq -c` (handles both quoted and unquoted YAML strings)."
   },
   "spec": {

--- a/website/app/[locale]/about/page.tsx
+++ b/website/app/[locale]/about/page.tsx
@@ -157,8 +157,8 @@ const MILESTONES: Milestone[] = [
   {
     date: "2026-06",
     title: {
-      en: "v3.4.0 · 652 rules across 10 categories",
-      zh: "v3.4.0 · 652 條規則,跨 10 個類別",
+      en: "v3.5.0 · 652 rules across 10 categories",
+      zh: "v3.5.0 · 652 條規則,跨 10 個類別",
     },
     detail: {
       en: "Current release line: 652 detection rules across 10 categories, specification 3.0.0-alpha.1 (Working Draft).",

--- a/website/app/[locale]/blog/five-eyes-supply-chain/page.tsx
+++ b/website/app/[locale]/blog/five-eyes-supply-chain/page.tsx
@@ -96,7 +96,7 @@ export default async function FiveEyesPostPage({
 
           <h2 className="font-display text-xl font-bold text-ink pt-4">跑起來</h2>
           <pre className="bg-ink text-paper font-data text-[13px] p-4 overflow-x-auto">
-            <code>npm install -g agent-threat-rules@3.4.0{"\n"}npx agent-threat-rules scan .</code>
+            <code>npm install -g agent-threat-rules@3.5.0{"\n"}npx agent-threat-rules scan .</code>
           </pre>
           <p>
             指向你的 skill 目錄或 MCP 設定。如果它標記了一個你沒寫的元件，把它當成不可信，
@@ -183,7 +183,7 @@ export default async function FiveEyesPostPage({
 
           <h2 className="font-display text-xl font-bold text-ink pt-4">Run it</h2>
           <pre className="bg-ink text-paper font-data text-[13px] p-4 overflow-x-auto">
-            <code>npm install -g agent-threat-rules@3.4.0{"\n"}npx agent-threat-rules scan .</code>
+            <code>npm install -g agent-threat-rules@3.5.0{"\n"}npx agent-threat-rules scan .</code>
           </pre>
           <p>
             Point it at your skill directory or MCP config. If it flags a component you did not

--- a/website/app/[locale]/blog/hades-credential-theft/page.tsx
+++ b/website/app/[locale]/blog/hades-credential-theft/page.tsx
@@ -97,7 +97,7 @@ export default async function HadesPostPage({
 
           <h2 className="font-display text-xl font-bold text-ink pt-4">跑起來</h2>
           <pre className="bg-ink text-paper font-data text-[13px] p-4 overflow-x-auto">
-            <code>npm install -g agent-threat-rules@3.4.0{"\n"}npx agent-threat-rules scan .</code>
+            <code>npm install -g agent-threat-rules@3.5.0{"\n"}npx agent-threat-rules scan .</code>
           </pre>
           <p>
             如果它標記了一個你沒寫的套件或檔案，把整個 checkout 當成已被入侵。
@@ -183,7 +183,7 @@ export default async function HadesPostPage({
 
           <h2 className="font-display text-xl font-bold text-ink pt-4">Run it</h2>
           <pre className="bg-ink text-paper font-data text-[13px] p-4 overflow-x-auto">
-            <code>npm install -g agent-threat-rules@3.4.0{"\n"}npx agent-threat-rules scan .</code>
+            <code>npm install -g agent-threat-rules@3.5.0{"\n"}npx agent-threat-rules scan .</code>
           </pre>
           <p>
             If it flags a package or a file you did not write, treat the checkout as compromised.

--- a/website/app/[locale]/compliance/nist-ai-rmf/page.tsx
+++ b/website/app/[locale]/compliance/nist-ai-rmf/page.tsx
@@ -416,7 +416,7 @@ export default async function NistAiRmfPage({
           />
           <CTACard
             num="NPM"
-            head={zh ? "v3.4.0 已發布" : "v3.4.0 published"}
+            head={zh ? "v3.5.0 已發布" : "v3.5.0 published"}
             body="npm install agent-threat-rules"
             href="https://www.npmjs.com/package/agent-threat-rules"
           />

--- a/website/app/[locale]/page.tsx
+++ b/website/app/[locale]/page.tsx
@@ -517,8 +517,8 @@ export default async function Home({ params }: { params: Promise<{ locale: strin
           <Reveal delay={0.15}>
             <p className="text-sm md:text-base text-graphite font-light max-w-[640px] mb-6 md:mb-8 leading-[1.8] text-pretty">
               {zh
-                ? <>紅隊大掃描飛輪與 CVE 匯入飛輪每天運轉:新攻擊被語義層抓到後,「結晶」成 regex 規則回流標準——從每次 500ms 的推理,變成 5ms 的 pattern match。自動結晶化把標準從 462 條長到 {stats.ruleCount} 條,全部隨 npm <span className="font-data text-graphite">agent-threat-rules@3.4.0</span> 發布。</>
-                : <>A red-team mega-scan flywheel and a CVE-ingestion flywheel run daily: when the semantic layer catches a novel attack, it crystallizes into a regex rule and flows back into the standard — turning a 500ms inference into a 5ms pattern match. Auto-crystallization grew the standard from 462 to {stats.ruleCount} rules, all shipped in npm <span className="font-data text-graphite">agent-threat-rules@3.4.0</span>.</>}
+                ? <>紅隊大掃描飛輪與 CVE 匯入飛輪每天運轉:新攻擊被語義層抓到後,「結晶」成 regex 規則回流標準——從每次 500ms 的推理,變成 5ms 的 pattern match。自動結晶化把標準從 462 條長到 {stats.ruleCount} 條,全部隨 npm <span className="font-data text-graphite">agent-threat-rules@3.5.0</span> 發布。</>
+                : <>A red-team mega-scan flywheel and a CVE-ingestion flywheel run daily: when the semantic layer catches a novel attack, it crystallizes into a regex rule and flows back into the standard — turning a 500ms inference into a 5ms pattern match. Auto-crystallization grew the standard from 462 to {stats.ruleCount} rules, all shipped in npm <span className="font-data text-graphite">agent-threat-rules@3.5.0</span>.</>}
             </p>
           </Reveal>
 

--- a/website/app/[locale]/quality-standard/page.tsx
+++ b/website/app/[locale]/quality-standard/page.tsx
@@ -272,7 +272,7 @@ export default async function QualityStandardPage({
             rel="noopener noreferrer"
             className="font-data text-xs text-stone hover:text-ink transition-colors border border-fog px-4 py-2.5 rounded-sm"
           >
-            npm install agent-threat-rules@3.4.0
+            npm install agent-threat-rules@3.5.0
           </a>
         </div>
       </Reveal>
@@ -791,7 +791,7 @@ export default async function QualityStandardPage({
             </span>
           </div>
           <pre className="font-data text-xs md:text-sm text-ink p-5 overflow-x-auto">
-            npm install agent-threat-rules@3.4.0
+            npm install agent-threat-rules@3.5.0
           </pre>
         </div>
       </Reveal>

--- a/website/app/[locale]/red-team/page.tsx
+++ b/website/app/[locale]/red-team/page.tsx
@@ -684,8 +684,8 @@ export default async function RedTeamPage({
           </p>
           <p className="text-base text-stone font-light max-w-[640px] mb-10">
             {zh
-              ? `這個流程現在每天跑：紅隊巨量掃描與 CVE 攝取兩條飛輪都已跑完整輪，並轉為每日更新。新發現自動結晶成規則，把標準從 462 條推進到目前的 ${stats.ruleCount} 條（npm agent-threat-rules@3.4.0，2026-06-13 發布）。`
-              : `This pipeline now runs daily: a red-team mega-scan flywheel and a CVE-ingestion flywheel have each completed a full sweep and moved to daily updates. New findings auto-crystallize into rules, growing the standard from 462 to the current ${stats.ruleCount} (npm agent-threat-rules@3.4.0, published 2026-06-13).`}
+              ? `這個流程現在每天跑：紅隊巨量掃描與 CVE 攝取兩條飛輪都已跑完整輪，並轉為每日更新。新發現自動結晶成規則，把標準從 462 條推進到目前的 ${stats.ruleCount} 條（npm agent-threat-rules@3.5.0，2026-06-16 發布）。`
+              : `This pipeline now runs daily: a red-team mega-scan flywheel and a CVE-ingestion flywheel have each completed a full sweep and moved to daily updates. New findings auto-crystallize into rules, growing the standard from 462 to the current ${stats.ruleCount} (npm agent-threat-rules@3.5.0, published 2026-06-16).`}
           </p>
         </Reveal>
         <Reveal delay={0.1}>

--- a/website/app/[locale]/research/page.tsx
+++ b/website/app/[locale]/research/page.tsx
@@ -309,8 +309,8 @@ export default async function ResearchPage({ params }: { params: Promise<{ local
       <Reveal delay={0.15}>
         <p className="text-sm text-graphite leading-[1.7] mb-6 max-w-[760px]">
           {locale === "zh"
-            ? `這個掃描現在是活的：紅隊巨量掃描與 CVE 攝取兩條飛輪都已跑完整輪，並轉為每日更新。新發現會自動結晶成偵測規則回流 ATR，把標準從 462 條推進到目前的 ${stats.ruleCount} 條（npm agent-threat-rules@3.4.0，2026-06-13 發布）。`
-            : `This scan is now a live loop: a red-team mega-scan flywheel and a CVE-ingestion flywheel have each run a full sweep and are moving to daily updates. New findings auto-crystallize into detection rules that flow back into ATR, growing the standard from 462 to the current ${stats.ruleCount} (npm agent-threat-rules@3.4.0, published 2026-06-13).`}
+            ? `這個掃描現在是活的：紅隊巨量掃描與 CVE 攝取兩條飛輪都已跑完整輪，並轉為每日更新。新發現會自動結晶成偵測規則回流 ATR，把標準從 462 條推進到目前的 ${stats.ruleCount} 條（npm agent-threat-rules@3.5.0，2026-06-16 發布）。`
+            : `This scan is now a live loop: a red-team mega-scan flywheel and a CVE-ingestion flywheel have each run a full sweep and are moving to daily updates. New findings auto-crystallize into detection rules that flow back into ATR, growing the standard from 462 to the current ${stats.ruleCount} (npm agent-threat-rules@3.5.0, published 2026-06-16).`}
         </p>
       </Reveal>
       <Reveal delay={0.2}>

--- a/website/public/og-image.svg
+++ b/website/public/og-image.svg
@@ -30,7 +30,7 @@
 
   <!-- Stats bar -->
   <text x="80" y="400" font-family="ui-monospace, monospace" font-size="16" fill="#6B6B76" letter-spacing="2">
-    <tspan>651 RULES</tspan>
+    <tspan>652 RULES</tspan>
     <tspan dx="30">96K SCANNED</tspan>
     <tspan dx="30">751 MALWARE</tspan>
     <tspan dx="30">CISCO SHIPPED</tspan>


### PR DESCRIPTION
Sync every user-facing surface to the published v3.5.0 / 652-rule release.

v3.5.0 shipped the engine changes (detection lanes + confirm field) but the docs, mapping files, and website were left on stale numbers (651 / v3.4.0 / v3.1.1). This PR reconciles them. No rule files changed.

Changes
- stats.json + data/stats.json: 3.5.0 / 652 rules (deprecated 1 -> 2)
- README: rules badge 651 -> 652; coverage table (Context Exfiltration 103 -> 104, Total 652); OWASP Agentic stat 488/403 -> 866/652 tagged (from docs/owasp-agentic-mapping.json); new "Detection lanes" section
- CITATION.cff + package.json description: 652 rules / 3.5.0 / 2026-06-16
- mapping docs (Five Eyes, ETSI, FINOS, OWASP AISVS/Agentic/Maturity, MITRE ATLAS, NIST CSF): corpus -> v3.5.0 / 652
- website: 8 npm @3.4.0 -> @3.5.0 strings, about/nist captions, og-image 651 -> 652 RULES

Mapping coverage verified before publish
- 6 CI-gated per-rule frameworks (owasp_agentic, owasp_llm, mitre_atlas, eu_ai_act, nist_ai_rmf, iso_42001) at 652/652 = 100% (validate.yml --require-full enforces this on every PR, so new rules cannot ship without mappings)
- narrative mapping docs: 0 dangling rule references against the 652 corpus

Detection-lanes wording follows the v3.5.0 honesty doctrine: default is hunt (~9% FP), enforce (~0.24%) is opt-in and trades recall, and FP is reported lane-keyed rather than as a single overall figure.