### PR TITLE
chore: add mcpName + bump 3.5.2 for MCP Registry publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "agent-threat-rules",
-  "version": "3.5.1",
+  "version": "3.5.2",
+  "mcpName": "io.github.Agent-Threat-Rule/agent-threat-rules",
   "type": "module",
   "description": "Open detection standard -- like Sigma, but for AI agents. 655 rules for prompt injection, tool poisoning, context exfiltration, and MCP attacks. Shipped in Cisco AI Defense. 97.2% recall on NVIDIA garak.",
   "main": "./dist/index.js",


### PR DESCRIPTION
Adds the `mcpName` field to `package.json` so the official [MCP Registry](https://registry.modelcontextprotocol.io) can verify that the `agent-threat-rules` npm package belongs to the `io.github.Agent-Threat-Rule/agent-threat-rules` server entry.

- `mcpName`: `io.github.Agent-Threat-Rule/agent-threat-rules`
- version `3.5.1` → `3.5.2` so the manual **Publish current package version** workflow ships a fresh version carrying `mcpName` (CI npm token, no 2FA).

After this merges + that workflow runs, `mcp-publisher publish ./server.json` (descriptor in `integrations/mcp-registry/`, already schema-validated) lists ATR's stdio MCP server in the registry.

Diff is two lines in `package.json`.