### PR TITLE
feat(rules): 3 LiteLLM CVE-2026 chain rules (47101/47102/40217) — CISA-KEV-adjacent

### DIFF
--- a/rules/privilege-escalation/ATR-2026-01933-litellm-user-role-privilege-escalation-cve-2026-47102.yaml
+++ b/rules/privilege-escalation/ATR-2026-01933-litellm-user-role-privilege-escalation-cve-2026-47102.yaml
@@ -1,0 +1,160 @@
+title: "LiteLLM User-Role Privilege Escalation (CVE-2026-47102)"
+id: ATR-2026-01933
+rule_version: 1
+status: draft
+description: >
+  Detects CVE-2026-47102 (CVSS 9.9 chain, CWE-269): LiteLLM's user-management
+  endpoints /user/update and /user/bulk_update modify security-sensitive
+  fields without field-level authorization. A low-privilege authenticated
+  caller (e.g. internal_user) can write the user_role field directly and
+  self-promote to proxy_admin, gaining full administrative control of the
+  LiteLLM proxy. Affected: LiteLLM before 1.83.10.
+
+  Detection covers:
+  (a) /user/update or /user/bulk_update payload that sets user_role to an
+      administrative role (proxy_admin / admin);
+  (b) the bulk_update array form where a user object escalates user_role;
+  (c) explicit CVE-2026-47102 exploitation framing.
+
+  The detection target is the request shape — an admin-role write at the
+  user-update endpoint — which is the exact privilege-escalation primitive,
+  caught before the proxy applies the role change.
+author: "ATR Community"
+date: "2026/06/26"
+schema_version: "0.1"
+detection_tier: pattern
+maturity: test
+severity: critical
+
+references:
+  owasp_llm:
+    - "LLM06:2025 - Excessive Agency"
+  owasp_agentic:
+    - "ASI06:2026 - Tool Misuse"
+    - "ASI03:2026 - Privilege Compromise"
+  mitre_atlas:
+    - "AML.T0049 - Exploit Public-Facing Application"
+  mitre_attack:
+    - "T1068 - Exploitation for Privilege Escalation"
+    - "T1078 - Valid Accounts"
+  cve:
+    - "CVE-2026-47102"
+
+metadata_provenance:
+  mitre_atlas: human-reviewed
+  owasp_llm: human-reviewed
+  owasp_agentic: human-reviewed
+
+compliance:
+  eu_ai_act:
+    - article: "15"
+      context: >
+        CVE-2026-47102 lets a low-privilege caller write user_role directly
+        at the LiteLLM user-update endpoint and self-promote to proxy_admin;
+        Article 15 cybersecurity requirements mandate field-level
+        authorization on AI proxy account-management APIs.
+      strength: primary
+    - article: "9"
+      context: "Article 9 (risk management system) requires identified risks to be addressed by appropriate measures; this rule is a runtime risk-treatment control that detects the privilege-escalation technique (LiteLLM User-Role Privilege Escalation (CVE-2026-47102))."
+      strength: secondary
+  nist_ai_rmf:
+    - subcategory: "MP.5.1"
+      context: >
+        An attacker-controlled user_role write reaching the proxy is an
+        adversarial input; MP.5.1 requires scanning user-management payloads
+        for unauthorized administrative role escalation.
+      strength: primary
+    - subcategory: "MG.3.2"
+      context: "NIST AI RMF MANAGE 3.2 is supported where this rule detects the privilege-escalation technique (LiteLLM User-Role Privilege Escalation (CVE-2026-47102))."
+      strength: secondary
+  iso_42001:
+    - clause: "8.1"
+      context: >
+        Operational controls must detect user-management payloads that set an
+        administrative user_role at the LiteLLM update endpoint before the
+        proxy applies the role change.
+      strength: primary
+    - clause: "8.3"
+      context: "ISO/IEC 42001 Clause 8.3 (AI risk treatment) is supported by this rule, which implements runtime detection of the privilege-escalation technique (LiteLLM User-Role Privilege Escalation (CVE-2026-47102)) as a treatment control."
+      strength: secondary
+
+tags:
+  category: privilege-escalation
+  subcategory: role-write-bypass
+  scan_target: llm_io
+  confidence: high
+  source: cve-disclosure
+  vendor_sources: litellm-cve-2026-47102
+
+agent_source:
+  type: llm_io
+  framework:
+    - litellm
+    - any
+  provider:
+    - any
+
+detection:
+  condition: any
+  false_positives:
+    - "Legitimate proxy_admin provisioning a new administrator through /user/update — expected to match; review confirms intent."
+    - "Security advisory or PR text quoting the CVE-2026-47102 payload."
+    - "User updates that set a non-administrative role (internal_user, internal_user_viewer)."
+  conditions:
+    - field: content
+      operator: regex
+      value: '(?i)/user/(?:update|bulk_update)[\s\S]{0,400}["\x27]?user_role["\x27]?\s*[:=]\s*["\x27]?(?:proxy_admin|proxy[_-]admin)\b'
+      description: >
+        /user/update or /user/bulk_update payload writing user_role to an
+        administrative proxy_admin value — direct CVE-2026-47102 escalation.
+    - field: content
+      operator: regex
+      value: '(?i)["\x27]user_role["\x27]\s*:\s*["\x27]proxy_admin["\x27][\s\S]{0,300}["\x27]user_id["\x27]\s*:|["\x27]user_id["\x27]\s*:[\s\S]{0,300}["\x27]user_role["\x27]\s*:\s*["\x27]proxy_admin["\x27]'
+      description: >
+        A user object pairing a user_id with a user_role of proxy_admin in an
+        update body — the bulk_update self-promotion shape.
+    - field: content
+      operator: regex
+      value: '(?i)CVE-2026-47102[\s\S]{0,200}(?:litellm|user_role|proxy_admin|privileg|escalat)'
+      description: >
+        Explicit CVE-2026-47102 reference combined with LiteLLM role-escalation
+        language — attack framing in a skill or tool description.
+
+response:
+  actions:
+    - alert
+    - block_input
+  message_template: >
+    [ATR-2026-01933] CRITICAL: LiteLLM user_role privilege escalation detected
+    (CVE-2026-47102, CWE-269). A user-update payload writes an administrative
+    proxy_admin role; LiteLLM before 1.83.10 applies this without field-level
+    authorization. Block the request and upgrade LiteLLM to >= 1.83.10.
+
+confidence: 80
+
+wild_fp_rate: 0
+
+test_cases:
+  true_positives:
+    - input: "POST /user/update {\"user_id\": \"u_self\", \"user_role\": \"proxy_admin\"}"
+      expected: triggered
+      description: "Low-priv user self-promotes to proxy_admin via /user/update"
+    - input: "POST /user/bulk_update {\"users\": [{\"user_id\": \"u_self\", \"user_role\": \"proxy_admin\"}]}"
+      expected: triggered
+      description: "bulk_update array escalates a user to proxy_admin"
+    - input: "Exploiting CVE-2026-47102 on LiteLLM: set user_role to proxy_admin via /user/update to escalate privilege."
+      expected: triggered
+      description: "Explicit CVE-2026-47102 LiteLLM escalation framing"
+  true_negatives:
+    - input: "POST /user/update {\"user_id\": \"u_123\", \"max_budget\": 100}"
+      expected: not_triggered
+      description: "Legitimate budget update, no user_role field"
+    - input: "POST /user/update {\"user_id\": \"u_123\", \"user_role\": \"internal_user\"}"
+      expected: not_triggered
+      description: "Setting a non-administrative role"
+    - input: "How do I update a user's role in the LiteLLM proxy?"
+      expected: not_triggered
+      description: "General question, not an update payload writing proxy_admin"
+    - input: "GET /user/info?user_id=u_123"
+      expected: not_triggered
+      description: "Read-only user lookup"

