### PR TITLE
docs(mapping): tag rug-pull/shadow rules with ATLAS AML.T0104 (Publish Poisoned AI Agent Tool)

### DIFF
--- a/rules/tool-poisoning/ATR-2026-00161-important-tag-cross-tool-shadowing.yaml
+++ b/rules/tool-poisoning/ATR-2026-00161-important-tag-cross-tool-shadowing.yaml
@@ -33,6 +33,7 @@ references:
     - "AML.T0051.001 - Indirect"
     - "AML.T0053 - AI Agent Tool Invocation"
     - "AML.T0110 - AI Agent Tool Poisoning"
+    - "AML.T0104 - Publish Poisoned AI Agent Tool"
   safe_mcp:
     - "SAFE-T1102 - Prompt Manipulation"
     - "SAFE-T1001 - Tool Poisoning"

--- a/rules/tool-poisoning/ATR-2026-00581-mcp-tool-rug-pull-post-approval-redefinition.yaml
+++ b/rules/tool-poisoning/ATR-2026-00581-mcp-tool-rug-pull-post-approval-redefinition.yaml
@@ -29,6 +29,7 @@ references:
   mitre_atlas:
   - "AML.T0053 - AI Agent Tool Invocation"
   - "AML.T0051.001 - Indirect"
+  - "AML.T0104 - Publish Poisoned AI Agent Tool"
   vulnerablemcp_id:
     - tool-poisoning-rce-rug-pull
   external:

--- a/rules/tool-poisoning/ATR-2026-01932-shadow-undeclared-mcp-server-registration.yaml
+++ b/rules/tool-poisoning/ATR-2026-01932-shadow-undeclared-mcp-server-registration.yaml
@@ -29,6 +29,7 @@ references:
     - "ASI09:2026 - Identity Spoofing and Impersonation"
   mitre_atlas:
     - "AML.T0010 - AI Supply Chain Compromise"
+    - "AML.T0104 - Publish Poisoned AI Agent Tool"
   mitre_attack:
     - "T1195.002 - Compromise Software Supply Chain"
     - "T1036 - Masquerading"


### PR DESCRIPTION
## What

Map ATR's three flagship supply-chain rug-pull / shadow-tool rules to MITRE
ATLAS **AML.T0104 — Publish Poisoned AI Agent Tool**, the technique ATLAS
v5.4.0 surfaced for exactly this pattern (a tool published clean, then poisoned
in a later version — e.g. the **postmark-mcp** in-the-wild incident: 15 clean
releases, then an exfiltration update).

| Rule | Detects | Was missing T0104 |
|---|---|---|
| ATR-2026-00581 | MCP tool rug-pull (post-approval redefinition) | yes → added |
| ATR-2026-01932 | shadow / undeclared MCP server registration | yes → added |
| ATR-2026-00161 | important-tag cross-tool shadowing (refs the postmark case) | yes → added |

## Notes

- Reference-only change (adds one `mitre_atlas` line per rule); detection logic untouched.
- Matches the repo's existing `AML.T0104 - Publish Poisoned AI Agent Tool` string convention.
- All three files parse cleanly; CI `validate-rules` covers schema.
