### PR TITLE
ci(measure-all): add weekly schedule so benchmarks don't go stale

### DIFF
--- a/.github/workflows/measure-all.yml
+++ b/.github/workflows/measure-all.yml
@@ -24,6 +24,13 @@ on:
         default: "all"
   release:
     types: [published]
+  schedule:
+    # Weekly safety net so the public-facing recall numbers don't silently
+    # drift between releases. Releases can be infrequent (publish-on-rules-merge
+    # only auto-publishes Threat-Cloud-crystallized commits, so human-authored
+    # rule work doesn't trigger a release), which previously let the benchmarks
+    # go stale by several minor versions. Sunday 06:00 UTC.
+    - cron: "0 6 * * 0"
 
 permissions:
   contents: write


### PR DESCRIPTION
## Why

`measure-all.yml` (the benchmark flywheel) only triggered on `workflow_dispatch` and `release: published`. But `publish-on-rules-merge.yml` only auto-publishes commits from the Threat-Cloud crystallize bot (`bot@agentthreatrule.org` / "crystallized rules from Threat Cloud"); human-authored rule merges (the actual majority — all recent `rules/**` commits are `adam@agentthreatrule.org` / `imadam4real@gmail.com`) skip publish and never cut a release.

Net effect: the version-pinned benchmark measurements never refreshed, so the public recall numbers sat on **3.0.0** while the live corpus moved to **3.5.0 / 652 rules** — exactly the drift that required a full manual re-measure.

## Change

Add a **weekly cron** (Sun 06:00 UTC) to `measure-all.yml` as a safety net so the measurements refresh on their own regardless of release cadence. Still cheap relative to its value (the full sweep is ~10–20 min, once a week).

## Not changed (deliberate)

`publish-on-rules-merge`'s author/message gate is left as-is — auto-patch-publishing every human rule edit is intentionally avoided per the project's release policy. This PR only decouples *benchmark freshness* from *release cadence*.