### PR TITLE
feat(atd): CVE to ATD ingest — feed the WHAT layer daily

### DIFF
--- a/.github/workflows/atd-ingest.yml
+++ b/.github/workflows/atd-ingest.yml
@@ -1,0 +1,135 @@
+name: ATD Ingest (CVE -> ATD)
+
+# The missing CVE -> ATD link. The daily collector turns frontline agent CVEs
+# into proposals and promote-cve turns the generalizable ones into ATR rules
+# (HOW). This feeds the ATD knowledge base (WHAT): every agent-relevant CVE
+# either enriches an existing technique with real-world evidence (automatic,
+# schema-validated, low risk), or — when a CWE is corroborated by multiple
+# independent CVEs but not yet covered by any technique — Claude drafts a
+# candidate technique entry for human review. Runs after the collector +
+# promote-cve.
+#
+# Cadence: daily. The ENRICH leg is cheap, deterministic, and safe to run
+# every day. The LLM-drafting leg only fires on CWE clusters that have never
+# been drafted before (scripts/atd/ingest-cve-to-atd.ts's
+# loadAlreadyDraftedCwes skips anything already sitting in a prior
+# data/atd-ingest/new-technique-drafts-*.json for review) — so a daily
+# cadence does not spam duplicate review PRs for the same unresolved cluster;
+# it just means new evidence and genuinely new clusters surface with minimal
+# lag instead of waiting up to a week.
+#
+# Safety posture:
+#   - Never auto-merges anything. Always opens a DRAFT PR; a human decides.
+#   - Never mints a technique directly into the catalog — drafted entries are
+#     schema-validated but land in data/atd-ingest/ for review, never written
+#     to website/public/atd/atd-techniques.json.
+#   - A run that changes nothing on disk opens NO PR — silence is the
+#     expected, honest outcome most days, not a bug (the maturity-promote
+#     workflow's daily no-op PR is the anti-pattern this deliberately avoids).
+
+on:
+  workflow_dispatch:
+    inputs:
+      source:
+        description: "Limit to one proposals source (blank = all)"
+        required: false
+        default: ""
+      cap:
+        description: "Max new-technique entries to draft this run"
+        required: false
+        default: "10"
+      dry_run:
+        description: "Compute enrichments/drafts but do not write, commit, or open a PR"
+        required: false
+        default: false
+        type: boolean
+  schedule:
+    - cron: "0 6 * * *" # daily, after the CVE collector + promote-cve (05:40)
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: atd-ingest
+  cancel-in-progress: false
+
+jobs:
+  ingest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+
+      - name: Ingest CVEs into ATD (enrich + drafted new techniques)
+        id: ingest
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          set -eo pipefail
+          SRC='${{ inputs.source }}'
+          CAP='${{ inputs.cap || '10' }}'
+          ARGS=(--draft-techniques --max-new-techniques "$CAP")
+          if [ "${{ inputs.dry_run }}" != "true" ]; then
+            ARGS=(--write "${ARGS[@]}")
+          fi
+          [ -n "$SRC" ] && ARGS=("${ARGS[@]}" --source "$SRC")
+          npx tsx scripts/atd/ingest-cve-to-atd.ts "${ARGS[@]}" | tee /tmp/atd-ingest.out
+          SUMMARY=$(grep -F '::atd-ingest::' /tmp/atd-ingest.out | tail -1 | sed 's/^.*::atd-ingest:://')
+          echo "summary=$SUMMARY" >> "$GITHUB_OUTPUT"
+          CHANGED=$(echo "$SUMMARY" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d['enrichments']+d['newTechniqueDraftsGenerated'])")
+          echo "changed=$CHANGED" >> "$GITHUB_OUTPUT"
+
+      - name: Validate ATD after ingest
+        if: steps.ingest.outputs.changed != '0' && inputs.dry_run != true
+        run: npx tsx scripts/validate-atd.ts
+
+      - name: Stop here on dry-run or null result (not an error)
+        if: inputs.dry_run == true || steps.ingest.outputs.changed == '0'
+        run: |
+          echo "Summary: ${{ steps.ingest.outputs.summary }}"
+          echo "dry_run=${{ inputs.dry_run }} — no write, no PR. This is the expected quiet outcome most runs."
+
+      - name: Open review PR
+        if: steps.ingest.outputs.changed != '0' && inputs.dry_run != true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -eo pipefail
+          # Guard against the maturity-promote anti-pattern: only commit + PR if
+          # something ACTUALLY changed on disk, even if the summary counters were
+          # non-zero (e.g. every enrichment already existed on a previous run).
+          if git diff --quiet website/public/atd/ data/atd-ingest/ 2>/dev/null && [ -z "$(git status --porcelain data/atd-ingest/)" ]; then
+            echo "No on-disk change; nothing to PR."
+            exit 0
+          fi
+          DATE=$(date -u +%Y-%m-%d)
+          BRANCH="atd-ingest/$DATE"
+          git config user.name "ATR ATD Bot"
+          git config user.email "atd-bot@agentthreatrule.org"
+          git push origin --delete "$BRANCH" 2>/dev/null || true
+          git checkout -b "$BRANCH"
+          git add website/public/atd/atd-techniques.json data/atd-ingest/
+          git commit -m "feat(atd): daily CVE ingest $DATE — ${{ steps.ingest.outputs.summary }}"
+          git push origin "$BRANCH"
+          {
+            echo "Daily CVE -> ATD ingest for $DATE."
+            echo ""
+            echo "Summary: ${{ steps.ingest.outputs.summary }}"
+            echo ""
+            echo "Enrichments add real CVE evidence onto existing techniques (matched by CWE) — automatic, schema-validated, low risk."
+            echo "New-technique DRAFTS (data/atd-ingest/new-technique-drafts-*.json) are Claude-authored candidate ATD entries for CWEs with no covering technique, corroborated by 2+ independent CVEs, and schema-validated against atd-technique.schema.json. Never auto-merged: a new technique is a claim about the threat taxonomy. Confirm tactic/mappings/atd_id (provisional — re-check it is still free) before pasting into website/public/atd/atd-techniques.json."
+            echo "The flat candidates dump (data/atd-ingest/candidates-*.json) is everything else — no CWE at all, or a CWE seen only once — for human triage, not auto-drafted."
+          } > /tmp/atd-pr-body.md
+          gh pr create \
+            --base main --head "$BRANCH" \
+            --title "atd: CVE ingest $DATE — ${{ steps.ingest.outputs.summary }}" \
+            --body-file /tmp/atd-pr-body.md \
+            --label "atd,needs-human-review" \
+            --draft

