### PR TITLE
docs(adopters): reconcile to current ecosystem state — correct Google, add Tencent/AMD/Dify/rulezet + 3 lists

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -184,14 +184,6 @@ Listed when the integration code has been merged or released.
 - **Since**: 2026-06-16
 - **Status**: in-review
 
-### Google ADK
-- **Org**: Google
-- **Type**: adapter
-- **Integration**: Sample ATR security-guardrail plugin for the Google Agent Development Kit
-- **Evidence**: <https://github.com/google/adk-python/pull/6130>
-- **Since**: 2026-06-16
-- **Status**: in-review
-
 ### Cisco mcp-scanner
 - **Org**: Cisco
 - **Type**: rule-import
@@ -207,6 +199,46 @@ Listed when the integration code has been merged or released.
 - **Evidence**: <https://github.com/splunk/security_content/pull/4128>
 - **Since**: 2026-06-16
 - **Status**: in-review
+
+### Dify
+- **Org**: ATR maintainers (plugin listed in the Dify plugin marketplace; NOT a Dify-core adoption or integration)
+- **Type**: adapter
+- **Integration**: ATR available as a reviewed plugin in the Dify plugin marketplace (146k★ platform)
+- **Evidence**: <https://github.com/langgenius/dify-plugins/pull/2584>
+- **Since**: 2026-06-22
+- **Status**: shipped
+
+### rulezet
+- **Org**: rulezet (independent project, ~50★; PR merged by external maintainer)
+- **Type**: adapter
+- **Integration**: ATR rule-format adapter merged into rulezet-core, letting rulezet ingest and translate ATR-format rules
+- **Evidence**: <https://github.com/rulezet/rulezet-core/pull/50>
+- **Since**: 2026-06-18
+- **Status**: shipped
+
+### Tencent AI-Infra-Guard
+- **Org**: Tencent
+- **Type**: rule-import
+- **Integration**: ATR-derived MCP threat-detection rules (tool poisoning, credential exfiltration) merged into Tencent's open-source AI-Infra-Guard scanner
+- **Evidence**: <https://github.com/Tencent/AI-Infra-Guard/pull/422>
+- **Since**: 2026-06-23
+- **Status**: shipped
+
+### Google ADK
+- **Org**: Google
+- **Type**: reference
+- **Integration**: ATR guardrail plugin documented as an integration in the official Google Agent Development Kit (ADK) docs (the earlier adk-python sample PR closed unmerged; the docs integration was merged by a Google maintainer)
+- **Evidence**: <https://github.com/google/adk-docs/pull/1850>
+- **Since**: 2026-06-24
+- **Status**: shipped
+
+### AMD GAIA
+- **Org**: AMD
+- **Type**: reference
+- **Integration**: ATR endpoint-guard integration pattern documented in the AMD GAIA docs
+- **Evidence**: <https://github.com/amd/gaia/pull/1809>
+- **Since**: 2026-06-24
+- **Status**: shipped
 
 ---
 
@@ -278,6 +310,30 @@ discoverability.
 - **Integration**: ATR listed in the AI security resource awesome-list
 - **Evidence**: <https://github.com/TalEliyahu/Awesome-AI-Security/pull/53>
 - **Since**: 2026-04-10
+- **Status**: shipped
+
+### cckuailong/awesome-gpt-security
+- **Org**: cckuailong (independent)
+- **Type**: reference
+- **Integration**: ATR listed in the Detecting section of the awesome-gpt-security list
+- **Evidence**: <https://github.com/cckuailong/awesome-gpt-security/pull/39>
+- **Since**: 2026-05-11
+- **Status**: shipped
+
+### Joe-B-Security/awesome-prompt-injection
+- **Org**: Joe B (independent)
+- **Type**: reference
+- **Integration**: ATR listed in the Tools section of the awesome-prompt-injection list
+- **Evidence**: <https://github.com/Joe-B-Security/awesome-prompt-injection/pull/45>
+- **Since**: 2026-06-02
+- **Status**: shipped
+
+### ProjectRecon/awesome-ai-agents-security
+- **Org**: ProjectRecon (independent)
+- **Type**: reference
+- **Integration**: ATR listed in the Static Analysis & Linters section of the awesome-ai-agents-security list
+- **Evidence**: <https://github.com/ProjectRecon/awesome-ai-agents-security/pull/17>
+- **Since**: 2026-06-12
 - **Status**: shipped
 
 ---


### PR DESCRIPTION
## What

Reconcile `ADOPTERS.md` (the machine-readable source of truth the
`agentthreatrule.org/ecosystem` page renders directly) to the current,
live-verified ecosystem state. Several merged wins were missing, and the Google
entry pointed at a closed PR.

Every PR state below was re-verified with `gh` (state + mergedBy) before editing.

## Tier 2 — merged integrations added / corrected

| Entry | Evidence | Verified |
|---|---|---|
| **Dify** | [langgenius/dify-plugins#2584](https://github.com/langgenius/dify-plugins/pull/2584) | MERGED by maintainer `crazywoola`. Framed as a reviewed **Dify-marketplace plugin listing** — explicitly **not** a Dify-core adoption of ATR. |
| **rulezet** | [rulezet/rulezet-core#50](https://github.com/rulezet/rulezet-core/pull/50) | MERGED by external maintainer `ecrou-exact`. |
| **Tencent AI-Infra-Guard** | [Tencent/AI-Infra-Guard#422](https://github.com/Tencent/AI-Infra-Guard/pull/422) | MERGED by Tencent maintainer `boy-hack`. Real MCP threat-detection rules. |
| **AMD GAIA** | [amd/gaia#1809](https://github.com/amd/gaia/pull/1809) | MERGED by AMD maintainer `kovtcharov`. Docs integration. |
| **Google ADK** (corrected) | [google/adk-docs#1850](https://github.com/google/adk-docs/pull/1850) | The earlier `adk-python#6130` sample PR **closed unmerged**, but the docs integration was **MERGED by Google maintainer `koverholt`** — so Google is an active adopter via docs, not a removed entry. The stale in-review `adk-python` entry is replaced. |

## Tier 3 — merged awesome-list references added

- [cckuailong/awesome-gpt-security#39](https://github.com/cckuailong/awesome-gpt-security/pull/39)
- [Joe-B-Security/awesome-prompt-injection#45](https://github.com/Joe-B-Security/awesome-prompt-injection/pull/45)
- [ProjectRecon/awesome-ai-agents-security#17](https://github.com/ProjectRecon/awesome-ai-agents-security/pull/17)

## Notes

- Schema format unchanged; the website parser is unaffected.
- ATR-independence preserved: no PanGuard reference anywhere in the file.
- Honest framing kept throughout — docs/marketplace integrations are labelled as
  such and never inflated into "the vendor productized ATR".