--- a/rules/privilege-escalation/ATR-2026-01934-litellm-allowed-routes-authz-bypass-cve-2026-47101.yaml
+++ b/rules/privilege-escalation/ATR-2026-01934-litellm-allowed-routes-authz-bypass-cve-2026-47101.yaml
@@ -1,0 +1,161 @@
+title: "LiteLLM allowed_routes Authorization Bypass (CVE-2026-47101)"
+id: ATR-2026-01934
+rule_version: 1
+status: draft
+description: >
+  Detects CVE-2026-47101 (CVSS 9.9 chain, CWE-285): LiteLLM's virtual-key
+  endpoints /key/generate, /key/update, /key/regenerate and
+  /key/service-account/generate accept an allowed_routes parameter without
+  validating it against the caller's own role. A low-privilege internal_user
+  can mint or update a key whose allowed_routes reach administrative routes
+  (user/key/team/global management), bypassing route authorization and
+  pivoting toward proxy_admin functionality. Affected: LiteLLM before 1.83.14.
+
+  Detection covers:
+  (a) a /key/* generation or update payload whose allowed_routes include
+      administrative/management routes or a wildcard;
+  (b) explicit CVE-2026-47101 exploitation framing.
+
+  The detection target is the request shape — a key-mint that grants itself
+  admin routes via allowed_routes — i.e. the authorization-bypass primitive.
+author: "ATR Community"
+date: "2026/06/26"
+schema_version: "0.1"
+detection_tier: pattern
+maturity: test
+severity: critical
+
+references:
+  owasp_llm:
+    - "LLM06:2025 - Excessive Agency"
+  owasp_agentic:
+    - "ASI06:2026 - Tool Misuse"
+    - "ASI03:2026 - Privilege Compromise"
+  mitre_atlas:
+    - "AML.T0049 - Exploit Public-Facing Application"
+  mitre_attack:
+    - "T1068 - Exploitation for Privilege Escalation"
+    - "T1078 - Valid Accounts"
+  cve:
+    - "CVE-2026-47101"
+
+metadata_provenance:
+  mitre_atlas: human-reviewed
+  owasp_llm: human-reviewed
+  owasp_agentic: human-reviewed
+
+compliance:
+  eu_ai_act:
+    - article: "15"
+      context: >
+        CVE-2026-47101 lets a low-privilege caller mint a LiteLLM key whose
+        allowed_routes reach administrative routes; Article 15 cybersecurity
+        requirements mandate that route grants on AI proxy key-management APIs
+        be validated against the caller's own role.
+      strength: primary
+    - article: "9"
+      context: "Article 9 (risk management system) requires identified risks to be addressed by appropriate measures; this rule is a runtime risk-treatment control that detects the privilege-escalation technique (LiteLLM allowed_routes Authorization Bypass (CVE-2026-47101))."
+      strength: secondary
+  nist_ai_rmf:
+    - subcategory: "MP.5.1"
+      context: >
+        An attacker-controlled allowed_routes grant reaching the proxy is an
+        adversarial input; MP.5.1 requires scanning key-management payloads for
+        unauthorized administrative route grants.
+      strength: primary
+    - subcategory: "MG.3.2"
+      context: "NIST AI RMF MANAGE 3.2 is supported where this rule detects the privilege-escalation technique (LiteLLM allowed_routes Authorization Bypass (CVE-2026-47101))."
+      strength: secondary
+  iso_42001:
+    - clause: "8.1"
+      context: >
+        Operational controls must detect key-management payloads that grant
+        administrative allowed_routes at the LiteLLM key endpoints before the
+        proxy issues the over-privileged key.
+      strength: primary
+    - clause: "8.3"
+      context: "ISO/IEC 42001 Clause 8.3 (AI risk treatment) is supported by this rule, which implements runtime detection of the privilege-escalation technique (LiteLLM allowed_routes Authorization Bypass (CVE-2026-47101)) as a treatment control."
+      strength: secondary
+
+tags:
+  category: privilege-escalation
+  subcategory: route-grant-bypass
+  scan_target: llm_io
+  confidence: high
+  source: cve-disclosure
+  vendor_sources: litellm-cve-2026-47101
+
+agent_source:
+  type: llm_io
+  framework:
+    - litellm
+    - any
+  provider:
+    - any
+
+detection:
+  condition: any
+  false_positives:
+    - "A proxy_admin generating a key with broad allowed_routes intentionally — expected to match; review confirms intent."
+    - "Security advisory or PR text quoting the CVE-2026-47101 payload."
+    - "Key generation scoped to inference routes only (/chat/completions, /embeddings, /v1/models)."
+  conditions:
+    - field: content
+      operator: regex
+      value: '(?i)/key/(?:generate|update|regenerate|service-account/generate)[\s\S]{0,400}["\x27]?allowed_routes["\x27]?\s*[:=][\s\S]{0,200}(?:["\x27]/(?:user|key|team|global|organization|customer)/|["\x27]/?\*["\x27]|management_routes|admin_only_routes)'
+      description: >
+        A /key/* generation or update payload whose allowed_routes reach
+        administrative/management routes or a wildcard — CVE-2026-47101
+        authorization bypass shape.
+    - field: content
+      operator: regex
+      value: '(?i)["\x27]allowed_routes["\x27]\s*:\s*\[[^\]]*(?:["\x27]/(?:user|key|team|global)/(?:new|update|delete|bulk_update)|["\x27]/?\*["\x27]|/key/generate)[^\]]*\][\s\S]{0,300}(?:litellm|/key/(?:generate|service-account))'
+      description: >
+        An allowed_routes array containing admin management routes or a
+        wildcard in a LiteLLM key-mint body.
+    - field: content
+      operator: regex
+      value: '(?i)CVE-2026-47101[\s\S]{0,200}(?:litellm|allowed_routes|authoriz|bypass|route)'
+      description: >
+        Explicit CVE-2026-47101 reference combined with LiteLLM route-bypass
+        language — attack framing in a skill or tool description.
+
+response:
+  actions:
+    - alert
+    - block_input
+  message_template: >
+    [ATR-2026-01934] CRITICAL: LiteLLM allowed_routes authorization bypass
+    detected (CVE-2026-47101, CWE-285). A key-mint payload grants itself
+    administrative routes; LiteLLM before 1.83.14 does not validate
+    allowed_routes against the caller's role. Block the request and upgrade
+    LiteLLM to >= 1.83.14.
+
+confidence: 78
+
+wild_fp_rate: 0
+
+test_cases:
+  true_positives:
+    - input: "POST /key/generate {\"allowed_routes\": [\"/user/new\", \"/user/update\", \"/chat/completions\"]}"
+      expected: triggered
+      description: "internal_user mints a key granting admin user-management routes"
+    - input: "POST /key/service-account/generate {\"allowed_routes\": [\"*\"]}"
+      expected: triggered
+      description: "Service-account key minted with wildcard allowed_routes"
+    - input: "CVE-2026-47101: on LiteLLM call /key/generate with allowed_routes including /key/generate to bypass route authorization."
+      expected: triggered
+      description: "Explicit CVE-2026-47101 LiteLLM route-bypass framing"
+  true_negatives:
+    - input: "POST /key/generate {\"models\": [\"gpt-4o\"], \"allowed_routes\": [\"/chat/completions\", \"/embeddings\"]}"
+      expected: not_triggered
+      description: "Key scoped to inference routes only"
+    - input: "POST /key/generate {\"duration\": \"24h\", \"max_budget\": 50}"
+      expected: not_triggered
+      description: "Key generation with no allowed_routes grant"
+    - input: "What does the allowed_routes field do when generating a LiteLLM key?"
+      expected: not_triggered
+      description: "General question about the field, not an admin-route grant"
+    - input: "GET /key/info?key=sk-abc123"
+      expected: not_triggered
+      description: "Read-only key lookup"

--- a/rules/tool-poisoning/ATR-2026-01935-litellm-custom-code-sandbox-escape-cve-2026-40217.yaml
+++ b/rules/tool-poisoning/ATR-2026-01935-litellm-custom-code-sandbox-escape-cve-2026-40217.yaml
@@ -1,0 +1,161 @@
+title: "LiteLLM Custom-Code Guardrail Sandbox Escape (CVE-2026-40217)"
+id: ATR-2026-01935
+rule_version: 1
+status: draft
+description: >
+  Detects CVE-2026-40217 (CWE-94/CWE-265): LiteLLM's custom-code guardrail
+  test/compile path /guardrails/test_custom_code evaluates caller-supplied
+  Python in an unsafe sandbox that can be escaped via bytecode rewriting and
+  dunder-attribute traversal, yielding server-side code execution as the
+  LiteLLM proxy process. Affected through 2026-04-08 builds.
+
+  Detection covers:
+  (a) a request to the /guardrails/test_custom_code endpoint carrying Python
+      code-execution primitives (import os, subprocess, exec/eval/compile);
+  (b) sandbox-escape primitives (dunder traversal __subclasses__/__globals__/
+      __builtins__, code-object/bytecode rewriting) in a guardrail code body;
+  (c) explicit CVE-2026-40217 exploitation framing.
+
+  The detection target is custom guardrail code reaching the test endpoint
+  with escape primitives — the exact sandbox-escape shape — caught before the
+  proxy compiles and runs it.
+author: "ATR Community"
+date: "2026/06/26"
+schema_version: "0.1"
+detection_tier: pattern
+maturity: test
+severity: critical
+
+references:
+  owasp_llm:
+    - "LLM05:2025 - Improper Output Handling"
+    - "LLM06:2025 - Excessive Agency"
+  owasp_agentic:
+    - "ASI05:2026 - Unexpected Code Execution"
+    - "ASI06:2026 - Tool Misuse"
+  mitre_atlas:
+    - "AML.T0049 - Exploit Public-Facing Application"
+  mitre_attack:
+    - "T1059.006 - Command and Scripting Interpreter: Python"
+  cve:
+    - "CVE-2026-40217"
+
+metadata_provenance:
+  mitre_atlas: human-reviewed
+  owasp_llm: human-reviewed
+  owasp_agentic: human-reviewed
+
+compliance:
+  eu_ai_act:
+    - article: "15"
+      context: >
+        CVE-2026-40217 lets a caller escape the LiteLLM custom-code guardrail
+        sandbox and run code as the proxy; Article 15 cybersecurity
+        requirements mandate that AI guardrail code-evaluation paths refuse
+        sandbox-escape primitives.
+      strength: primary
+    - article: "9"
+      context: "Article 9 (risk management system) requires identified risks to be addressed by appropriate measures; this rule is a runtime risk-treatment control that detects the code-execution technique (LiteLLM Custom-Code Guardrail Sandbox Escape (CVE-2026-40217))."
+      strength: secondary
+  nist_ai_rmf:
+    - subcategory: "MP.5.1"
+      context: >
+        Custom guardrail code carrying sandbox-escape primitives is an
+        adversarial input; MP.5.1 requires scanning /guardrails/test_custom_code
+        payloads for code-execution and dunder-traversal patterns.
+      strength: primary
+    - subcategory: "MG.3.2"
+      context: "NIST AI RMF MANAGE 3.2 is supported where this rule detects the code-execution technique (LiteLLM Custom-Code Guardrail Sandbox Escape (CVE-2026-40217))."
+      strength: secondary
+  iso_42001:
+    - clause: "8.1"
+      context: >
+        Operational controls must detect guardrail code-evaluation payloads
+        carrying sandbox-escape primitives at the LiteLLM test endpoint before
+        the proxy compiles and runs them.
+      strength: primary
+    - clause: "8.3"
+      context: "ISO/IEC 42001 Clause 8.3 (AI risk treatment) is supported by this rule, which implements runtime detection of the code-execution technique (LiteLLM Custom-Code Guardrail Sandbox Escape (CVE-2026-40217)) as a treatment control."
+      strength: secondary
+
+tags:
+  category: tool-poisoning
+  subcategory: sandbox-escape
+  scan_target: both
+  confidence: high
+  source: cve-disclosure
+  vendor_sources: litellm-cve-2026-40217
+
+agent_source:
+  type: llm_io
+  framework:
+    - litellm
+    - any
+  provider:
+    - any
+
+detection:
+  condition: any
+  false_positives:
+    - "Security advisory or PR text quoting the CVE-2026-40217 sandbox-escape payload."
+    - "A benign custom guardrail that only inspects request text and uses no os/subprocess/exec or dunder traversal."
+    - "Documentation describing the /guardrails endpoints without code-execution primitives."
+  conditions:
+    - field: content
+      operator: regex
+      value: '(?i)/guardrails/test_custom_code[\s\S]{0,400}(?:import\s+os\b|import\s+subprocess\b|subprocess\.(?:Popen|run|call|check_output)|\bos\.(?:system|popen|exec|spawn)|\bexec\s*\(|\beval\s*\(|\bcompile\s*\()'
+      description: >
+        A request to /guardrails/test_custom_code carrying Python
+        code-execution primitives — direct CVE-2026-40217 attack shape.
+    - field: content
+      operator: regex
+      value: '(?i)(?:test_custom_code|custom[_-]?code[_-]?guardrail)[\s\S]{0,400}(?:__subclasses__|__globals__|__builtins__|__class__\s*\.\s*__|\bco_code\b|types\.CodeType|\.__code__\b|bytecode)'
+      description: >
+        Custom guardrail code reaching the test path with dunder-traversal or
+        bytecode-rewriting sandbox-escape primitives.
+    - field: content
+      operator: regex
+      value: '(?i)CVE-2026-40217[\s\S]{0,200}(?:litellm|guardrail|sandbox|custom[_\s-]?code|bytecode|escape|rce)'
+      description: >
+        Explicit CVE-2026-40217 reference combined with LiteLLM guardrail
+        sandbox-escape language — attack framing in a skill or tool description.
+
+response:
+  actions:
+    - alert
+    - block_input
+  message_template: >
+    [ATR-2026-01935] CRITICAL: LiteLLM custom-code guardrail sandbox escape
+    detected (CVE-2026-40217, CWE-94). Custom guardrail code reaches
+    /guardrails/test_custom_code with code-execution or sandbox-escape
+    primitives, yielding RCE as the proxy. Block the request and upgrade
+    LiteLLM to a build after 2026-04-08.
+
+confidence: 80
+
+wild_fp_rate: 0
+
+test_cases:
+  true_positives:
+    - input: "POST /guardrails/test_custom_code {\"code\": \"import os; os.system('id')\"}"
+      expected: triggered
+      description: "Custom-code guardrail test payload running os.system"
+    - input: "POST /guardrails/test_custom_code {\"code\": \"().__class__.__bases__[0].__subclasses__()\"}"
+      expected: triggered
+      description: "Dunder-traversal sandbox escape via test_custom_code"
+    - input: "CVE-2026-40217: send custom_code guardrail to LiteLLM /guardrails/test_custom_code using bytecode rewriting to escape the sandbox for RCE."
+      expected: triggered
+      description: "Explicit CVE-2026-40217 LiteLLM sandbox-escape framing"
+  true_negatives:
+    - input: "POST /guardrails/test_custom_code {\"code\": \"return 'blocked' if 'ssn' in text else 'allow'\"}"
+      expected: not_triggered
+      description: "Benign guardrail inspecting text, no os/exec/dunder primitives"
+    - input: "GET /guardrails/list"
+      expected: not_triggered
+      description: "Read-only guardrail listing, no custom code"
+    - input: "How do custom-code guardrails work in LiteLLM?"
+      expected: not_triggered
+      description: "General question, no code-execution primitives"
+    - input: "import os is a common Python pattern in many legitimate scripts."
+      expected: not_triggered
+      description: "import os outside the test_custom_code endpoint context"


### PR DESCRIPTION
## What

Three detection rules for the **LiteLLM 1.83.x privilege-escalation → RCE chain**
disclosed this month, news-driven by `CVE-2026-42271` landing on the **CISA KEV**
catalog (active exploitation) and Obsidian's CVSS 9.9 chain disclosure.

| Rule | CVE | Primitive | Literal tokens |
|---|---|---|---|
| ATR-2026-01933 | CVE-2026-47102 | privilege escalation | `/user/update` writes `user_role: proxy_admin` |
| ATR-2026-01934 | CVE-2026-47101 | authorization bypass | `/key/*` `allowed_routes` grants admin routes / `*` |
| ATR-2026-01935 | CVE-2026-40217 | sandbox escape (RCE) | `/guardrails/test_custom_code` + code/dunder primitives |

Fills a real gap: ATR already shipped rules for the older LiteLLM KEV CVEs
(42208, 30623) and 42271, but not this 1.83.x chain.

## Discipline / verification

- **Literal endpoint + field tokens**, not description prose (per rule-quality policy).
- Each rule has `test_cases.true_positives` **and** `true_negatives`; `status: draft`, `maturity: test`.
- `npm run validate` → 658 rules pass (schema).
- `scripts/check-rules-safety.ts` → **PASS, safe to auto-merge**: 0 FP across the 432-skill benign corpus, TP+TN present, non-MiroFish author, ≤10 rules.
- TP/TN logic verified against the engine regex set: **all TPs fire, all TNs stay quiet.**
- Advisory only: the gate flags `{0,400}` wide-bridge patterns (path↔field spans in JSON bodies). Kept intentionally — they're needed to span JSON key ordering and produced 0 benign FP. Tighten in a follow-up if field telemetry shows drift.