--- a/docs/atd-ingest.md
+++ b/docs/atd-ingest.md
@@ -1,0 +1,76 @@
+# CVE -> ATD ingest — the WHAT layer's daily feed
+
+ATR has three layers, mirroring the vulnerability stack: ATD is the WHAT
+(technique knowledge base, like ATT&CK/CWE), the rules are the HOW (detection,
+like Sigma), and the wild-scan/instance layer is the WHICH. The daily collector
+caught frontline agent CVEs and `promote-detection-ready.ts` turned the
+generalizable ones into rules — but nothing fed ATD. A CVE either became a
+detection rule or vanished; the knowledge base stayed hand-maintained.
+
+`scripts/atd/ingest-cve-to-atd.ts` closes that gap:
+
+```
+agent-relevant CVE  ->  ATD technique (always)  ->  if generalizable -> ATR rule
+```
+
+## Three outcomes per CVE
+
+- **ENRICH** — if the CVE's CWE matches an existing technique, the CVE is added
+  as real-world evidence on that technique. Automatic, schema-validated, low
+  risk. This turns ATD from 80 hand-written techniques into a living evidence
+  base.
+- **DRAFT** — if a CWE has NO covering technique but is corroborated by 2+
+  independent CVEs (`--min-evidence`, default 2), Claude drafts a full
+  candidate technique entry — title, description, tactic, abstraction,
+  detection_surface, OWASP ASI / MITRE ATLAS mappings — via a direct
+  `@anthropic-ai/sdk` call (same pattern as `scripts/fn-mine-llm.ts`). The
+  draft is validated against `atd-technique.schema.json`; a failure triggers
+  one corrective retry with the validator's error message, and a cluster that
+  still fails is dropped (never force-written) and logged. Survivors land in
+  `data/atd-ingest/new-technique-drafts-<date>.json` for HUMAN review — never
+  auto-merged into the catalog, since a new technique is a claim about the
+  threat taxonomy, not a row to mint. `atd_id` is assigned deterministically
+  (next free `ATD-Tnnnn` after the real catalog) but is explicitly provisional:
+  re-check it's still free at merge time. A CWE already covered by a prior
+  run's draft is skipped (`loadAlreadyDraftedCwes`) so an unresolved cluster
+  doesn't spawn a near-duplicate review PR every day it runs.
+- **RAW** — everything that doesn't clear the DRAFT bar (no CWE at all, or a
+  CWE seen only once) is dumped as a flat list in
+  `data/atd-ingest/candidates-<date>.json` for human triage. Fabricating a
+  technique off a single unconfirmed data point would be worse than saying
+  "not enough signal yet" — in the current backlog roughly 3 in 4 CVE
+  candidates have no extracted CWE at all and cannot be responsibly clustered.
+
+The agent-relevance gate (`agentRelevance()`, reused from the GHSA collector) is
+re-applied as defence in depth: a stray non-agent CVE must never reach ATD.
+
+## Daily flywheel
+
+`.github/workflows/atd-ingest.yml` runs daily after the collector + promote-cve,
+and opens a **draft** PR (label `atd,needs-human-review`) only when something
+actually changed on disk — a quiet no-op day opens no PR. Nothing auto-merges;
+nothing is auto-minted into the catalog.
+
+## Usage
+
+```
+npx tsx scripts/atd/ingest-cve-to-atd.ts                                # dry-run, ENRICH/RAW only
+npx tsx scripts/atd/ingest-cve-to-atd.ts --write                        # apply enrichments
+npx tsx scripts/atd/ingest-cve-to-atd.ts --write --draft-techniques     # + Claude-drafted new techniques
+npx tsx scripts/atd/ingest-cve-to-atd.ts --source ghsa --max 200
+npx tsx scripts/atd/ingest-cve-to-atd.ts --draft-techniques --min-evidence 3 --max-new-techniques 5
+```
+
+`--draft-techniques` requires `ANTHROPIC_API_KEY` in the environment; if unset
+it logs a warning and skips LLM drafting without failing the run (ENRICH/RAW
+still complete). Model defaults to `claude-sonnet-5`, overridable via
+`ATR_ATDMINE_MODEL`.
+
+## Note
+
+Candidate/draft tactics are only as good as the proposal's `tags.category`.
+Some collector rows are mis-categorized (e.g. an MCP-server network-binding CVE
+tagged `model-abuse`), so a deterministic category-derived tactic — and
+Claude's own tactic pick, which is told to cross-check but not blindly trust
+that suggestion — are both starting points for the reviewer, not a verdict.
+Fixing collector categorization upstream improves candidate and draft quality.

--- a/scripts/atd/ingest-cve-to-atd.ts
+++ b/scripts/atd/ingest-cve-to-atd.ts
@@ -1,0 +1,547 @@
+/**
+ * ingest-cve-to-atd.ts — the missing CVE -> ATD link.
+ *
+ * The daily collector turns frontline agent CVEs into proposals, and
+ * promote-detection-ready.ts turns the generalizable ones into ATR rules (the
+ * HOW layer). But nothing fed the ATD knowledge base (the WHAT layer): a CVE
+ * skipped straight to a detection rule or nowhere. This wires the first leg the
+ * user asked for — "做成 atd, 符合條件就做成 atr":
+ *
+ *   agent-relevant CVE  ->  ATD technique (always)  ->  if generalizable -> ATR rule
+ *
+ * For each agent-relevant CVE proposal:
+ *   ENRICH    — if a CVE's CWE matches an existing technique, add the CVE as
+ *               evidence on that technique. Automatic, schema-validated, low
+ *               risk. ATD's evidence base grows daily from real frontline CVEs.
+ *   DRAFT     — if a CWE has NO covering technique but is corroborated by
+ *               >= --min-evidence independent CVEs, Claude drafts a full
+ *               candidate technique entry (title/description/mappings/
+ *               detection_surface). The drafted entry is schema-validated
+ *               (one corrective retry on failure, then dropped — never
+ *               force-written) and saved to data/atd-ingest/ for HUMAN review.
+ *               Never auto-merged into the catalog: a new technique is a claim
+ *               about the threat taxonomy, not a row to mint.
+ *   RAW       — everything else that doesn't clear the DRAFT bar (no CWE at
+ *               all, or a CWE seen only once) is dumped as a flat candidate
+ *               list for human triage. Fabricating a technique off a single
+ *               unconfirmed data point is worse than saying "not enough
+ *               signal yet."
+ *
+ * Usage:
+ *   npx tsx scripts/atd/ingest-cve-to-atd.ts                    # dry-run (no LLM, no writes)
+ *   npx tsx scripts/atd/ingest-cve-to-atd.ts --write             # apply enrichments
+ *   npx tsx scripts/atd/ingest-cve-to-atd.ts --write --draft-techniques   # + LLM-draft new techniques
+ *   npx tsx scripts/atd/ingest-cve-to-atd.ts --source ghsa --max 200
+ *
+ * Environment:
+ *   ANTHROPIC_API_KEY   required for --draft-techniques (silently skipped, not
+ *                       an error, if unset — the ENRICH/RAW legs still run).
+ *   ATR_ATDMINE_MODEL   optional (default: claude-sonnet-5)
+ */
+import { readFileSync, writeFileSync, readdirSync, existsSync, mkdirSync } from "node:fs";
+import { join, resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import yaml from "js-yaml";
+import Anthropic from "@anthropic-ai/sdk";
+import Ajv2020 from "ajv/dist/2020.js";
+import { agentRelevance } from "../sync-ghsa.ts";
+
+const REPO = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const ATD_PATH = join(REPO, "website/public/atd/atd-techniques.json");
+const SCHEMA_PATH = join(REPO, "website/public/atd/atd-technique.schema.json");
+const PROPOSALS = join(REPO, "proposals");
+const OUT_DIR = join(REPO, "data/atd-ingest");
+
+const DEFAULT_MODEL = process.env["ATR_ATDMINE_MODEL"] ?? "claude-sonnet-5";
+const MAX_TOKENS = 4096;
+const VALID_TACTICS = ["ATD-TA1", "ATD-TA2", "ATD-TA3", "ATD-TA4", "ATD-TA5", "ATD-TA6", "ATD-TA7", "ATD-TA8", "ATD-TA9"];
+const VALID_ABSTRACTIONS = ["pillar", "class", "base", "variant"];
+const VALID_SURFACES = ["content", "tool_input", "tool_response", "inter_agent_msg", "memory_op", "trace", "screen", "payment_mandate"];
+const VALID_SEVERITIES = ["informational", "low", "medium", "high", "critical"];
+
+interface Mappings { owasp_asi: string[]; mitre_atlas: string[]; cwe: string[]; gap_note?: string }
+interface Reference { type?: string; url: string }
+interface Technique {
+  atd_id: string;
+  schema_version: string;
+  title: string;
+  tactic: string;
+  abstraction: string;
+  status: string;
+  severity?: string;
+  description: string;
+  detection_surface: string[];
+  mappings: Mappings;
+  references: Reference[];
+  atr_rule?: string;
+}
+interface AtdDoc { tactics: Array<{ id: string; name: string }>; techniques: Technique[]; [k: string]: unknown }
+
+interface Proposal {
+  references?: { cve?: string[]; ghsa?: string[]; cwe?: string[]; external?: string[]; atlas?: string[] };
+  title?: string;
+  description?: string;
+  severity?: string;
+  tags?: { category?: string; scan_target?: string };
+}
+
+// ATR category -> ATD tactic, for candidates whose CWE the catalog does not yet
+// cover. Derived from the catalog's own tactic semantics; kept conservative.
+const CATEGORY_TO_TACTIC: Record<string, string> = {
+  "prompt-injection": "ATD-TA2",
+  "tool-poisoning": "ATD-TA5",
+  "skill-compromise": "ATD-TA5",
+  "context-exfiltration": "ATD-TA2",
+  "privilege-escalation": "ATD-TA4",
+  "excessive-autonomy": "ATD-TA6",
+  "agent-manipulation": "ATD-TA3",
+  "data-poisoning": "ATD-TA2",
+  "model-abuse": "ATD-TA8",
+  "model-security": "ATD-TA8",
+};
+
+const SEVERITY_ORDER = ["informational", "low", "medium", "high", "critical"];
+
+function parseArgs(argv: string[]): Record<string, string | boolean> {
+  const out: Record<string, string | boolean> = {};
+  for (let i = 0; i < argv.length; i++) {
+    if (!argv[i].startsWith("--")) continue;
+    const k = argv[i].slice(2);
+    const n = argv[i + 1];
+    if (n && !n.startsWith("--")) { out[k] = n; i++; } else out[k] = true;
+  }
+  return out;
+}
+
+function cveUrl(id: string): string {
+  return `https://nvd.nist.gov/vuln/detail/${id}`;
+}
+
+function loadProposals(sourceFilter?: string, max?: number): Array<{ file: string; cve: string; cwes: string[]; p: Proposal }> {
+  const out: Array<{ file: string; cve: string; cwes: string[]; p: Proposal }> = [];
+  const dirs = readdirSync(PROPOSALS, { withFileTypes: true })
+    .filter((d) => d.isDirectory() && (!sourceFilter || d.name === sourceFilter))
+    .map((d) => d.name);
+  for (const dir of dirs) {
+    const dpath = join(PROPOSALS, dir);
+    for (const f of readdirSync(dpath)) {
+      if (!f.endsWith(".yaml") && !f.endsWith(".yml")) continue;
+      let p: Proposal;
+      try { p = yaml.load(readFileSync(join(dpath, f), "utf-8")) as Proposal; } catch { continue; }
+      const refs = p.references ?? {};
+      const cve = (refs.cve ?? []).find((c) => /^CVE-/i.test(c)) ?? "";
+      if (!cve) continue; // ATD evidence anchors on a real CVE id
+      const cwes = (refs.cwe ?? []).filter((c) => /^CWE-/i.test(c));
+      // Re-apply the agent-relevance gate (defence in depth — the collector
+      // already filters, but a stray non-agent CVE must never reach ATD).
+      const rel = agentRelevance({
+        summary: p.title,
+        description: p.description,
+        cwes: cwes.map((c) => ({ cwe_id: c })),
+      });
+      if (!rel.relevant) continue;
+      out.push({ file: join(dir, f), cve, cwes, p });
+      if (max && out.length >= max) return out;
+    }
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// LLM drafting of new-technique candidates (mirrors scripts/fn-mine-llm.ts's
+// callClaude / extractBalancedJson pattern — direct @anthropic-ai/sdk calls,
+// no framework, so this can run headless in GitHub Actions).
+// ---------------------------------------------------------------------------
+
+async function callClaude(systemPrompt: string, userPrompt: string, model: string): Promise<string> {
+  const client = new Anthropic({ apiKey: process.env["ANTHROPIC_API_KEY"] });
+  const response = await client.messages.create({
+    model,
+    max_tokens: MAX_TOKENS,
+    system: systemPrompt,
+    messages: [{ role: "user", content: userPrompt }],
+  });
+  const textBlock = response.content.find((b) => b.type === "text");
+  if (!textBlock || textBlock.type !== "text") throw new Error("No text block in LLM response");
+  return textBlock.text;
+}
+
+function extractBalancedJson(text: string): string {
+  let cleaned = text.trim();
+  cleaned = cleaned.replace(/^```(?:json)?\s*\n?/i, "").replace(/\n?```\s*$/i, "");
+  const firstBrace = cleaned.indexOf("{");
+  if (firstBrace === -1) throw new Error("No JSON object opening brace found in LLM output");
+  let depth = 0;
+  let inString = false;
+  let escape = false;
+  let lastBrace = -1;
+  for (let i = firstBrace; i < cleaned.length; i++) {
+    const ch = cleaned[i];
+    if (escape) { escape = false; continue; }
+    if (inString) {
+      if (ch === "\\") escape = true;
+      else if (ch === '"') inString = false;
+      continue;
+    }
+    if (ch === '"') { inString = true; continue; }
+    if (ch === "{") depth++;
+    else if (ch === "}") { depth--; if (depth === 0) { lastBrace = i; break; } }
+  }
+  if (lastBrace === -1) throw new Error("Unbalanced braces — no top-level JSON object closed");
+  return cleaned.slice(firstBrace, lastBrace + 1);
+}
+
+interface NewTechniqueCluster {
+  cwe: string;
+  category: string;
+  proposedTactic: string;
+  severity?: string;
+  cves: string[];
+  titles: string[];
+}
+
+interface DraftFields {
+  title: string;
+  tactic?: string;
+  abstraction?: string;
+  severity?: string;
+  description: string;
+  detection_surface: string[];
+  owasp_asi?: string[];
+  mitre_atlas?: string[];
+}
+
+const DRAFT_SYSTEM_PROMPT = `You are documenting ONE new technique entry for ATD (Agent Threat Database) — a technique KNOWLEDGE BASE for AI-agent attacks, structured like MITRE ATT&CK/CWE. You are NOT writing a detection rule; you are naming and describing an attack technique so humans and tooling have a shared vocabulary for it.
+
+You will be given a CWE code that the catalog does not yet cover, corroborated by 2+ real CVEs in agent/MCP-adjacent software. Produce ONE technique entry describing the underlying attack TECHNIQUE (the class of vulnerability), not any single CVE.
+
+Rules:
+- title: a short imperative noun phrase (4-120 chars) naming the technique generically — e.g. "Unauthenticated cross-origin tool invocation via missing Origin check", not the name of one product.
+- description: 1-3 sentences (>=20 chars) explaining the mechanism and why it matters for agents — what an attacker does and what breaks.
+- tactic: pick exactly ONE from this enum, the closest fit: ATD-TA1 (Protocol&Interconnect) / ATD-TA2 (Memory&Context) / ATD-TA3 (Goal/Planning/Reasoning) / ATD-TA4 (Identity/Authz/Delegation) / ATD-TA5 (Tool&Supply-Chain) / ATD-TA6 (Execution&Autonomy) / ATD-TA7 (Multi-Agent Dynamics) / ATD-TA8 (Model-Intrinsic&Governance) / ATD-TA9 (Agentic Commerce).
+- abstraction: one of pillar/class/base/variant — almost always "base" (a specific, observable technique) unless the CWE is unusually broad (then "class").
+- severity: one of informational/low/medium/high/critical, reflecting typical real-world impact for this technique class.
+- detection_surface: 1+ from content/tool_input/tool_response/inter_agent_msg/memory_op/trace/screen/payment_mandate — where in agent I/O this technique is actually observable.
+- owasp_asi: 0+ OWASP Agentic Top 10 2026 ids (ASI01..ASI10) that plausibly cover this technique. Empty array if genuinely none fit — do not force a weak match.
+- mitre_atlas: 0+ MITRE ATLAS ids (AML.T####) if you are confident one applies. Empty array if unsure — never guess a specific ID you cannot justify.
+
+Do not include atd_id, schema_version, status, mappings.cwe, or references — those are assigned deterministically by the calling script, not by you.
+
+OUTPUT FORMAT: pure JSON, no markdown fences, no prose before or after. First character must be {. Schema:
+{
+  "title": "...",
+  "tactic": "ATD-TAx",
+  "abstraction": "base",
+  "severity": "high",
+  "description": "...",
+  "detection_surface": ["tool_input"],
+  "owasp_asi": [],
+  "mitre_atlas": []
+}`;
+
+function buildDraftUserPrompt(cluster: NewTechniqueCluster): string {
+  return `CWE: ${cluster.cwe} (not covered by any existing ATD technique)
+Suggested category (from the ATR collector, cross-check but do not blindly trust): ${cluster.category || "(unknown)"}
+Suggested tactic (deterministic category mapping, cross-check but you may override): ${cluster.proposedTactic || "(none — you must pick one)"}
+Typical severity across evidence: ${cluster.severity ?? "(unknown)"}
+Corroborating evidence — ${cluster.cves.length} independent CVEs against agent/MCP-adjacent software:
+${cluster.titles.map((t, i) => `${i + 1}. [${cluster.cves[i]}] ${t.slice(0, 220)}`).join("\n")}`;
+}
+
+async function draftTechniqueFields(cluster: NewTechniqueCluster, model: string, correctionNote?: string): Promise<DraftFields> {
+  const user = buildDraftUserPrompt(cluster) + (correctionNote ? `\n\nPREVIOUS ATTEMPT FAILED SCHEMA VALIDATION: ${correctionNote}\nFix this specific issue and output the complete corrected JSON.` : "");
+  const raw = await callClaude(DRAFT_SYSTEM_PROMPT, user, model);
+  return JSON.parse(extractBalancedJson(raw)) as DraftFields;
+}
+
+function assembleTechnique(cluster: NewTechniqueCluster, draft: DraftFields, atdId: string): Technique {
+  const tactic = VALID_TACTICS.includes(draft.tactic ?? "") ? (draft.tactic as string) : (cluster.proposedTactic || "ATD-TA8");
+  const abstraction = VALID_ABSTRACTIONS.includes(draft.abstraction ?? "") ? (draft.abstraction as string) : "base";
+  const severity = VALID_SEVERITIES.includes(draft.severity ?? "") ? draft.severity : cluster.severity;
+  const detectionSurface = (draft.detection_surface ?? []).filter((s) => VALID_SURFACES.includes(s));
+  return {
+    atd_id: atdId,
+    schema_version: "0.1.0",
+    title: draft.title ?? `Undocumented technique (${cluster.cwe})`,
+    tactic,
+    abstraction,
+    status: "experimental",
+    ...(severity ? { severity } : {}),
+    description: draft.description ?? "",
+    detection_surface: detectionSurface.length > 0 ? detectionSurface : ["tool_input"],
+    mappings: {
+      owasp_asi: Array.isArray(draft.owasp_asi) ? draft.owasp_asi : [],
+      mitre_atlas: Array.isArray(draft.mitre_atlas) ? draft.mitre_atlas : [],
+      cwe: [cluster.cwe],
+    },
+    // Real evidence only — the CVEs that corroborated this cluster. Never
+    // fabricated: these are the exact CVE ids the cluster was built from.
+    references: cluster.cves.map((cve) => ({ type: "cve", url: cveUrl(cve) })),
+  };
+}
+
+/**
+ * CWEs already covered by a VALID draft from a previous run, sitting in
+ * data/atd-ingest/ awaiting human review. Re-drafting the same unresolved
+ * cluster every day would spam near-duplicate review PRs — the same failure
+ * mode this pipeline must avoid (see the maturity-promote no-op-PR lesson).
+ * A cluster whose only prior attempt was DROPPED is not excluded — new
+ * evidence or a better LLM attempt on a later run is worth retrying.
+ */
+function loadAlreadyDraftedCwes(outDir: string): Set<string> {
+  const seen = new Set<string>();
+  if (!existsSync(outDir)) return seen;
+  for (const f of readdirSync(outDir)) {
+    if (!/^new-technique-drafts-.*\.json$/.test(f)) continue;
+    try {
+      const doc = JSON.parse(readFileSync(join(outDir, f), "utf-8")) as { drafted?: Technique[] };
+      for (const t of doc.drafted ?? []) {
+        for (const cwe of t.mappings?.cwe ?? []) seen.add(cwe);
+      }
+    } catch {
+      // ignore unreadable/malformed prior output — do not let it block this run
+    }
+  }
+  return seen;
+}
+
+function nextAtdId(existing: readonly Technique[], alreadyAssigned: ReadonlySet<string>): string {
+  let max = 0;
+  for (const t of existing) {
+    const m = /^ATD-T(\d{4})$/.exec(t.atd_id);
+    if (m) max = Math.max(max, parseInt(m[1], 10));
+  }
+  for (const id of alreadyAssigned) {
+    const m = /^ATD-T(\d{4})$/.exec(id);
+    if (m) max = Math.max(max, parseInt(m[1], 10));
+  }
+  return `ATD-T${String(max + 1).padStart(4, "0")}`;
+}
+
+/** Compiles the normative schema once; validate() returns null on success, a joined error string otherwise. */
+function makeValidator(): (tech: unknown) => string | null {
+  const schema = JSON.parse(readFileSync(SCHEMA_PATH, "utf-8"));
+  const ajv = new Ajv2020({ allErrors: true, strict: false });
+  ajv.addFormat("uri", () => true);
+  ajv.addFormat("uuid", () => true);
+  const validate = ajv.compile(schema);
+  return (tech: unknown) => {
+    if (validate(tech)) return null;
+    return (validate.errors ?? []).map((e) => `${e.instancePath || "/"} ${e.message}`).join("; ");
+  };
+}
+
+async function draftNewTechniques(
+  clusters: readonly NewTechniqueCluster[],
+  model: string,
+  existingTechniques: readonly Technique[],
+  maxNew: number,
+): Promise<{ drafted: Technique[]; dropped: Array<{ cwe: string; reason: string }> }> {
+  const validate = makeValidator();
+  const drafted: Technique[] = [];
+  const dropped: Array<{ cwe: string; reason: string }> = [];
+  const assignedIds = new Set<string>();
+
+  for (const cluster of clusters.slice(0, maxNew)) {
+    const atdId = nextAtdId(existingTechniques, assignedIds);
+    let fields: DraftFields;
+    let tech: Technique;
+    let error: string | null;
+    try {
+      fields = await draftTechniqueFields(cluster, model);
+      tech = assembleTechnique(cluster, fields, atdId);
+      error = validate(tech);
+      if (error) {
+        console.log(`[atd-ingest]   ${cluster.cwe}: schema validation failed, one corrective retry — ${error}`);
+        fields = await draftTechniqueFields(cluster, model, error);
+        tech = assembleTechnique(cluster, fields, atdId);
+        error = validate(tech);
+      }
+    } catch (e) {
+      dropped.push({ cwe: cluster.cwe, reason: e instanceof Error ? e.message : String(e) });
+      console.log(`[atd-ingest]   ${cluster.cwe}: DROPPED — LLM call/parse failed: ${e instanceof Error ? e.message : String(e)}`);
+      continue;
+    }
+    if (error) {
+      dropped.push({ cwe: cluster.cwe, reason: error });
+      console.log(`[atd-ingest]   ${cluster.cwe}: DROPPED — still fails schema after retry: ${error}`);
+      continue;
+    }
+    assignedIds.add(atdId);
+    drafted.push(tech);
+    console.log(`[atd-ingest]   ${cluster.cwe}: drafted ${atdId} — "${tech.title}" (${cluster.cves.length} CVE evidence)`);
+  }
+  return { drafted, dropped };
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+  const write = !!args.write;
+  const draftTechniques = !!args["draft-techniques"];
+  const sourceFilter = typeof args.source === "string" ? args.source : undefined;
+  const max = args.max ? parseInt(args.max as string, 10) : undefined;
+  const minEvidence = args["min-evidence"] ? parseInt(args["min-evidence"] as string, 10) : 2;
+  const maxNewTechniques = args["max-new-techniques"] ? parseInt(args["max-new-techniques"] as string, 10) : 10;
+  const model = typeof args.model === "string" ? args.model : DEFAULT_MODEL;
+
+  const doc = JSON.parse(readFileSync(ATD_PATH, "utf-8")) as AtdDoc;
+  const techniques = doc.techniques;
+
+  // CWE -> techniques that already cover it.
+  const byCwe = new Map<string, Technique[]>();
+  for (const t of techniques) {
+    for (const c of t.mappings?.cwe ?? []) {
+      byCwe.set(c, [...(byCwe.get(c) ?? []), t]);
+    }
+  }
+  const existingCveUrls = new Set<string>(
+    techniques.flatMap((t) => (t.references ?? []).map((r) => r.url)),
+  );
+
+  const proposals = loadProposals(sourceFilter, max);
+
+  // ENRICH: best-matching technique (largest CWE overlap) gains the CVE.
+  const enrichments: Array<{ atd_id: string; cve: string; via: string }> = [];
+  const enriched = techniques.map((t) => ({ ...t, references: [...(t.references ?? [])] }));
+  const idIndex = new Map(enriched.map((t, i) => [t.atd_id, i] as const));
+
+  const candidates: Array<{ cve: string; cwes: string[]; title: string; proposedTactic: string; category: string; severity?: string; file: string }> = [];
+
+  for (const { cve, cwes, p, file } of proposals) {
+    const url = cveUrl(cve);
+    const hitTechs = cwes.flatMap((c) => byCwe.get(c) ?? []);
+    if (hitTechs.length > 0) {
+      // pick the technique sharing the most CWEs with this proposal
+      const best = hitTechs
+        .map((t) => ({ t, overlap: (t.mappings.cwe ?? []).filter((c) => cwes.includes(c)).length }))
+        .sort((a, b) => b.overlap - a.overlap)[0].t;
+      if (existingCveUrls.has(url)) continue; // already evidenced somewhere
+      const i = idIndex.get(best.atd_id)!;
+      if (!enriched[i].references.some((r) => r.url === url)) {
+        enriched[i].references.push({ type: "cve", url });
+        existingCveUrls.add(url);
+        enrichments.push({ atd_id: best.atd_id, cve, via: cwes.filter((c) => (best.mappings.cwe ?? []).includes(c)).join(",") });
+      }
+    } else {
+      // No technique covers this CWE -> candidate new documented technique.
+      const cat = p.tags?.category ?? "";
+      const tactic = CATEGORY_TO_TACTIC[cat] ?? "";
+      if (existingCveUrls.has(url)) continue;
+      candidates.push({ cve, cwes, title: p.title ?? cve, proposedTactic: tactic, category: cat, severity: p.severity, file });
+    }
+  }
+
+  if (!existsSync(OUT_DIR)) mkdirSync(OUT_DIR, { recursive: true });
+  const today = new Date().toISOString().slice(0, 10);
+  // Dedup candidates by CVE.
+  const candByCve = new Map(candidates.map((c) => [c.cve, c] as const));
+  const candList = Array.from(candByCve.values());
+
+  // Cluster the CWE-bearing candidates by their primary (first-listed) CWE.
+  // A cluster with >= minEvidence independent CVEs is strong enough signal to
+  // draft a real technique entry; everything else (no CWE at all, or a CWE
+  // seen only once) stays in the flat candidates dump for human triage —
+  // drafting a technique off a single unconfirmed data point would be
+  // fabrication, not documentation.
+  const clusterMap = new Map<string, NewTechniqueCluster>();
+  for (const c of candList) {
+    if (c.cwes.length === 0) continue;
+    const key = c.cwes[0];
+    const existing = clusterMap.get(key);
+    if (existing) {
+      existing.cves.push(c.cve);
+      existing.titles.push(c.title);
+      if (c.severity && SEVERITY_ORDER.indexOf(c.severity) > SEVERITY_ORDER.indexOf(existing.severity ?? "")) {
+        existing.severity = c.severity;
+      }
+    } else {
+      clusterMap.set(key, {
+        cwe: key,
+        category: c.category,
+        proposedTactic: c.proposedTactic,
+        severity: c.severity,
+        cves: [c.cve],
+        titles: [c.title],
+      });
+    }
+  }
+  const alreadyDrafted = loadAlreadyDraftedCwes(OUT_DIR);
+  const eligibleClusters = Array.from(clusterMap.values())
+    .filter((c) => c.cves.length >= minEvidence && !alreadyDrafted.has(c.cwe))
+    .sort((a, b) => b.cves.length - a.cves.length);
+
+  let draftedTechniques: Technique[] = [];
+  let droppedDrafts: Array<{ cwe: string; reason: string }> = [];
+  if (draftTechniques) {
+    if (!process.env["ANTHROPIC_API_KEY"]) {
+      console.log("[atd-ingest] --draft-techniques requested but ANTHROPIC_API_KEY is unset — skipping LLM drafting (ENRICH + raw candidates still run).");
+    } else if (eligibleClusters.length === 0) {
+      console.log(`[atd-ingest] no CWE cluster reaches --min-evidence=${minEvidence} this run — nothing to draft. This is a valid, honest outcome.`);
+    } else {
+      console.log(`[atd-ingest] drafting up to ${Math.min(maxNewTechniques, eligibleClusters.length)} new-technique candidates from ${eligibleClusters.length} eligible CWE clusters (model=${model})...`);
+      const result = await draftNewTechniques(eligibleClusters, model, techniques, maxNewTechniques);
+      draftedTechniques = result.drafted;
+      droppedDrafts = result.dropped;
+    }
+  }
+
+  const summary = {
+    proposalsConsidered: proposals.length,
+    enrichments: enrichments.length,
+    techniquesTouched: new Set(enrichments.map((e) => e.atd_id)).size,
+    newTechniqueCandidatesRaw: candList.length,
+    eligibleClusters: eligibleClusters.length,
+    newTechniqueDraftsGenerated: draftedTechniques.length,
+    newTechniqueDraftsDropped: droppedDrafts.length,
+  };
+
+  writeFileSync(
+    join(OUT_DIR, `candidates-${today}.json`),
+    JSON.stringify({ generated: new Date().toISOString(), candidates: candList }, null, 2),
+  );
+
+  if (draftTechniques) {
+    writeFileSync(
+      join(OUT_DIR, `new-technique-drafts-${today}.json`),
+      JSON.stringify(
+        {
+          generated: new Date().toISOString(),
+          model,
+          minEvidence,
+          note:
+            "LLM-drafted candidate ATD technique entries, schema-validated but NEVER auto-merged. " +
+            "atd_id is provisional — re-verify it is still the next free id at merge time (concurrent " +
+            "PRs may also claim it). A human must confirm tactic/mappings before pasting into " +
+            "website/public/atd/atd-techniques.json.",
+          drafted: draftedTechniques,
+          dropped: droppedDrafts,
+        },
+        null,
+        2,
+      ),
+    );
+  }
+
+  if (write) {
+    const outDoc: AtdDoc = { ...doc, techniques: enriched };
+    if (typeof outDoc.stats === "object" && outDoc.stats) {
+      outDoc.stats = { ...(outDoc.stats as object), withCve: enriched.filter((t) => (t.references ?? []).some((r) => r.type === "cve")).length };
+    }
+    writeFileSync(ATD_PATH, JSON.stringify(outDoc, null, 2) + "\n");
+  }
+
+  console.log(`::atd-ingest::${JSON.stringify(summary)}`);
+  console.log(
+    `CVE -> ATD ingest (${write ? "WRITE" : "dry-run"}): ${summary.proposalsConsidered} agent CVEs considered\n` +
+      `  enriched ${summary.enrichments} CVE references onto ${summary.techniquesTouched} existing techniques\n` +
+      `  ${summary.newTechniqueCandidatesRaw} raw new-technique candidates (${summary.eligibleClusters} CWE clusters with >= ${minEvidence} evidence) -> data/atd-ingest/candidates-${today}.json` +
+      (draftTechniques
+        ? `\n  ${summary.newTechniqueDraftsGenerated} new-technique entries drafted by Claude (${summary.newTechniqueDraftsDropped} dropped on failed validation) -> data/atd-ingest/new-technique-drafts-${today}.json for human review`
+        : ""),
+  );
+}
+
+main().catch((e) => {
+  console.error("[atd-ingest] FATAL:", e);
+  process.exit(1);
+});


### PR DESCRIPTION
Rebases this branch onto current main and fixes the CI break (its tests depended on scripts/author-rule-llm.ts / check-collector-freshness.ts / format-poc-backlog-issue.ts, deleted from the public repo after this PR was opened on 2026-06-21; those orphaned tests were already removed from main by #210, so the rebase alone resolves it). Also drops the wild-scan-diff.ts / wild-scan-refresh.yml files that were bundled into the original branch — that's a separate, unrelated feature out of scope here.

## What this does

ATR has three layers: ATD is the WHAT (technique knowledge base, like ATT&CK/CWE), the rules are the HOW (detection, like Sigma). The daily collector caught frontline agent CVEs and promote-cve turned the generalizable ones into rules, but nothing fed ATD. `scripts/atd/ingest-cve-to-atd.ts` gives each agent-relevant CVE one of three outcomes:

- **ENRICH** — if the CVE's CWE matches an existing technique, add the CVE as real-world evidence on that technique. Automatic, schema-validated, low risk.
- **DRAFT** (new in this update) — if a CWE has no covering technique but is corroborated by 2+ independent CVEs, Claude drafts a full candidate technique entry (title/description/tactic/abstraction/detection_surface/OWASP-ASI/MITRE-ATLAS) via a direct `@anthropic-ai/sdk` call (same `callClaude`/`extractBalancedJson` pattern as `scripts/fn-mine-llm.ts`), schema-validated with one corrective retry before dropping. Lands in `data/atd-ingest/new-technique-drafts-<date>.json` for human review — never auto-merged. A CWE already covered by a prior draft is skipped so an unresolved cluster doesn't spawn a duplicate PR every day.
- **RAW** — everything else (no CWE, or a CWE seen only once) stays a flat list for human triage.

`.github/workflows/atd-ingest.yml` runs daily after the collector + promote-cve, with `workflow_dispatch` inputs (`source`, `cap`, `dry_run`), `set -eo pipefail`, and opens a draft PR (`atd,needs-human-review`) only when something actually changed on disk — a no-op day opens nothing.

## Verified

Typecheck clean, actionlint clean, baseline `validate-atd` PASS (80 techniques). Dry-run against the real current `proposals/` backlog (4,876 proposals, 1,256 agent-relevant CVEs): 579 real ENRICH opportunities across 24 existing techniques, plus 29 CWE clusters with >= 2 CVEs each that are genuinely uncovered by any existing technique (e.g. CWE-346 unauthenticated cross-origin MCP tool invocation, CWE-1336 Jinja2 SSTI in Haystack, CWE-88 kubectl flag injection via an MCP Kubernetes server) — real material for `--draft-techniques`. The schema-validation + corrective-retry path was smoke-tested against the real ajv validator with a fake LLM response.

Left as draft. Nothing here auto-merges or auto-mints a technique into the catalog.