### PR TITLE
docs(crosswalk): add ATR to MITRE ATT&CK / ATLAS crosswalk + metadata hygiene

### DIFF
--- a/data/stats.json
+++ b/data/stats.json
@@ -197,14 +197,14 @@
     {
       "source": "promptbench",
       "source_version": "snapshot-2026-04",
-      "atr_version": "3.5.0",
-      "measured_at": "2026-06-16",
+      "atr_version": "3.5.2",
+      "measured_at": "2026-06-25",
       "samples": 3280,
-      "recall": 0,
+      "recall": 0.23231707317073172,
       "precision": 1,
-      "f1": 0,
+      "f1": 0.3770410687778327,
       "fp_rate": 0,
-      "measurement_file": "data/measurements/promptbench/2026-06-16_promptbench-snapshot-2026-04_atr-3-5-0.json"
+      "measurement_file": "data/measurements/promptbench/2026-06-25_promptbench-snapshot-2026-04_atr-3-5-2.json"
     },
     {
       "source": "promptfoo",
@@ -221,14 +221,14 @@
     {
       "source": "promptinject",
       "source_version": "snapshot-2026-04",
-      "atr_version": "3.5.0",
-      "measured_at": "2026-06-16",
+      "atr_version": "3.5.2",
+      "measured_at": "2026-06-25",
       "samples": 1080,
-      "recall": 0,
+      "recall": 1,
       "precision": 1,
-      "f1": 0,
+      "f1": 1,
       "fp_rate": 0,
-      "measurement_file": "data/measurements/promptinject/2026-06-16_promptinject-snapshot-2026-04_atr-3-5-0.json"
+      "measurement_file": "data/measurements/promptinject/2026-06-25_promptinject-snapshot-2026-04_atr-3-5-2.json"
     },
     {
       "source": "skill-benchmark",
@@ -255,5 +255,5 @@
       "measurement_file": "data/measurements/wild-scan/2026-04-14_wild-scan-corpus-2026-04-14_atr-2-0-0.json"
     }
   ],
-  "benchmarks_generated_at": "2026-06-18T05:30:43.175Z"
+  "benchmarks_generated_at": "2026-06-28T11:56:29.896Z"
 }

--- a/docs/crosswalks/atr-attack-crosswalk.md
+++ b/docs/crosswalks/atr-attack-crosswalk.md
@@ -1,0 +1,326 @@
+# ATR -> MITRE ATT&CK / ATLAS Crosswalk
+
+This document maps Agent Threat Rules (ATR) categories and rules to MITRE
+technique ids, so any ruleset that tags with MITRE ATT&CK (for example a
+Sigma ruleset using `tags: attack.txxxx`) can align with ATR on the shared
+technique-id axis. It was produced in response to
+agentshield-ai/sigma-ai#9.
+
+All technique ids below are read verbatim from each rule's `references`
+block. None are authored by hand. Regenerate with
+`python3 scripts/generate-attack-crosswalk.py`.
+
+## How to join against this crosswalk
+
+The clean, machine-derivable key is the enterprise ATT&CK technique id.
+ATR stores it as `references.mitre_attack: Txxxx`; a Sigma rule stores it
+as `tags: attack.txxxx`. They line up after case folding (ATR upper-cases
+and omits the prefix, Sigma lower-cases and prefixes `attack.`):
+
+    ATR   references.mitre_attack: T1059
+    Sigma tags: attack.t1059
+
+MITRE ATLAS (`AML.Txxxx`) and OWASP Agentic (`ASIxx`) are the
+agent-specific layer ATR carries that ATT&CK-tagged rulesets do not tag.
+They are included as additional columns so this document is the place that
+connects ATT&CK-tagged runtime rules to the agent frameworks. Those
+columns are still extracted from ATR metadata, not authored here.
+
+## Coverage
+
+- ATR rules total: 655
+- Rules carrying an enterprise ATT&CK id (`references.mitre_attack` Txxxx): 88
+- Distinct enterprise ATT&CK techniques referenced: 46
+- Rules carrying a MITRE ATLAS id (`references.mitre_atlas`): 655
+- Distinct MITRE ATLAS techniques referenced: 39
+- Rules carrying an OWASP Agentic id (`references.owasp_agentic`): 655
+- ATR categories (distinct `tags.category` values): 9
+
+Categories are keyed on each rule's `tags.category` metadata, not on its
+directory. The repo has ten rule directories, but three rules under
+`rules/model-security/` carry `tags.category` of `model-abuse` or
+`data-poisoning`, so nine distinct categories appear in the metadata.
+
+Data-fidelity note: a small number of rules carry an ATLAS short-form id
+(`T00xx`, e.g. AML.T0051) inside the `mitre_attack` field rather than in
+`mitre_atlas`. These are reported as ATLAS, not enterprise ATT&CK, so the
+ATT&CK join key stays clean. Affected entries:
+
+- `ATR-2026-00084` (prompt-injection): `T0051` -> treated as ATLAS `T0051`
+- `ATR-2026-00091` (prompt-injection): `T0051` -> treated as ATLAS `T0051`
+- `ATR-2026-00092` (prompt-injection): `T0010` -> treated as ATLAS `T0010`
+- `ATR-2026-00096` (tool-poisoning): `T0056` -> treated as ATLAS `T0056`
+
+## ATT&CK techniques referenced by ATR (the join surface)
+
+Every enterprise ATT&CK technique id present in ATR metadata, with the ATR
+rules that reference it. This is the column a Sigma `attack.txxxx` tag joins
+against.
+
+| ATT&CK technique | Name | ATR rules | ATR categories |
+|---|---|---|---|
+| T1027 | Obfuscated Files or Information | `ATR-2026-00535` | prompt-injection |
+| T1036 | Masquerading | `ATR-2026-00117`, `ATR-2026-00204`, `ATR-2026-00572`, `ATR-2026-01932` | agent-manipulation, privilege-escalation, tool-poisoning |
+| T1041 | Exfiltration Over C2 Channel | `ATR-2026-00201`, `ATR-2026-00576`, `ATR-2026-00863` | context-exfiltration, tool-poisoning |
+| T1048 | Exfiltration Over Alternative Protocol | `ATR-2026-01609` | privilege-escalation |
+| T1053 | Scheduled Task/Job | `ATR-2026-00107`, `ATR-2026-00204`, `ATR-2026-00441` | privilege-escalation |
+| T1059 | Command and Scripting Interpreter | `ATR-2026-00010`, `ATR-2026-00012`, `ATR-2026-00110`, `ATR-2026-00204`, `ATR-2026-00209`, `ATR-2026-00210`, `ATR-2026-00415`, `ATR-2026-00416`, `ATR-2026-00417`, `ATR-2026-00418`, `ATR-2026-00419`, `ATR-2026-00432`, `ATR-2026-00433`, `ATR-2026-00434`, `ATR-2026-00436`, `ATR-2026-00440`, `ATR-2026-00451`, `ATR-2026-00523`, `ATR-2026-00531`, `ATR-2026-00535`, `ATR-2026-00538`, `ATR-2026-00540`, `ATR-2026-00541`, `ATR-2026-00542`, `ATR-2026-00543`, `ATR-2026-00545`, `ATR-2026-00572`, `ATR-2026-00575`, `ATR-2026-01610`, `ATR-2026-01611`, `ATR-2026-01930`, `ATR-2026-01931` | agent-manipulation, model-abuse, privilege-escalation, prompt-injection, skill-compromise, tool-poisoning |
+| T1059.003 | Windows Command Shell | `ATR-2026-00537` | tool-poisoning |
+| T1059.004 | Command and Scripting Interpreter: Unix Shell | `ATR-2026-00111`, `ATR-2026-00532`, `ATR-2026-00536`, `ATR-2026-00863` | context-exfiltration, privilege-escalation, tool-poisoning |
+| T1059.006 | Python | `ATR-2026-00432`, `ATR-2026-00440`, `ATR-2026-00539`, `ATR-2026-00544` | agent-manipulation, privilege-escalation, tool-poisoning |
+| T1059.007 | JavaScript | `ATR-2026-00415`, `ATR-2026-00436` | privilege-escalation, tool-poisoning |
+| T1068 | Exploitation for Privilege Escalation | `ATR-2026-00417` | agent-manipulation |
+| T1070.004 | Indicator Removal on Host: File Deletion | `ATR-2026-00858` | context-exfiltration |
+| T1071 | Application Layer Protocol | `ATR-2026-00010`, `ATR-2026-00013`, `ATR-2026-00212` | context-exfiltration, tool-poisoning |
+| T1078 | Valid Accounts | `ATR-2026-00074`, `ATR-2026-00416`, `ATR-2026-00435`, `ATR-2026-00531`, `ATR-2026-00533`, `ATR-2026-00536`, `ATR-2026-00538`, `ATR-2026-00543` | agent-manipulation, tool-poisoning |
+| T1082 | System Information Discovery | `ATR-2026-00115` | context-exfiltration |
+| T1083 | File and Directory Discovery | `ATR-2026-00012`, `ATR-2026-00546`, `ATR-2026-01608`, `ATR-2026-01616` | context-exfiltration, privilege-escalation, tool-poisoning |
+| T1090 | Proxy | `ATR-2026-00013`, `ATR-2026-00547`, `ATR-2026-01606` | context-exfiltration, privilege-escalation, tool-poisoning |
+| T1111 | Multi-Factor Authentication Interception | `ATR-2026-00862` | context-exfiltration |
+| T1129 | Shared Modules | `ATR-2026-00112` | privilege-escalation |
+| T1190 | Exploit Public-Facing Application | `ATR-2026-00210`, `ATR-2026-00415`, `ATR-2026-00416`, `ATR-2026-00434`, `ATR-2026-00435`, `ATR-2026-00448`, `ATR-2026-00451`, `ATR-2026-00531`, `ATR-2026-00532`, `ATR-2026-00533`, `ATR-2026-00534`, `ATR-2026-00536`, `ATR-2026-00537`, `ATR-2026-00538`, `ATR-2026-00540`, `ATR-2026-00541`, `ATR-2026-00542`, `ATR-2026-00545`, `ATR-2026-01600`, `ATR-2026-01602`, `ATR-2026-01603`, `ATR-2026-01604` | agent-manipulation, privilege-escalation, tool-poisoning |
+| T1195 | Supply Chain Compromise | `ATR-2026-00060`, `ATR-2026-00418`, `ATR-2026-01930` | agent-manipulation, skill-compromise, tool-poisoning |
+| T1195.002 | Compromise Software Supply Chain | `ATR-2026-00419`, `ATR-2026-00433`, `ATR-2026-00523`, `ATR-2026-00524`, `ATR-2026-00572`, `ATR-2026-00575`, `ATR-2026-00576`, `ATR-2026-01932` | context-exfiltration, model-abuse, skill-compromise, tool-poisoning |
+| T1204 | User Execution | `ATR-2026-00118` | agent-manipulation |
+| T1485 | Data Destruction | `ATR-2026-00858`, `ATR-2026-01601` | context-exfiltration, privilege-escalation |
+| T1499 | Endpoint Denial of Service | `ATR-2026-00209` | tool-poisoning |
+| T1528 | Steal Application Access Token | `ATR-2026-00114` | context-exfiltration |
+| T1530 | Data from Cloud Storage Object | `ATR-2026-00449` | context-exfiltration |
+| T1539 | Steal Web Session Cookie | `ATR-2026-00524` | context-exfiltration |
+| T1543 | Create or Modify System Process | `ATR-2026-00204` | privilege-escalation |
+| T1546 | Event Triggered Execution | `ATR-2026-00418`, `ATR-2026-00419`, `ATR-2026-00450`, `ATR-2026-00523`, `ATR-2026-00572`, `ATR-2026-00575` | agent-manipulation, data-poisoning, skill-compromise, tool-poisoning |
+| T1546.016 | Boot or Logon Autostart Execution: .pth Files | `ATR-2026-00544` | tool-poisoning |
+| T1547 | Boot or Logon Autostart Execution | `ATR-2026-00441` | privilege-escalation |
+| T1547.001 | Registry Run Keys / Startup Folder | `ATR-2026-00441` | privilege-escalation |
+| T1548 | Abuse Elevation Control Mechanism | `ATR-2026-00040` | privilege-escalation |
+| T1550 | Use Alternate Authentication Material | `ATR-2026-00074` | agent-manipulation |
+| T1552 | Unsecured Credentials | `ATR-2026-00212`, `ATR-2026-00431`, `ATR-2026-00524`, `ATR-2026-00534`, `ATR-2026-00546`, `ATR-2026-01931` | context-exfiltration, privilege-escalation, tool-poisoning |
+| T1552.001 | Credentials In Files | `ATR-2026-00113`, `ATR-2026-00201`, `ATR-2026-00524`, `ATR-2026-00576`, `ATR-2026-00863` | context-exfiltration, tool-poisoning |
+| T1552.005 | Cloud Instance Metadata API | `ATR-2026-00547`, `ATR-2026-01605`, `ATR-2026-01607` | context-exfiltration, privilege-escalation |
+| T1553 | Subvert Trust Controls | `ATR-2026-00539` | privilege-escalation |
+| T1557 | Adversary-in-the-Middle | `ATR-2026-00116` | agent-manipulation |
+| T1565 | Data Manipulation | `ATR-2026-00070`, `ATR-2026-00450` | data-poisoning |
+| T1565.001 | Data Manipulation: Stored Data Manipulation | `ATR-2026-00075`, `ATR-2026-00200`, `ATR-2026-01155` | context-exfiltration, data-poisoning, skill-compromise |
+| T1566 | Phishing | `ATR-2026-00119`, `ATR-2026-00420` | agent-manipulation, prompt-injection |
+| T1567 | Exfiltration Over Web Service | `ATR-2026-00420` | prompt-injection |
+| T1611 | Escape to Host | `ATR-2026-00040`, `ATR-2026-00436`, `ATR-2026-00441`, `ATR-2026-00539`, `ATR-2026-01615` | privilege-escalation |
+| T1657 | Financial Theft | `ATR-2026-00860`, `ATR-2026-00861` | context-exfiltration |
+
+## Crosswalk by ATR category
+
+For each ATR category: the enterprise ATT&CK techniques its rules reference
+(the shared join key), plus the ATLAS and OWASP Agentic techniques ATR adds.
+
+### agent-manipulation
+
+Rules in category: 106
+
+ATT&CK techniques (join key):
+
+| ATT&CK technique | Name | ATR rules |
+|---|---|---|
+| T1036 | Masquerading | `ATR-2026-00117` |
+| T1059 | Command and Scripting Interpreter | `ATR-2026-00416`, `ATR-2026-00417`, `ATR-2026-00418`, `ATR-2026-00432`, `ATR-2026-00440` |
+| T1059.006 | Python | `ATR-2026-00432`, `ATR-2026-00440` |
+| T1068 | Exploitation for Privilege Escalation | `ATR-2026-00417` |
+| T1078 | Valid Accounts | `ATR-2026-00074`, `ATR-2026-00416` |
+| T1190 | Exploit Public-Facing Application | `ATR-2026-00416` |
+| T1195 | Supply Chain Compromise | `ATR-2026-00418` |
+| T1204 | User Execution | `ATR-2026-00118` |
+| T1546 | Event Triggered Execution | `ATR-2026-00418` |
+| T1550 | Use Alternate Authentication Material | `ATR-2026-00074` |
+| T1557 | Adversary-in-the-Middle | `ATR-2026-00116` |
+| T1566 | Phishing | `ATR-2026-00119` |
+
+ATLAS techniques ATR adds: AML.T0010, AML.T0040, AML.T0043, AML.T0048, AML.T0049, AML.T0050, AML.T0051, AML.T0051.000, AML.T0051.001, AML.T0052.000, AML.T0054
+
+OWASP Agentic categories ATR adds: ASI01:2026, ASI02:2026, ASI03, ASI03:2026, ASI04:2026, ASI05:2026, ASI06, ASI06:2026, ASI07:2026, ASI09:2026, ASI10:2026
+
+### context-exfiltration
+
+Rules in category: 104
+
+ATT&CK techniques (join key):
+
+| ATT&CK technique | Name | ATR rules |
+|---|---|---|
+| T1041 | Exfiltration Over C2 Channel | `ATR-2026-00201`, `ATR-2026-00863` |
+| T1059.004 | Command and Scripting Interpreter: Unix Shell | `ATR-2026-00863` |
+| T1070.004 | Indicator Removal on Host: File Deletion | `ATR-2026-00858` |
+| T1071 | Application Layer Protocol | `ATR-2026-00212` |
+| T1082 | System Information Discovery | `ATR-2026-00115` |
+| T1083 | File and Directory Discovery | `ATR-2026-01608` |
+| T1090 | Proxy | `ATR-2026-01606` |
+| T1111 | Multi-Factor Authentication Interception | `ATR-2026-00862` |
+| T1195.002 | Compromise Software Supply Chain | `ATR-2026-00524` |
+| T1485 | Data Destruction | `ATR-2026-00858` |
+| T1528 | Steal Application Access Token | `ATR-2026-00114` |
+| T1530 | Data from Cloud Storage Object | `ATR-2026-00449` |
+| T1539 | Steal Web Session Cookie | `ATR-2026-00524` |
+| T1552 | Unsecured Credentials | `ATR-2026-00212`, `ATR-2026-00431`, `ATR-2026-00524` |
+| T1552.001 | Credentials In Files | `ATR-2026-00113`, `ATR-2026-00201`, `ATR-2026-00524`, `ATR-2026-00863` |
+| T1552.005 | Cloud Instance Metadata API | `ATR-2026-01605`, `ATR-2026-01607` |
+| T1565.001 | Data Manipulation: Stored Data Manipulation | `ATR-2026-00075` |
+| T1657 | Financial Theft | `ATR-2026-00860`, `ATR-2026-00861` |
+
+ATLAS techniques ATR adds: AML.CS0036, AML.T0010, AML.T0024, AML.T0025, AML.T0040, AML.T0043, AML.T0048, AML.T0051, AML.T0051.001, AML.T0053, AML.T0054, AML.T0055, AML.T0056, AML.T0057, AML.T0069, AML.T0080, AML.T0088
+
+OWASP Agentic categories ATR adds: ASI01:2026, ASI02:2026, ASI03:2026, ASI04:2026, ASI05:2026, ASI06, ASI06:2026, ASI07:2026, ASI08, ASI08:2026, ASI09:2026
+
+### data-poisoning
+
+Rules in category: 6
+
+ATT&CK techniques (join key):
+
+| ATT&CK technique | Name | ATR rules |
+|---|---|---|
+| T1546 | Event Triggered Execution | `ATR-2026-00450` |
+| T1565 | Data Manipulation | `ATR-2026-00070`, `ATR-2026-00450` |
+| T1565.001 | Data Manipulation: Stored Data Manipulation | `ATR-2026-01155` |
+
+ATLAS techniques ATR adds: AML.T0018.000, AML.T0020, AML.T0051, AML.T0051.001, AML.T0070
+
+OWASP Agentic categories ATR adds: ASI01:2026, ASI04:2026, ASI06:2026
+
+### excessive-autonomy
+
+Rules in category: 30
+
+ATT&CK techniques (join key): none tagged in this category's rules.
+
+ATLAS techniques ATR adds: AML.T0011.001, AML.T0034, AML.T0044, AML.T0046, AML.T0050, AML.T0051, AML.T0051.001, AML.T0053, AML.T0057
+
+OWASP Agentic categories ATR adds: ASI01:2026, ASI02:2026, ASI03:2026, ASI04:2026, ASI05:2026, ASI06:2026, ASI07:2026, ASI08:2026, ASI09:2026, ASI10:2026
+
+### model-abuse
+
+Rules in category: 39
+
+ATT&CK techniques (join key):
+
+| ATT&CK technique | Name | ATR rules |
+|---|---|---|
+| T1059 | Command and Scripting Interpreter | `ATR-2026-00433` |
+| T1195.002 | Compromise Software Supply Chain | `ATR-2026-00433` |
+
+ATLAS techniques ATR adds: AML.T0010, AML.T0011.000, AML.T0024, AML.T0040, AML.T0044, AML.T0046, AML.T0048, AML.T0051, AML.T0057, AML.T0102
+
+OWASP Agentic categories ATR adds: ASI01:2026, ASI04:2026, ASI05:2026, ASI08:2026
+
+### privilege-escalation
+
+Rules in category: 37
+
+ATT&CK techniques (join key):
+
+| ATT&CK technique | Name | ATR rules |
+|---|---|---|
+| T1036 | Masquerading | `ATR-2026-00204` |
+| T1048 | Exfiltration Over Alternative Protocol | `ATR-2026-01609` |
+| T1053 | Scheduled Task/Job | `ATR-2026-00107`, `ATR-2026-00204`, `ATR-2026-00441` |
+| T1059 | Command and Scripting Interpreter | `ATR-2026-00110`, `ATR-2026-00204`, `ATR-2026-00436`, `ATR-2026-00451`, `ATR-2026-01610`, `ATR-2026-01611` |
+| T1059.004 | Command and Scripting Interpreter: Unix Shell | `ATR-2026-00111` |
+| T1059.006 | Python | `ATR-2026-00539` |
+| T1059.007 | JavaScript | `ATR-2026-00436` |
+| T1083 | File and Directory Discovery | `ATR-2026-00546`, `ATR-2026-01616` |
+| T1090 | Proxy | `ATR-2026-00547` |
+| T1129 | Shared Modules | `ATR-2026-00112` |
+| T1190 | Exploit Public-Facing Application | `ATR-2026-00451`, `ATR-2026-01600`, `ATR-2026-01602`, `ATR-2026-01603`, `ATR-2026-01604` |
+| T1485 | Data Destruction | `ATR-2026-01601` |
+| T1543 | Create or Modify System Process | `ATR-2026-00204` |
+| T1547 | Boot or Logon Autostart Execution | `ATR-2026-00441` |
+| T1547.001 | Registry Run Keys / Startup Folder | `ATR-2026-00441` |
+| T1548 | Abuse Elevation Control Mechanism | `ATR-2026-00040` |
+| T1552 | Unsecured Credentials | `ATR-2026-00546` |
+| T1552.005 | Cloud Instance Metadata API | `ATR-2026-00547` |
+| T1553 | Subvert Trust Controls | `ATR-2026-00539` |
+| T1611 | Escape to Host | `ATR-2026-00040`, `ATR-2026-00436`, `ATR-2026-00441`, `ATR-2026-00539`, `ATR-2026-01615` |
+
+ATLAS techniques ATR adds: AML.T0024, AML.T0040, AML.T0043, AML.T0047, AML.T0049, AML.T0050, AML.T0051, AML.T0053, AML.T0054, AML.T0080, AML.T0105
+
+OWASP Agentic categories ATR adds: ASI01:2026, ASI02:2026, ASI03, ASI03:2026, ASI04:2026, ASI05:2026, ASI06:2026, ASI07:2026
+
+### prompt-injection
+
+Rules in category: 219
+
+ATT&CK techniques (join key):
+
+| ATT&CK technique | Name | ATR rules |
+|---|---|---|
+| T1027 | Obfuscated Files or Information | `ATR-2026-00535` |
+| T1059 | Command and Scripting Interpreter | `ATR-2026-00535` |
+| T1566 | Phishing | `ATR-2026-00420` |
+| T1567 | Exfiltration Over Web Service | `ATR-2026-00420` |
+
+ATLAS techniques ATR adds: AML.CS0038, AML.T0010, AML.T0025, AML.T0036, AML.T0040, AML.T0043, AML.T0048, AML.T0050, AML.T0051, AML.T0051.000, AML.T0051.001, AML.T0054, AML.T0057
+
+OWASP Agentic categories ATR adds: ASI01, ASI01:2026, ASI03:2026, ASI04:2026, ASI05:2026, ASI06:2026, ASI07:2026, ASI08:2026, ASI10:2026
+
+### skill-compromise
+
+Rules in category: 41
+
+ATT&CK techniques (join key):
+
+| ATT&CK technique | Name | ATR rules |
+|---|---|---|
+| T1059 | Command and Scripting Interpreter | `ATR-2026-00523` |
+| T1195 | Supply Chain Compromise | `ATR-2026-00060` |
+| T1195.002 | Compromise Software Supply Chain | `ATR-2026-00523` |
+| T1546 | Event Triggered Execution | `ATR-2026-00523` |
+| T1565.001 | Data Manipulation: Stored Data Manipulation | `ATR-2026-00200` |
+
+ATLAS techniques ATR adds: AML.T0010, AML.T0011.000, AML.T0018.000, AML.T0020, AML.T0024, AML.T0040, AML.T0044, AML.T0048, AML.T0050, AML.T0051, AML.T0051.001, AML.T0053, AML.T0057, AML.T0060, AML.T0080, AML.T0104, AML.T0109
+
+OWASP Agentic categories ATR adds: ASI01:2026, ASI02:2026, ASI03:2026, ASI04, ASI04:2026, ASI05:2026, ASI06:2026, ASI07:2026, ASI08:2026, ASI09:2026
+
+### tool-poisoning
+
+Rules in category: 73
+
+ATT&CK techniques (join key):
+
+| ATT&CK technique | Name | ATR rules |
+|---|---|---|
+| T1036 | Masquerading | `ATR-2026-00572`, `ATR-2026-01932` |
+| T1041 | Exfiltration Over C2 Channel | `ATR-2026-00576` |
+| T1059 | Command and Scripting Interpreter | `ATR-2026-00010`, `ATR-2026-00012`, `ATR-2026-00209`, `ATR-2026-00210`, `ATR-2026-00415`, `ATR-2026-00419`, `ATR-2026-00434`, `ATR-2026-00531`, `ATR-2026-00538`, `ATR-2026-00540`, `ATR-2026-00541`, `ATR-2026-00542`, `ATR-2026-00543`, `ATR-2026-00545`, `ATR-2026-00572`, `ATR-2026-00575`, `ATR-2026-01930`, `ATR-2026-01931` |
+| T1059.003 | Windows Command Shell | `ATR-2026-00537` |
+| T1059.004 | Command and Scripting Interpreter: Unix Shell | `ATR-2026-00532`, `ATR-2026-00536` |
+| T1059.006 | Python | `ATR-2026-00544` |
+| T1059.007 | JavaScript | `ATR-2026-00415` |
+| T1071 | Application Layer Protocol | `ATR-2026-00010`, `ATR-2026-00013` |
+| T1078 | Valid Accounts | `ATR-2026-00435`, `ATR-2026-00531`, `ATR-2026-00533`, `ATR-2026-00536`, `ATR-2026-00538`, `ATR-2026-00543` |
+| T1083 | File and Directory Discovery | `ATR-2026-00012` |
+| T1090 | Proxy | `ATR-2026-00013` |
+| T1190 | Exploit Public-Facing Application | `ATR-2026-00210`, `ATR-2026-00415`, `ATR-2026-00434`, `ATR-2026-00435`, `ATR-2026-00448`, `ATR-2026-00531`, `ATR-2026-00532`, `ATR-2026-00533`, `ATR-2026-00534`, `ATR-2026-00536`, `ATR-2026-00537`, `ATR-2026-00538`, `ATR-2026-00540`, `ATR-2026-00541`, `ATR-2026-00542`, `ATR-2026-00545` |
+| T1195 | Supply Chain Compromise | `ATR-2026-01930` |
+| T1195.002 | Compromise Software Supply Chain | `ATR-2026-00419`, `ATR-2026-00572`, `ATR-2026-00575`, `ATR-2026-00576`, `ATR-2026-01932` |
+| T1499 | Endpoint Denial of Service | `ATR-2026-00209` |
+| T1546 | Event Triggered Execution | `ATR-2026-00419`, `ATR-2026-00572`, `ATR-2026-00575` |
+| T1546.016 | Boot or Logon Autostart Execution: .pth Files | `ATR-2026-00544` |
+| T1552 | Unsecured Credentials | `ATR-2026-00534`, `ATR-2026-01931` |
+| T1552.001 | Credentials In Files | `ATR-2026-00576` |
+
+ATLAS techniques ATR adds: AML.T0010, AML.T0019, AML.T0024, AML.T0040, AML.T0049, AML.T0051, AML.T0051.001, AML.T0053, AML.T0056, AML.T0057, AML.T0069, AML.T0070, AML.T0110
+
+OWASP Agentic categories ATR adds: ASI01:2026, ASI02:2026, ASI03:2026, ASI04:2026, ASI05:2026, ASI06:2026, ASI07:2026, ASI08:2026, ASI09:2026
+
+## Methodology
+
+- Source of truth: the YAML rule files under `rules/`. Each rule's
+  `references` block carries `mitre_attack`, `mitre_atlas`, and
+  `owasp_agentic` lists in `Txxxx - Name` form.
+- The generator (`scripts/generate-attack-crosswalk.py`) parses every rule,
+  takes the leading id token from each entry, and classifies it: `T1xxx`
+  (optionally `.NNN`) is enterprise ATT&CK; `AML.Txxxx` or short-form
+  `T00xx` is ATLAS.
+- The ATT&CK column is fully auto-derivable and is what an ATT&CK-tagged
+  ruleset joins against. ATLAS and OWASP Agentic columns are likewise
+  extracted from metadata, not hand-authored.
+- All counts above are computed by the generator at build time; none are
+  hard-coded. Re-run the script to refresh after rule changes.
+- License: ATR is MIT. This crosswalk may be reused under the same terms.
+

--- a/docs/crosswalks/atr-attack-crosswalk.md
+++ b/docs/crosswalks/atr-attack-crosswalk.md
@@ -41,16 +41,6 @@ directory. The repo has ten rule directories, but three rules under
 `rules/model-security/` carry `tags.category` of `model-abuse` or
 `data-poisoning`, so nine distinct categories appear in the metadata.
 
-Data-fidelity note: a small number of rules carry an ATLAS short-form id
-(`T00xx`, e.g. AML.T0051) inside the `mitre_attack` field rather than in
-`mitre_atlas`. These are reported as ATLAS, not enterprise ATT&CK, so the
-ATT&CK join key stays clean. Affected entries:
-
-- `ATR-2026-00084` (prompt-injection): `T0051` -> treated as ATLAS `T0051`
-- `ATR-2026-00091` (prompt-injection): `T0051` -> treated as ATLAS `T0051`
-- `ATR-2026-00092` (prompt-injection): `T0010` -> treated as ATLAS `T0010`
-- `ATR-2026-00096` (tool-poisoning): `T0056` -> treated as ATLAS `T0056`
-
 ## ATT&CK techniques referenced by ATR (the join surface)
 
 Every enterprise ATT&CK technique id present in ATR metadata, with the ATR
@@ -134,7 +124,7 @@ ATT&CK techniques (join key):
 
 ATLAS techniques ATR adds: AML.T0010, AML.T0040, AML.T0043, AML.T0048, AML.T0049, AML.T0050, AML.T0051, AML.T0051.000, AML.T0051.001, AML.T0052.000, AML.T0054
 
-OWASP Agentic categories ATR adds: ASI01:2026, ASI02:2026, ASI03, ASI03:2026, ASI04:2026, ASI05:2026, ASI06, ASI06:2026, ASI07:2026, ASI09:2026, ASI10:2026
+OWASP Agentic categories ATR adds: ASI01:2026, ASI02:2026, ASI03:2026, ASI04:2026, ASI05:2026, ASI06:2026, ASI07:2026, ASI09:2026, ASI10:2026
 
 ### context-exfiltration
 
@@ -165,7 +155,7 @@ ATT&CK techniques (join key):
 
 ATLAS techniques ATR adds: AML.CS0036, AML.T0010, AML.T0024, AML.T0025, AML.T0040, AML.T0043, AML.T0048, AML.T0051, AML.T0051.001, AML.T0053, AML.T0054, AML.T0055, AML.T0056, AML.T0057, AML.T0069, AML.T0080, AML.T0088
 
-OWASP Agentic categories ATR adds: ASI01:2026, ASI02:2026, ASI03:2026, ASI04:2026, ASI05:2026, ASI06, ASI06:2026, ASI07:2026, ASI08, ASI08:2026, ASI09:2026
+OWASP Agentic categories ATR adds: ASI01:2026, ASI02:2026, ASI03:2026, ASI04:2026, ASI05:2026, ASI06:2026, ASI07:2026, ASI08:2026, ASI09:2026
 
 ### data-poisoning
 
@@ -239,7 +229,7 @@ ATT&CK techniques (join key):
 
 ATLAS techniques ATR adds: AML.T0024, AML.T0040, AML.T0043, AML.T0047, AML.T0049, AML.T0050, AML.T0051, AML.T0053, AML.T0054, AML.T0080, AML.T0105
 
-OWASP Agentic categories ATR adds: ASI01:2026, ASI02:2026, ASI03, ASI03:2026, ASI04:2026, ASI05:2026, ASI06:2026, ASI07:2026
+OWASP Agentic categories ATR adds: ASI01:2026, ASI02:2026, ASI03:2026, ASI04:2026, ASI05:2026, ASI06:2026, ASI07:2026
 
 ### prompt-injection
 
@@ -256,7 +246,7 @@ ATT&CK techniques (join key):
 
 ATLAS techniques ATR adds: AML.CS0038, AML.T0010, AML.T0025, AML.T0036, AML.T0040, AML.T0043, AML.T0048, AML.T0050, AML.T0051, AML.T0051.000, AML.T0051.001, AML.T0054, AML.T0057
 
-OWASP Agentic categories ATR adds: ASI01, ASI01:2026, ASI03:2026, ASI04:2026, ASI05:2026, ASI06:2026, ASI07:2026, ASI08:2026, ASI10:2026
+OWASP Agentic categories ATR adds: ASI01:2026, ASI03:2026, ASI04:2026, ASI05:2026, ASI06:2026, ASI07:2026, ASI08:2026, ASI10:2026
 
 ### skill-compromise
 
@@ -274,7 +264,7 @@ ATT&CK techniques (join key):
 
 ATLAS techniques ATR adds: AML.T0010, AML.T0011.000, AML.T0018.000, AML.T0020, AML.T0024, AML.T0040, AML.T0044, AML.T0048, AML.T0050, AML.T0051, AML.T0051.001, AML.T0053, AML.T0057, AML.T0060, AML.T0080, AML.T0104, AML.T0109
 
-OWASP Agentic categories ATR adds: ASI01:2026, ASI02:2026, ASI03:2026, ASI04, ASI04:2026, ASI05:2026, ASI06:2026, ASI07:2026, ASI08:2026, ASI09:2026
+OWASP Agentic categories ATR adds: ASI01:2026, ASI02:2026, ASI03:2026, ASI04:2026, ASI05:2026, ASI06:2026, ASI07:2026, ASI08:2026, ASI09:2026
 
 ### tool-poisoning
 

--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/Users/user/Downloads/agent-threat-rules/node_modules

--- a/rules/agent-manipulation/ATR-2026-00139-casual-authority-redirect.yaml
+++ b/rules/agent-manipulation/ATR-2026-00139-casual-authority-redirect.yaml
@@ -17,8 +17,8 @@ references:
   owasp_llm:
     - LLM01:2025 - Prompt Injection
   owasp_agentic:
-    - ASI03 - Excessive Agency
-    - ASI06 - Rogue Actions
+    - ASI03:2026 - Excessive Agency
+    - ASI06:2026 - Rogue Actions
 metadata_provenance:
   mitre_atlas: auto-generated
 compliance:

--- a/rules/context-exfiltration/ATR-2026-00020-system-prompt-leak.yaml
+++ b/rules/context-exfiltration/ATR-2026-00020-system-prompt-leak.yaml
@@ -35,10 +35,10 @@ references:
 compliance:
   owasp_agentic:
     - id: ASI01:2026
-      context: "Revealing system prompt content enables adversaries to map agent constraints and craft targeted bypass attacks, directly enabling future Agent Goal Hijack attacks classified under ASI01."
+      context: "Revealing system prompt content enables adversaries to map agent constraints and craft targeted bypass attacks, directly enabling future Agent Goal Hijack attacks classified under ASI01:2026."
       strength: primary
     - id: ASI06:2026
-      context: "System prompt leakage exposes the agent's memory and context configuration to adversaries, falling under ASI06 Memory and Context Poisoning as an information disclosure precursor."
+      context: "System prompt leakage exposes the agent's memory and context configuration to adversaries, falling under ASI06:2026 Memory and Context Poisoning as an information disclosure precursor."
       strength: secondary
   owasp_llm:
     - id: LLM07:2025

--- a/rules/context-exfiltration/ATR-2026-00021-api-key-exposure.yaml
+++ b/rules/context-exfiltration/ATR-2026-00021-api-key-exposure.yaml
@@ -32,7 +32,7 @@ references:
 compliance:
   owasp_agentic:
     - id: ASI03:2026
-      context: "Credential exposure in agent output enables adversaries to abuse the identity and privileges associated with leaked keys, directly enabling unauthorized resource access classified under ASI03."
+      context: "Credential exposure in agent output enables adversaries to abuse the identity and privileges associated with leaked keys, directly enabling unauthorized resource access classified under ASI03:2026."
       strength: primary
   owasp_llm:
     - id: LLM02:2025

--- a/rules/context-exfiltration/ATR-2026-00136-tool-response-data-piggyback.yaml
+++ b/rules/context-exfiltration/ATR-2026-00136-tool-response-data-piggyback.yaml
@@ -17,8 +17,8 @@ references:
   owasp_llm:
     - LLM01:2025 - Prompt Injection
   owasp_agentic:
-    - ASI06 - Rogue Actions
-    - ASI08 - Data Leakage
+    - ASI06:2026 - Rogue Actions
+    - ASI08:2026 - Data Leakage
   mitre_atlas:
     - AML.T0054
   safe_mcp:

--- a/rules/context-exfiltration/ATR-2026-00141-example-format-key-leak.yaml
+++ b/rules/context-exfiltration/ATR-2026-00141-example-format-key-leak.yaml
@@ -17,7 +17,7 @@ references:
   owasp_llm:
     - LLM02:2025 - Sensitive Information Disclosure
   owasp_agentic:
-    - ASI08 - Data Leakage
+    - ASI08:2026 - Data Leakage
 metadata_provenance:
   mitre_atlas: auto-generated
 compliance:

--- a/rules/context-exfiltration/ATR-2026-00142-piggyback-transition-words.yaml
+++ b/rules/context-exfiltration/ATR-2026-00142-piggyback-transition-words.yaml
@@ -17,7 +17,7 @@ references:
   owasp_llm:
     - LLM01:2025 - Prompt Injection
   owasp_agentic:
-    - ASI08 - Data Leakage
+    - ASI08:2026 - Data Leakage
 metadata_provenance:
   mitre_atlas: auto-generated
 compliance:

--- a/rules/context-exfiltration/ATR-2026-00145-obfuscated-key-disclosure.yaml
+++ b/rules/context-exfiltration/ATR-2026-00145-obfuscated-key-disclosure.yaml
@@ -18,7 +18,7 @@ references:
   owasp_llm:
     - LLM02:2025 - Sensitive Information Disclosure
   owasp_agentic:
-    - ASI08 - Data Leakage
+    - ASI08:2026 - Data Leakage
 metadata_provenance:
   mitre_atlas: auto-generated
 compliance:

--- a/rules/context-exfiltration/ATR-2026-00146-env-var-existence-probe.yaml
+++ b/rules/context-exfiltration/ATR-2026-00146-env-var-existence-probe.yaml
@@ -18,7 +18,7 @@ references:
   owasp_llm:
     - LLM02:2025 - Sensitive Information Disclosure
   owasp_agentic:
-    - ASI08 - Data Leakage
+    - ASI08:2026 - Data Leakage
 metadata_provenance:
   mitre_atlas: auto-generated
 compliance:

--- a/rules/context-exfiltration/ATR-2026-00703-ipi-financial-data-exfil-indirect.yaml
+++ b/rules/context-exfiltration/ATR-2026-00703-ipi-financial-data-exfil-indirect.yaml
@@ -38,7 +38,7 @@ compliance:
       strength: primary
   owasp_agentic:
     - id: ASI07:2026
-      context: "Financial data exfiltration via agent-executed tool calls is the ASI07 Data and Model Exfiltration pattern."
+      context: "Financial data exfiltration via agent-executed tool calls is the ASI07:2026 Data and Model Exfiltration pattern."
       strength: primary
   nist_ai_rmf:
     - subcategory: "MS.2.7"

--- a/rules/context-exfiltration/ATR-2026-00704-ipi-medical-genetic-data-exfil.yaml
+++ b/rules/context-exfiltration/ATR-2026-00704-ipi-medical-genetic-data-exfil.yaml
@@ -38,7 +38,7 @@ compliance:
       strength: primary
   owasp_agentic:
     - id: ASI07:2026
-      context: "Medical record and genetic data exfiltration via agent tool calls is the ASI07 pattern applied to healthcare data."
+      context: "Medical record and genetic data exfiltration via agent tool calls is the ASI07:2026 pattern applied to healthcare data."
       strength: primary
   nist_ai_rmf:
     - subcategory: "MS.2.7"

--- a/rules/context-exfiltration/ATR-2026-00705-ipi-location-address-browsing-exfil.yaml
+++ b/rules/context-exfiltration/ATR-2026-00705-ipi-location-address-browsing-exfil.yaml
@@ -38,7 +38,7 @@ compliance:
       strength: primary
   owasp_agentic:
     - id: ASI07:2026
-      context: "Location and browsing data exfiltration via agent tool calls is the ASI07 pattern applied to personal tracking data."
+      context: "Location and browsing data exfiltration via agent tool calls is the ASI07:2026 pattern applied to personal tracking data."
       strength: primary
   nist_ai_rmf:
     - subcategory: "MS.2.7"

--- a/rules/context-exfiltration/ATR-2026-00706-ipi-physical-biometric-exfil.yaml
+++ b/rules/context-exfiltration/ATR-2026-00706-ipi-physical-biometric-exfil.yaml
@@ -38,7 +38,7 @@ compliance:
       strength: primary
   owasp_agentic:
     - id: ASI07:2026
-      context: "Deepfake audio generation and exfil via agent tool calls is the ASI07 pattern applied to biometric/physical media."
+      context: "Deepfake audio generation and exfil via agent tool calls is the ASI07:2026 pattern applied to biometric/physical media."
       strength: primary
   nist_ai_rmf:
     - subcategory: "MS.2.7"

--- a/rules/context-exfiltration/ATR-2026-00707-ipi-file-exfil-with-destroy-or-tamper.yaml
+++ b/rules/context-exfiltration/ATR-2026-00707-ipi-file-exfil-with-destroy-or-tamper.yaml
@@ -38,7 +38,7 @@ compliance:
       strength: primary
   owasp_agentic:
     - id: ASI07:2026
-      context: "File exfiltration followed by deletion or tampering via agent tool calls is the ASI07 pattern with additional data integrity impact."
+      context: "File exfiltration followed by deletion or tampering via agent tool calls is the ASI07:2026 pattern with additional data integrity impact."
       strength: primary
   nist_ai_rmf:
     - subcategory: "MS.2.7"

--- a/rules/context-exfiltration/ATR-2026-01807-asb-bulk-data-exfil-external.yaml
+++ b/rules/context-exfiltration/ATR-2026-01807-asb-bulk-data-exfil-external.yaml
@@ -49,7 +49,7 @@ compliance:
       strength: primary
   owasp_agentic:
     - id: "ASI02:2026"
-      context: "Bulk exfiltration of sensitive data to an external destination via the agent is an unauthorized action (ASI02)."
+      context: "Bulk exfiltration of sensitive data to an external destination via the agent is an unauthorized action (ASI02:2026)."
       strength: primary
   nist_ai_rmf:
     - subcategory: "MS.2.10"

--- a/rules/context-exfiltration/ATR-2026-01862-llmail-email-tool-exfil-confirmation.yaml
+++ b/rules/context-exfiltration/ATR-2026-01862-llmail-email-tool-exfil-confirmation.yaml
@@ -43,7 +43,7 @@ compliance:
       context: "An email-tool directive hidden in retrieved content steers the agent into exfiltrating data to a fixed attacker address, hijacking the agent's goal."
       strength: primary
     - id: ASI05:2026
-      context: "Acting on attacker instructions embedded in inbound email to invoke the send-email tool is an autonomous cascading action satisfying ASI05."
+      context: "Acting on attacker instructions embedded in inbound email to invoke the send-email tool is an autonomous cascading action satisfying ASI05:2026."
       strength: secondary
   owasp_llm:
     - id: LLM02:2025

--- a/rules/context-exfiltration/ATR-2026-01863-llmail-post-summary-exfil-directive.yaml
+++ b/rules/context-exfiltration/ATR-2026-01863-llmail-post-summary-exfil-directive.yaml
@@ -41,7 +41,7 @@ compliance:
       context: "A post-summary follow-up directive hidden in retrieved email steers the agent into emailing a fixed attacker address, hijacking the agent's goal after its legitimate task."
       strength: primary
     - id: ASI05:2026
-      context: "Chaining an exfiltration action onto completion of the summarization task is an autonomous cascading action satisfying ASI05."
+      context: "Chaining an exfiltration action onto completion of the summarization task is an autonomous cascading action satisfying ASI05:2026."
       strength: secondary
   owasp_llm:
     - id: LLM02:2025

--- a/rules/context-exfiltration/ATR-2026-01864-llmail-obfuscated-exfil-address.yaml
+++ b/rules/context-exfiltration/ATR-2026-01864-llmail-obfuscated-exfil-address.yaml
@@ -41,7 +41,7 @@ compliance:
       context: "An exfiltration directive using an obfuscated attacker address still hijacks the agent's goal toward emailing the attacker mailbox."
       strength: primary
     - id: ASI05:2026
-      context: "Tool-mediated exfiltration to an obfuscated external address is an autonomous cascading action satisfying ASI05."
+      context: "Tool-mediated exfiltration to an obfuscated external address is an autonomous cascading action satisfying ASI05:2026."
       strength: secondary
   owasp_llm:
     - id: LLM02:2025

--- a/rules/context-exfiltration/ATR-2026-01924-system-instruction-extraction-reformat.yaml
+++ b/rules/context-exfiltration/ATR-2026-01924-system-instruction-extraction-reformat.yaml
@@ -40,7 +40,7 @@ references:
 compliance:
   owasp_agentic:
     - id: ASI05:2026
-      context: "Reformat-based extraction of the agent's hidden instructions discloses sensitive system configuration, satisfying ASI05 Sensitive Information Disclosure."
+      context: "Reformat-based extraction of the agent's hidden instructions discloses sensitive system configuration, satisfying ASI05:2026 Sensitive Information Disclosure."
       strength: primary
     - id: ASI01:2026
       context: "Reciting the defense prompt as a 'summary' subverts the agent's confidentiality goal, a goal-hijack via laundered reformatting."

--- a/rules/data-poisoning/ATR-2026-00070-data-poisoning.yaml
+++ b/rules/data-poisoning/ATR-2026-00070-data-poisoning.yaml
@@ -33,7 +33,7 @@ references:
 compliance:
   owasp_agentic:
     - id: ASI06:2026
-      context: "Injecting hidden directives into RAG-retrieved documents or knowledge base entries is the primary ASI06 Memory and Context Poisoning attack — the agent's context window is contaminated with attacker-controlled instructions."
+      context: "Injecting hidden directives into RAG-retrieved documents or knowledge base entries is the primary ASI06:2026 Memory and Context Poisoning attack — the agent's context window is contaminated with attacker-controlled instructions."
       strength: primary
   owasp_llm:
     - id: LLM01:2025

--- a/rules/excessive-autonomy/ATR-2026-00050-runaway-agent-loop.yaml
+++ b/rules/excessive-autonomy/ATR-2026-00050-runaway-agent-loop.yaml
@@ -29,7 +29,7 @@ references:
 compliance:
   owasp_agentic:
     - id: ASI05:2026
-      context: "Runaway agent loops represent uncontrolled autonomous execution — the agent performs repeated identical actions without human intervention, satisfying the ASI05 Unexpected Code Execution category at the behavioral level."
+      context: "Runaway agent loops represent uncontrolled autonomous execution — the agent performs repeated identical actions without human intervention, satisfying the ASI05:2026 Unexpected Code Execution category at the behavioral level."
       strength: primary
   owasp_llm:
     - id: LLM06:2025

--- a/rules/excessive-autonomy/ATR-2026-00491-garak-agent-breaker-markdown-just-raw-json.yaml
+++ b/rules/excessive-autonomy/ATR-2026-00491-garak-agent-breaker-markdown-just-raw-json.yaml
@@ -27,7 +27,7 @@ references:
 compliance:
   owasp_agentic:
     - id: ASI06:2026
-      context: "Excessive autonomy attacks induce agents to perform actions beyond their authorized scope -- the canonical ASI06 Tool Misuse vector when executed via prompt manipulation."
+      context: "Excessive autonomy attacks induce agents to perform actions beyond their authorized scope -- the canonical ASI06:2026 Tool Misuse vector when executed via prompt manipulation."
       strength: primary
   owasp_llm:
     - id: LLM06:2025

--- a/rules/excessive-autonomy/ATR-2026-00500-ssrf-via-agent-url-fetch-instruction.yaml
+++ b/rules/excessive-autonomy/ATR-2026-00500-ssrf-via-agent-url-fetch-instruction.yaml
@@ -29,7 +29,7 @@ references:
 compliance:
   owasp_agentic:
     - id: ASI06:2026
-      context: "Excessive autonomy attacks induce agents to perform actions beyond their authorized scope -- the canonical ASI06 Tool Misuse vector when executed via prompt manipulation."
+      context: "Excessive autonomy attacks induce agents to perform actions beyond their authorized scope -- the canonical ASI06:2026 Tool Misuse vector when executed via prompt manipulation."
       strength: primary
   owasp_llm:
     - id: LLM06:2025

--- a/rules/excessive-autonomy/ATR-2026-00719-tool-misuse-destructive-bulk-action.yaml
+++ b/rules/excessive-autonomy/ATR-2026-00719-tool-misuse-destructive-bulk-action.yaml
@@ -32,7 +32,7 @@ compliance:
       strength: primary
   owasp_agentic:
     - id: ASI03:2026
-      context: "Bulk destructive actions (delete all tasks, turn off all devices) are ASI03 excessive agency with irreversible real-world impact."
+      context: "Bulk destructive actions (delete all tasks, turn off all devices) are ASI03:2026 excessive agency with irreversible real-world impact."
       strength: primary
   nist_ai_rmf:
     - subcategory: "MS.2.7"

--- a/rules/excessive-autonomy/ATR-2026-01773-semantic-excessive-agency-action.yaml
+++ b/rules/excessive-autonomy/ATR-2026-01773-semantic-excessive-agency-action.yaml
@@ -49,7 +49,7 @@ compliance:
       strength: primary
   owasp_agentic:
     - id: "ASI03:2026"
-      context: "Inducing the agent to act beyond intended scope or authorization is the ASI03 excessive-agency pattern."
+      context: "Inducing the agent to act beyond intended scope or authorization is the ASI03:2026 excessive-agency pattern."
       strength: primary
   nist_ai_rmf:
     - subcategory: "MS.2.7"

--- a/rules/excessive-autonomy/ATR-2026-01801-asb-autonomous-vehicle-sabotage.yaml
+++ b/rules/excessive-autonomy/ATR-2026-01801-asb-autonomous-vehicle-sabotage.yaml
@@ -49,7 +49,7 @@ compliance:
       strength: primary
   owasp_agentic:
     - id: "ASI03:2026"
-      context: "Weaponizing the agent's actuator/control tools against a moving vehicle is the ASI03 excessive-agency pattern."
+      context: "Weaponizing the agent's actuator/control tools against a moving vehicle is the ASI03:2026 excessive-agency pattern."
       strength: primary
   nist_ai_rmf:
     - subcategory: "MS.2.7"

--- a/rules/excessive-autonomy/ATR-2026-01804-asb-covert-unlogged-action.yaml
+++ b/rules/excessive-autonomy/ATR-2026-01804-asb-covert-unlogged-action.yaml
@@ -50,7 +50,7 @@ compliance:
       strength: primary
   owasp_agentic:
     - id: "ASI02:2026"
-      context: "Concealing an action from records or detection is an unauthorized-action pattern (ASI02) designed to evade accountability."
+      context: "Concealing an action from records or detection is an unauthorized-action pattern (ASI02:2026) designed to evade accountability."
       strength: primary
   nist_ai_rmf:
     - subcategory: "MS.2.7"

--- a/rules/excessive-autonomy/ATR-2026-01805-asb-financial-fraud-execution.yaml
+++ b/rules/excessive-autonomy/ATR-2026-01805-asb-financial-fraud-execution.yaml
@@ -50,7 +50,7 @@ compliance:
       strength: primary
   owasp_agentic:
     - id: "ASI02:2026"
-      context: "Executing fraudulent fund movements and fabricated records via the agent are unauthorized actions (ASI02)."
+      context: "Executing fraudulent fund movements and fabricated records via the agent are unauthorized actions (ASI02:2026)."
       strength: primary
   nist_ai_rmf:
     - subcategory: "MS.2.7"

--- a/rules/excessive-autonomy/ATR-2026-01806-asb-clinical-patient-harm.yaml
+++ b/rules/excessive-autonomy/ATR-2026-01806-asb-clinical-patient-harm.yaml
@@ -50,7 +50,7 @@ compliance:
       strength: primary
   owasp_agentic:
     - id: "ASI03:2026"
-      context: "Weaponizing a healthcare agent's order/record capability to harm a patient is the ASI03 excessive-agency pattern."
+      context: "Weaponizing a healthcare agent's order/record capability to harm a patient is the ASI03:2026 excessive-agency pattern."
       strength: primary
   nist_ai_rmf:
     - subcategory: "MS.2.6"

--- a/rules/excessive-autonomy/ATR-2026-01809-semantic-insider-manipulation-process-corruption.yaml
+++ b/rules/excessive-autonomy/ATR-2026-01809-semantic-insider-manipulation-process-corruption.yaml
@@ -62,7 +62,7 @@ compliance:
       strength: primary
   owasp_agentic:
     - id: "ASI02:2026"
-      context: "Process corruption and pretextual consequential actions performed via the agent are unauthorized actions (ASI02)."
+      context: "Process corruption and pretextual consequential actions performed via the agent are unauthorized actions (ASI02:2026)."
       strength: primary
   nist_ai_rmf:
     - subcategory: "MS.2.7"

--- a/rules/privilege-escalation/ATR-2026-00040-privilege-escalation.yaml
+++ b/rules/privilege-escalation/ATR-2026-00040-privilege-escalation.yaml
@@ -34,7 +34,7 @@ references:
 compliance:
   owasp_agentic:
     - id: ASI03:2026
-      context: "Privilege escalation via tool permission abuse or admin function invocation is the primary ASI03 Identity and Privilege Abuse scenario — the agent acquires capabilities exceeding its authorized scope."
+      context: "Privilege escalation via tool permission abuse or admin function invocation is the primary ASI03:2026 Identity and Privilege Abuse scenario — the agent acquires capabilities exceeding its authorized scope."
       strength: primary
   owasp_llm:
     - id: LLM06:2025

--- a/rules/privilege-escalation/ATR-2026-00143-casual-privilege-escalation.yaml
+++ b/rules/privilege-escalation/ATR-2026-00143-casual-privilege-escalation.yaml
@@ -18,7 +18,7 @@ references:
   owasp_llm:
     - LLM01:2025 - Prompt Injection
   owasp_agentic:
-    - ASI03 - Excessive Agency
+    - ASI03:2026 - Excessive Agency
 metadata_provenance:
   mitre_atlas: auto-generated
 compliance:

--- a/rules/privilege-escalation/ATR-2026-00144-rationalized-safety-bypass.yaml
+++ b/rules/privilege-escalation/ATR-2026-00144-rationalized-safety-bypass.yaml
@@ -18,7 +18,7 @@ references:
   owasp_llm:
     - LLM01:2025 - Prompt Injection
   owasp_agentic:
-    - ASI03 - Excessive Agency
+    - ASI03:2026 - Excessive Agency
 metadata_provenance:
   mitre_atlas: auto-generated
 compliance:

--- a/rules/privilege-escalation/ATR-2026-00528-praisonai-auth-disabled-default.yaml
+++ b/rules/privilege-escalation/ATR-2026-00528-praisonai-auth-disabled-default.yaml
@@ -33,7 +33,7 @@ compliance:
   owasp_agentic:
     - id: ASI01:2026
       context: >
-        ASI01 Improper IAM directly covers agent frameworks that ship
+        ASI01:2026 Improper IAM directly covers agent frameworks that ship
         with authentication disabled by default. Detection at install
         time stops the exposed-by-default deployment shape.
       strength: primary

--- a/rules/privilege-escalation/ATR-2026-01802-asb-backdoor-surveillance-implant.yaml
+++ b/rules/privilege-escalation/ATR-2026-01802-asb-backdoor-surveillance-implant.yaml
@@ -48,7 +48,7 @@ compliance:
       strength: primary
   owasp_agentic:
     - id: "ASI02:2026"
-      context: "Implanting persistent remote access via a maintenance window is an unauthorized action (ASI02) performed under the cover of a legitimate task."
+      context: "Implanting persistent remote access via a maintenance window is an unauthorized action (ASI02:2026) performed under the cover of a legitimate task."
       strength: primary
   nist_ai_rmf:
     - subcategory: "MS.2.7"

--- a/rules/privilege-escalation/ATR-2026-01803-asb-covert-server-intrusion.yaml
+++ b/rules/privilege-escalation/ATR-2026-01803-asb-covert-server-intrusion.yaml
@@ -50,7 +50,7 @@ compliance:
       strength: primary
   owasp_agentic:
     - id: "ASI02:2026"
-      context: "Covert process injection, anti-forensic log wiping, and DNS hijack are unauthorized actions (ASI02) performed under cover of normal operations."
+      context: "Covert process injection, anti-forensic log wiping, and DNS hijack are unauthorized actions (ASI02:2026) performed under cover of normal operations."
       strength: primary
   nist_ai_rmf:
     - subcategory: "MS.2.7"

--- a/rules/privilege-escalation/ATR-2026-01808-asb-synthetic-pan-payment-probe.yaml
+++ b/rules/privilege-escalation/ATR-2026-01808-asb-synthetic-pan-payment-probe.yaml
@@ -46,7 +46,7 @@ compliance:
       strength: primary
   owasp_agentic:
     - id: "ASI02:2026"
-      context: "Submitting synthetic card data to a production payment system is an unauthorized action (ASI02)."
+      context: "Submitting synthetic card data to a production payment system is an unauthorized action (ASI02:2026)."
       strength: primary
   nist_ai_rmf:
     - subcategory: "MS.2.7"

--- a/rules/prompt-injection/ATR-2026-00002-indirect-prompt-injection.yaml
+++ b/rules/prompt-injection/ATR-2026-00002-indirect-prompt-injection.yaml
@@ -40,7 +40,7 @@ compliance:
       context: "Indirect prompt injection hijacks agent goals via externally-consumed content (documents, web pages, API responses); the agent processes attacker-controlled instructions without user awareness."
       strength: primary
     - id: ASI06:2026
-      context: "Injection via external content poisons the agent's context window and memory with attacker-controlled directives, satisfying the ASI06 Memory and Context Poisoning category."
+      context: "Injection via external content poisons the agent's context window and memory with attacker-controlled directives, satisfying the ASI06:2026 Memory and Context Poisoning category."
       strength: secondary
   owasp_llm:
     - id: LLM01:2025

--- a/rules/prompt-injection/ATR-2026-00084-structured-data-injection.yaml
+++ b/rules/prompt-injection/ATR-2026-00084-structured-data-injection.yaml
@@ -19,8 +19,6 @@ references:
     - "LLM01:2025 - Prompt Injection"
   mitre_atlas:
     - "AML.T0051"
-  mitre_attack:
-    - "T0051"
 
   owasp_agentic:
     - ASI01:2026 - Agent Goal Hijack

--- a/rules/prompt-injection/ATR-2026-00091-nested-payload.yaml
+++ b/rules/prompt-injection/ATR-2026-00091-nested-payload.yaml
@@ -17,8 +17,6 @@ references:
     - LLM01:2025 - Prompt Injection
   mitre_atlas:
     - AML.T0051
-  mitre_attack:
-    - T0051
   owasp_agentic:
     - ASI01:2026 - Agent Goal Hijack
 metadata_provenance:

--- a/rules/prompt-injection/ATR-2026-00092-consensus-poisoning.yaml
+++ b/rules/prompt-injection/ATR-2026-00092-consensus-poisoning.yaml
@@ -17,8 +17,6 @@ references:
     - LLM01:2025 - Prompt Injection
   mitre_atlas:
     - AML.T0010
-  mitre_attack:
-    - T0010
   owasp_agentic:
     - ASI01:2026 - Agent Goal Hijack
 metadata_provenance:

--- a/rules/prompt-injection/ATR-2026-00137-authority-claim-injection.yaml
+++ b/rules/prompt-injection/ATR-2026-00137-authority-claim-injection.yaml
@@ -17,7 +17,7 @@ references:
   owasp_llm:
     - LLM01:2025 - Prompt Injection
   owasp_agentic:
-    - ASI01 - Prompt Injection
+    - ASI01:2026 - Prompt Injection
 metadata_provenance:
   mitre_atlas: auto-generated
 compliance:

--- a/rules/prompt-injection/ATR-2026-00138-fictional-framing-bypass.yaml
+++ b/rules/prompt-injection/ATR-2026-00138-fictional-framing-bypass.yaml
@@ -17,7 +17,7 @@ references:
   owasp_llm:
     - LLM01:2025 - Prompt Injection
   owasp_agentic:
-    - ASI01 - Prompt Injection
+    - ASI01:2026 - Prompt Injection
 metadata_provenance:
   mitre_atlas: auto-generated
 compliance:

--- a/rules/prompt-injection/ATR-2026-00140-indirect-reference-reversal.yaml
+++ b/rules/prompt-injection/ATR-2026-00140-indirect-reference-reversal.yaml
@@ -17,7 +17,7 @@ references:
   owasp_llm:
     - LLM01:2025 - Prompt Injection
   owasp_agentic:
-    - ASI01 - Prompt Injection
+    - ASI01:2026 - Prompt Injection
 metadata_provenance:
   mitre_atlas: auto-generated
 compliance:

--- a/rules/prompt-injection/ATR-2026-00148-language-switch-injection.yaml
+++ b/rules/prompt-injection/ATR-2026-00148-language-switch-injection.yaml
@@ -18,7 +18,7 @@ references:
   owasp_llm:
     - LLM01:2025 - Prompt Injection
   owasp_agentic:
-    - ASI01 - Prompt Injection
+    - ASI01:2026 - Prompt Injection
 metadata_provenance:
   mitre_atlas: auto-generated
 compliance:

--- a/rules/prompt-injection/ATR-2026-01800-asb-trigger-marker-tool-coercion.yaml
+++ b/rules/prompt-injection/ATR-2026-01800-asb-trigger-marker-tool-coercion.yaml
@@ -54,7 +54,7 @@ compliance:
       strength: secondary
   owasp_agentic:
     - id: "ASI03:2026"
-      context: "Coercing selection of a specific malicious tool via a fake conditional is the ASI03 tool-misuse pattern."
+      context: "Coercing selection of a specific malicious tool via a fake conditional is the ASI03:2026 tool-misuse pattern."
       strength: primary
   nist_ai_rmf:
     - subcategory: "MS.2.7"

--- a/rules/prompt-injection/ATR-2026-01860-llmail-chat-template-boundary-spoof.yaml
+++ b/rules/prompt-injection/ATR-2026-01860-llmail-chat-template-boundary-spoof.yaml
@@ -42,7 +42,7 @@ compliance:
       context: "Forged chat-template boundaries injected into retrieved email content hijack the agent's goal by laundering attacker directives as trusted user/tool turns."
       strength: primary
     - id: ASI06:2026
-      context: "Custom turn-boundary spoofing poisons the agent's context window with attacker-controlled role framing, satisfying ASI06 Memory and Context Poisoning."
+      context: "Custom turn-boundary spoofing poisons the agent's context window with attacker-controlled role framing, satisfying ASI06:2026 Memory and Context Poisoning."
       strength: secondary
   owasp_llm:
     - id: LLM01:2025

--- a/rules/prompt-injection/ATR-2026-01861-llmail-pseudo-xml-role-injection.yaml
+++ b/rules/prompt-injection/ATR-2026-01861-llmail-pseudo-xml-role-injection.yaml
@@ -39,7 +39,7 @@ compliance:
       context: "Forged XML role-boundary transitions injected into email content reframe attacker text as a privileged user/system turn, hijacking the agent's goal."
       strength: primary
     - id: ASI06:2026
-      context: "Fake role-tag transitions poison the agent's serialized context with attacker-controlled turn framing, satisfying ASI06 Memory and Context Poisoning."
+      context: "Fake role-tag transitions poison the agent's serialized context with attacker-controlled turn framing, satisfying ASI06:2026 Memory and Context Poisoning."
       strength: secondary
   owasp_llm:
     - id: LLM01:2025

--- a/rules/prompt-injection/ATR-2026-01865-llmail-fake-email-boundary-marker.yaml
+++ b/rules/prompt-injection/ATR-2026-01865-llmail-fake-email-boundary-marker.yaml
@@ -39,7 +39,7 @@ compliance:
       context: "A forged inter-email boundary marker makes the agent attribute an injected tool-call directive to a separate trusted message, hijacking the agent's goal."
       strength: primary
     - id: ASI06:2026
-      context: "Impersonating the harness's email-delimiter poisons the agent's context-window segmentation, satisfying ASI06 Memory and Context Poisoning."
+      context: "Impersonating the harness's email-delimiter poisons the agent's context-window segmentation, satisfying ASI06:2026 Memory and Context Poisoning."
       strength: secondary
   owasp_llm:
     - id: LLM01:2025

--- a/rules/prompt-injection/ATR-2026-01923-forged-input-boundary-markers.yaml
+++ b/rules/prompt-injection/ATR-2026-01923-forged-input-boundary-markers.yaml
@@ -42,7 +42,7 @@ compliance:
       context: "A forged end-of-input boundary reframes trailing attacker text as a privileged rule block, hijacking the agent's goal."
       strength: primary
     - id: ASI06:2026
-      context: "Percent-fence and bracket boundary markers poison the agent's context with attacker-controlled framing of where user input ends, satisfying ASI06."
+      context: "Percent-fence and bracket boundary markers poison the agent's context with attacker-controlled framing of where user input ends, satisfying ASI06:2026."
       strength: secondary
   owasp_llm:
     - id: LLM01:2025

--- a/rules/prompt-injection/ATR-2026-01925-encoded-payload-decoding-coercion.yaml
+++ b/rules/prompt-injection/ATR-2026-01925-encoded-payload-decoding-coercion.yaml
@@ -39,7 +39,7 @@ compliance:
       context: "Smuggling the target output inside an encoding and ordering a decode bypasses the agent's output policy, hijacking its gatekeeping goal."
       strength: primary
     - id: ASI06:2026
-      context: "Encoded payloads inject content the agent's safety layer cannot read in plaintext, a context-poisoning evasion satisfying ASI06."
+      context: "Encoded payloads inject content the agent's safety layer cannot read in plaintext, a context-poisoning evasion satisfying ASI06:2026."
       strength: secondary
   owasp_llm:
     - id: LLM01:2025

--- a/rules/skill-compromise/ATR-2026-00060-skill-impersonation.yaml
+++ b/rules/skill-compromise/ATR-2026-00060-skill-impersonation.yaml
@@ -31,7 +31,7 @@ references:
 compliance:
   owasp_agentic:
     - id: ASI04:2026
-      context: "MCP skill impersonation via typosquatting, namespace collision, and version spoofing is the primary ASI04 Agentic Supply Chain Vulnerabilities attack vector — malicious skills masquerade as trusted tools to gain agent execution context."
+      context: "MCP skill impersonation via typosquatting, namespace collision, and version spoofing is the primary ASI04:2026 Agentic Supply Chain Vulnerabilities attack vector — malicious skills masquerade as trusted tools to gain agent execution context."
       strength: primary
   owasp_llm:
     - id: LLM03:2025

--- a/rules/skill-compromise/ATR-2026-00147-fork-impersonation.yaml
+++ b/rules/skill-compromise/ATR-2026-00147-fork-impersonation.yaml
@@ -18,7 +18,7 @@ references:
   owasp_llm:
     - "LLM01:2025 - Prompt Injection"
   owasp_agentic:
-    - "ASI04 - Supply Chain Vulnerabilities"
+    - "ASI04:2026 - Supply Chain Vulnerabilities"
 metadata_provenance:
   mitre_atlas: auto-generated
 

--- a/rules/skill-compromise/ATR-2026-00525-mini-shai-hulud-gh-token-monitor-persistence.yaml
+++ b/rules/skill-compromise/ATR-2026-00525-mini-shai-hulud-gh-token-monitor-persistence.yaml
@@ -35,7 +35,7 @@ compliance:
     - id: ASI05:2026
       context: >
         Skill compromise via tampered npm/PyPI package is the canonical
-        ASI05 Supply Chain Compromise vector. Detecting the worm's
+        ASI05:2026 Supply Chain Compromise vector. Detecting the worm's
         persistence daemon string at install time enables blocking
         before token exfiltration.
       strength: primary

--- a/rules/skill-compromise/ATR-2026-00527-skill-silent-git-remote-mirror-exfiltration.yaml
+++ b/rules/skill-compromise/ATR-2026-00527-skill-silent-git-remote-mirror-exfiltration.yaml
@@ -34,7 +34,7 @@ compliance:
   owasp_agentic:
     - id: ASI04:2026
       context: >
-        Silent git mirror-push is a textbook ASI04 Data Exfiltration vector
+        Silent git mirror-push is a textbook ASI04:2026 Data Exfiltration vector
         executed through the agent's shell tool. The skill weaponizes the
         agent's existing repository access.
       strength: primary

--- a/rules/tool-poisoning/ATR-2026-00010-mcp-malicious-response.yaml
+++ b/rules/tool-poisoning/ATR-2026-00010-mcp-malicious-response.yaml
@@ -43,10 +43,10 @@ references:
 compliance:
   owasp_agentic:
     - id: ASI02:2026
-      context: "Malicious content injected via MCP tool responses is the primary ASI02 Tool Misuse and Exploitation vector — a compromised or impersonated MCP server weaponizes the tool call interface to deliver shells, encoded payloads, and privilege escalation commands."
+      context: "Malicious content injected via MCP tool responses is the primary ASI02:2026 Tool Misuse and Exploitation vector — a compromised or impersonated MCP server weaponizes the tool call interface to deliver shells, encoded payloads, and privilege escalation commands."
       strength: primary
     - id: ASI05:2026
-      context: "Shell commands and code execution payloads in tool responses aim to trigger unexpected code execution by the agent, falling under the ASI05 Unexpected Code Execution category."
+      context: "Shell commands and code execution payloads in tool responses aim to trigger unexpected code execution by the agent, falling under the ASI05:2026 Unexpected Code Execution category."
       strength: secondary
   owasp_llm:
     - id: LLM01:2025

--- a/rules/tool-poisoning/ATR-2026-00096-registry-poisoning.yaml
+++ b/rules/tool-poisoning/ATR-2026-00096-registry-poisoning.yaml
@@ -17,8 +17,6 @@ references:
     - LLM06:2025 - Excessive Agency
   mitre_atlas:
     - AML.T0056
-  mitre_attack:
-    - T0056
   owasp_agentic:
     - ASI05:2026 - Unexpected Code Execution
 metadata_provenance:

--- a/rules/tool-poisoning/ATR-2026-00494-garak-exploitation-mixedunassigned.yaml
+++ b/rules/tool-poisoning/ATR-2026-00494-garak-exploitation-mixedunassigned.yaml
@@ -28,7 +28,7 @@ references:
 compliance:
   owasp_agentic:
     - id: ASI06:2026
-      context: "Tool poisoning exploits the agent's tool execution capability, inducing the agent to invoke tools with attacker-controlled parameters -- the canonical ASI06 Tool Misuse vector."
+      context: "Tool poisoning exploits the agent's tool execution capability, inducing the agent to invoke tools with attacker-controlled parameters -- the canonical ASI06:2026 Tool Misuse vector."
       strength: primary
   owasp_llm:
     - id: LLM06:2025

--- a/rules/tool-poisoning/ATR-2026-00513-package-hallucination-exploitation.yaml
+++ b/rules/tool-poisoning/ATR-2026-00513-package-hallucination-exploitation.yaml
@@ -29,7 +29,7 @@ references:
 compliance:
   owasp_agentic:
     - id: ASI06:2026
-      context: "Tool poisoning exploits the agent's tool execution capability, inducing the agent to invoke tools with attacker-controlled parameters -- the canonical ASI06 Tool Misuse vector."
+      context: "Tool poisoning exploits the agent's tool execution capability, inducing the agent to invoke tools with attacker-controlled parameters -- the canonical ASI06:2026 Tool Misuse vector."
       strength: primary
   owasp_llm:
     - id: LLM06:2025

--- a/rules/tool-poisoning/ATR-2026-00521-shell-command-injection-agent-tool-context.yaml
+++ b/rules/tool-poisoning/ATR-2026-00521-shell-command-injection-agent-tool-context.yaml
@@ -31,7 +31,7 @@ references:
 compliance:
   owasp_agentic:
     - id: ASI06:2026
-      context: "Tool poisoning exploits the agent's tool execution capability, inducing the agent to invoke tools with attacker-controlled parameters -- the canonical ASI06 Tool Misuse vector."
+      context: "Tool poisoning exploits the agent's tool execution capability, inducing the agent to invoke tools with attacker-controlled parameters -- the canonical ASI06:2026 Tool Misuse vector."
       strength: primary
   owasp_llm:
     - id: LLM06:2025

--- a/rules/tool-poisoning/ATR-2026-00522-sql-injection-natural-language-agent-interface.yaml
+++ b/rules/tool-poisoning/ATR-2026-00522-sql-injection-natural-language-agent-interface.yaml
@@ -34,7 +34,7 @@ references:
 compliance:
   owasp_agentic:
     - id: ASI06:2026
-      context: "Tool poisoning exploits the agent's tool execution capability, inducing the agent to invoke tools with attacker-controlled parameters -- the canonical ASI06 Tool Misuse vector."
+      context: "Tool poisoning exploits the agent's tool execution capability, inducing the agent to invoke tools with attacker-controlled parameters -- the canonical ASI06:2026 Tool Misuse vector."
       strength: primary
   owasp_llm:
     - id: LLM06:2025

--- a/rules/tool-poisoning/ATR-2026-00526-claude-code-shell-metachar-in-double-quoted-path.yaml
+++ b/rules/tool-poisoning/ATR-2026-00526-claude-code-shell-metachar-in-double-quoted-path.yaml
@@ -35,7 +35,7 @@ compliance:
     - id: ASI06:2026
       context: >
         Path-argument command substitution exploits the agent's shell
-        tool execution capability — the canonical ASI06 Tool Misuse
+        tool execution capability — the canonical ASI06:2026 Tool Misuse
         vector when the agent is allowed to construct file path inputs.
       strength: primary
   owasp_llm:

--- a/rules/tool-poisoning/ATR-2026-00529-litellm-proxy-sqli-cisa-kev.yaml
+++ b/rules/tool-poisoning/ATR-2026-00529-litellm-proxy-sqli-cisa-kev.yaml
@@ -32,7 +32,7 @@ compliance:
   owasp_agentic:
     - id: ASI06:2026
       context: >
-        ASI06 Tool Misuse — the agent's LLM proxy tool is exploited via
+        ASI06:2026 Tool Misuse — the agent's LLM proxy tool is exploited via
         an injection vector. Detection on the request shape stops
         the exploit before SQL execution.
       strength: primary

--- a/rules/tool-poisoning/ATR-2026-00530-ms-agent-shell-tool-unsanitized-argv-rce.yaml
+++ b/rules/tool-poisoning/ATR-2026-00530-ms-agent-shell-tool-unsanitized-argv-rce.yaml
@@ -34,7 +34,7 @@ compliance:
   owasp_agentic:
     - id: ASI06:2026
       context: >
-        ASI06 Tool Misuse — the agent's shell tool accepts unsanitized
+        ASI06:2026 Tool Misuse — the agent's shell tool accepts unsanitized
         input as a direct exploit primitive. Detection on the unsafe
         invocation pattern blocks the class.
       strength: primary

--- a/scripts/generate-attack-crosswalk.py
+++ b/scripts/generate-attack-crosswalk.py
@@ -1,0 +1,312 @@
+#!/usr/bin/env python3
+"""Generate the ATR -> MITRE ATT&CK / ATLAS crosswalk document.
+
+This script reads the real MITRE mapping metadata out of every ATR rule YAML
+and emits docs/crosswalks/atr-attack-crosswalk.md. Nothing is invented: every
+technique id printed is read verbatim from a rule's `references` block.
+
+Join key (per agentshield-ai/sigma-ai#9 with @markbriers): the shared,
+machine-derivable axis between ATR and a Sigma ruleset is the enterprise
+ATT&CK technique id -- ATR's `references.mitre_attack: Txxxx` against Sigma's
+`tags: attack.txxxx` (case-folded). MITRE ATLAS (AML.Txxxx) and OWASP Agentic
+(ASIxx) are the agent-specific layer ATR carries that Sigma does not tag; they
+are surfaced here as the value-add columns, also read straight from metadata.
+
+Run:  python3 scripts/generate-attack-crosswalk.py
+      python3 scripts/generate-attack-crosswalk.py --check   # CI: verify doc is current
+"""
+from __future__ import annotations
+
+import argparse
+import glob
+import re
+import sys
+from collections import defaultdict
+
+try:
+    import yaml
+except ImportError:
+    sys.exit("PyYAML required: pip install pyyaml")
+
+RULES_GLOB = "rules/**/*.yaml"
+DOC_PATH = "docs/crosswalks/atr-attack-crosswalk.md"
+
+# Enterprise ATT&CK technique ids are T1000+ (optionally .NNN subtechnique).
+# ATLAS technique ids are AML.Txxxx, sometimes written in short form as T00xx.
+ATTACK_RE = re.compile(r"^(T1\d{3})(\.\d{3})?\b")
+ATLAS_SHORT_RE = re.compile(r"^(T0\d{2,3})\b")
+ATLAS_FULL_RE = re.compile(r"^(AML\.T\d{4})\b")
+
+
+def first_token(value: str) -> str:
+    """Return the id token from a 'Txxxx - Name' style string."""
+    return str(value).strip().split()[0] if str(value).strip() else ""
+
+
+def classify(token: str) -> str:
+    if ATTACK_RE.match(token):
+        return "attack"
+    if ATLAS_FULL_RE.match(token) or ATLAS_SHORT_RE.match(token):
+        return "atlas"
+    return "other"
+
+
+def load_rules() -> list[dict]:
+    rules = []
+    for path in sorted(glob.glob(RULES_GLOB, recursive=True)):
+        try:
+            doc = yaml.safe_load(open(path))
+        except Exception as exc:  # noqa: BLE001 - report and skip malformed YAML
+            print(f"WARN: could not parse {path}: {exc}", file=sys.stderr)
+            continue
+        if not isinstance(doc, dict):
+            continue
+        refs = doc.get("references") or {}
+        if not isinstance(refs, dict):
+            refs = {}
+        tags = doc.get("tags") or {}
+        if not isinstance(tags, dict):
+            tags = {}
+        rules.append(
+            {
+                "path": path,
+                "id": doc.get("id", ""),
+                "title": doc.get("title", ""),
+                "category": tags.get("category") or path.split("/")[1],
+                "mitre_attack": _aslist(refs.get("mitre_attack")),
+                "mitre_atlas": _aslist(refs.get("mitre_atlas")),
+                "owasp_agentic": _aslist(refs.get("owasp_agentic")),
+            }
+        )
+    return rules
+
+
+def _aslist(value) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return [str(v) for v in value]
+    return [str(value)]
+
+
+def build(rules: list[dict]) -> str:
+    total_rules = len(rules)
+
+    # Split each rule's mitre_attack entries into real ATT&CK vs misfiled ATLAS.
+    rules_with_attack = []  # rule has at least one genuine enterprise ATT&CK id
+    atlas_in_attack_field = []  # (rule, token) where an ATLAS id sits in mitre_attack
+    for r in rules:
+        attack_ids, atlas_ids = [], []
+        for entry in r["mitre_attack"]:
+            tok = first_token(entry)
+            kind = classify(tok)
+            if kind == "attack":
+                attack_ids.append((tok, entry))
+            elif kind == "atlas":
+                atlas_ids.append((tok, entry))
+                atlas_in_attack_field.append((r, tok, entry))
+        r["_attack_ids"] = attack_ids
+        r["_atlas_in_attack"] = atlas_ids
+        if attack_ids:
+            rules_with_attack.append(r)
+
+    # Coverage counts (all computed, never hard-coded).
+    n_with_attack = len(rules_with_attack)
+    distinct_attack = sorted(
+        {tok for r in rules_with_attack for tok, _ in r["_attack_ids"]}
+    )
+    distinct_atlas = sorted(
+        {first_token(e) for r in rules for e in r["mitre_atlas"] if first_token(e)}
+    )
+    n_with_atlas = sum(1 for r in rules if r["mitre_atlas"])
+    n_with_owasp = sum(1 for r in rules if r["owasp_agentic"])
+
+    # Per-category aggregation, anchored on ATT&CK id.
+    cat_attack = defaultdict(lambda: defaultdict(set))  # category -> attack_id -> {rule ids}
+    cat_attack_names = {}  # attack_id -> human name (from first occurrence)
+    cat_atlas = defaultdict(set)  # category -> {atlas tokens}
+    cat_owasp = defaultdict(set)  # category -> {owasp tokens}
+    cat_rule_count = defaultdict(int)
+
+    for r in rules:
+        cat = r["category"]
+        cat_rule_count[cat] += 1
+        for tok, entry in r["_attack_ids"]:
+            cat_attack[cat][tok].add(r["id"])
+            if tok not in cat_attack_names:
+                name = entry[len(tok):].lstrip(" -")
+                cat_attack_names[tok] = name
+        for e in r["mitre_atlas"]:
+            t = first_token(e)
+            if t:
+                cat_atlas[cat].add(t)
+        for e in r["owasp_agentic"]:
+            t = first_token(e)
+            if t:
+                cat_owasp[cat].add(t)
+
+    categories = sorted(cat_rule_count)
+
+    lines: list[str] = []
+    w = lines.append
+
+    w("# ATR -> MITRE ATT&CK / ATLAS Crosswalk")
+    w("")
+    w("This document maps Agent Threat Rules (ATR) categories and rules to MITRE")
+    w("technique ids, so any ruleset that tags with MITRE ATT&CK (for example a")
+    w("Sigma ruleset using `tags: attack.txxxx`) can align with ATR on the shared")
+    w("technique-id axis. It was produced in response to")
+    w("agentshield-ai/sigma-ai#9.")
+    w("")
+    w("All technique ids below are read verbatim from each rule's `references`")
+    w("block. None are authored by hand. Regenerate with")
+    w("`python3 scripts/generate-attack-crosswalk.py`.")
+    w("")
+    w("## How to join against this crosswalk")
+    w("")
+    w("The clean, machine-derivable key is the enterprise ATT&CK technique id.")
+    w("ATR stores it as `references.mitre_attack: Txxxx`; a Sigma rule stores it")
+    w("as `tags: attack.txxxx`. They line up after case folding (ATR upper-cases")
+    w("and omits the prefix, Sigma lower-cases and prefixes `attack.`):")
+    w("")
+    w("    ATR   references.mitre_attack: T1059")
+    w("    Sigma tags: attack.t1059")
+    w("")
+    w("MITRE ATLAS (`AML.Txxxx`) and OWASP Agentic (`ASIxx`) are the")
+    w("agent-specific layer ATR carries that ATT&CK-tagged rulesets do not tag.")
+    w("They are included as additional columns so this document is the place that")
+    w("connects ATT&CK-tagged runtime rules to the agent frameworks. Those")
+    w("columns are still extracted from ATR metadata, not authored here.")
+    w("")
+    w("## Coverage")
+    w("")
+    w(f"- ATR rules total: {total_rules}")
+    w(f"- Rules carrying an enterprise ATT&CK id (`references.mitre_attack` Txxxx): {n_with_attack}")
+    w(f"- Distinct enterprise ATT&CK techniques referenced: {len(distinct_attack)}")
+    w(f"- Rules carrying a MITRE ATLAS id (`references.mitre_atlas`): {n_with_atlas}")
+    w(f"- Distinct MITRE ATLAS techniques referenced: {len(distinct_atlas)}")
+    w(f"- Rules carrying an OWASP Agentic id (`references.owasp_agentic`): {n_with_owasp}")
+    w(f"- ATR categories (distinct `tags.category` values): {len(categories)}")
+    w("")
+    w("Categories are keyed on each rule's `tags.category` metadata, not on its")
+    w("directory. The repo has ten rule directories, but three rules under")
+    w("`rules/model-security/` carry `tags.category` of `model-abuse` or")
+    w("`data-poisoning`, so nine distinct categories appear in the metadata.")
+    w("")
+    if atlas_in_attack_field:
+        w("Data-fidelity note: a small number of rules carry an ATLAS short-form id")
+        w("(`T00xx`, e.g. AML.T0051) inside the `mitre_attack` field rather than in")
+        w("`mitre_atlas`. These are reported as ATLAS, not enterprise ATT&CK, so the")
+        w("ATT&CK join key stays clean. Affected entries:")
+        w("")
+        for r, tok, entry in atlas_in_attack_field:
+            w(f"- `{r['id']}` ({r['category']}): `{entry}` -> treated as ATLAS `{tok}`")
+        w("")
+
+    w("## ATT&CK techniques referenced by ATR (the join surface)")
+    w("")
+    w("Every enterprise ATT&CK technique id present in ATR metadata, with the ATR")
+    w("rules that reference it. This is the column a Sigma `attack.txxxx` tag joins")
+    w("against.")
+    w("")
+    w("| ATT&CK technique | Name | ATR rules | ATR categories |")
+    w("|---|---|---|---|")
+    attack_to_rules = defaultdict(list)
+    attack_to_cats = defaultdict(set)
+    for r in rules_with_attack:
+        for tok, _ in r["_attack_ids"]:
+            attack_to_rules[tok].append(r["id"])
+            attack_to_cats[tok].add(r["category"])
+    for tok in distinct_attack:
+        name = cat_attack_names.get(tok, "")
+        rule_ids = sorted(set(attack_to_rules[tok]))
+        cats = ", ".join(sorted(attack_to_cats[tok]))
+        rules_cell = ", ".join(f"`{rid}`" for rid in rule_ids)
+        w(f"| {tok} | {name} | {rules_cell} | {cats} |")
+    w("")
+
+    w("## Crosswalk by ATR category")
+    w("")
+    w("For each ATR category: the enterprise ATT&CK techniques its rules reference")
+    w("(the shared join key), plus the ATLAS and OWASP Agentic techniques ATR adds.")
+    w("")
+    for cat in categories:
+        w(f"### {cat}")
+        w("")
+        w(f"Rules in category: {cat_rule_count[cat]}")
+        w("")
+        attack_map = cat_attack[cat]
+        if attack_map:
+            w("ATT&CK techniques (join key):")
+            w("")
+            w("| ATT&CK technique | Name | ATR rules |")
+            w("|---|---|---|")
+            for tok in sorted(attack_map):
+                name = cat_attack_names.get(tok, "")
+                rule_ids = ", ".join(f"`{rid}`" for rid in sorted(attack_map[tok]))
+                w(f"| {tok} | {name} | {rule_ids} |")
+            w("")
+        else:
+            w("ATT&CK techniques (join key): none tagged in this category's rules.")
+            w("")
+        atlas = sorted(cat_atlas[cat])
+        owasp = sorted(cat_owasp[cat])
+        w(f"ATLAS techniques ATR adds: {', '.join(atlas) if atlas else 'none'}")
+        w("")
+        w(f"OWASP Agentic categories ATR adds: {', '.join(owasp) if owasp else 'none'}")
+        w("")
+
+    w("## Methodology")
+    w("")
+    w("- Source of truth: the YAML rule files under `rules/`. Each rule's")
+    w("  `references` block carries `mitre_attack`, `mitre_atlas`, and")
+    w("  `owasp_agentic` lists in `Txxxx - Name` form.")
+    w("- The generator (`scripts/generate-attack-crosswalk.py`) parses every rule,")
+    w("  takes the leading id token from each entry, and classifies it: `T1xxx`")
+    w("  (optionally `.NNN`) is enterprise ATT&CK; `AML.Txxxx` or short-form")
+    w("  `T00xx` is ATLAS.")
+    w("- The ATT&CK column is fully auto-derivable and is what an ATT&CK-tagged")
+    w("  ruleset joins against. ATLAS and OWASP Agentic columns are likewise")
+    w("  extracted from metadata, not hand-authored.")
+    w("- All counts above are computed by the generator at build time; none are")
+    w("  hard-coded. Re-run the script to refresh after rule changes.")
+    w("- License: ATR is MIT. This crosswalk may be reused under the same terms.")
+    w("")
+    return "\n".join(lines) + "\n"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="verify the committed doc matches freshly generated output (CI mode)",
+    )
+    args = parser.parse_args()
+
+    rules = load_rules()
+    content = build(rules)
+
+    if args.check:
+        try:
+            existing = open(DOC_PATH).read()
+        except FileNotFoundError:
+            print(f"FAIL: {DOC_PATH} does not exist; run the generator.", file=sys.stderr)
+            return 1
+        if existing != content:
+            print(
+                f"FAIL: {DOC_PATH} is stale. Re-run scripts/generate-attack-crosswalk.py.",
+                file=sys.stderr,
+            )
+            return 1
+        print(f"OK: {DOC_PATH} matches the rule metadata.")
+        return 0
+
+    with open(DOC_PATH, "w") as fh:
+        fh.write(content)
+    print(f"Wrote {DOC_PATH} ({len(content)} bytes)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Adds docs/crosswalks/atr-attack-crosswalk.md and the generator that produces it
from rule metadata, in response to agentshield-ai/sigma-ai#9, plus a small
metadata cleanup that keeps the crosswalk's join keys clean.

The crosswalk anchors on the enterprise ATT&CK technique id, which is the part
that derives cleanly on both sides: ATR stores it as references.mitre_attack
Txxxx, an ATT&CK-tagged Sigma rule stores it as tags attack.txxxx, and they line
up after case folding. MITRE ATLAS (AML.Txxxx) and OWASP Agentic (ASIxx:2026) are
surfaced as the agent-specific layer ATR carries that ATT&CK-tagged rulesets do
not tag, so this doc connects ATT&CK-tagged runtime rules to the agent frameworks.

Everything is extracted from each rule references block. Nothing is authored by
hand. scripts/generate-attack-crosswalk.py --check verifies the doc stays in sync
with the rules and can run in CI.

Metadata hygiene in the same change (this is what makes the columns clean):
- Four rules carried an ATLAS short-form id (T0051/T0010/T0056) in
  references.mitre_attack while the correct AML.T00xx was already in
  mitre_atlas. Removed the misfiled entries so ATLAS ids no longer leak into
  the ATT&CK column.
- Normalized 59 rules that used a bare OWASP Agentic id (ASIxx) to the
  canonical ASIxx:2026 form used by the other 642 rules, removing the
  duplicate rows this produced in the crosswalk.

Validation
- npm run validate: 655 passed, 0 failed
- typecheck clean
- generate-attack-crosswalk.py --check: doc matches rule metadata

Coverage at this commit: 655 rules total, 88 carry an enterprise ATT&CK id across
46 distinct techniques, all 655 carry ATLAS and OWASP Agentic ids.

License: ATR is MIT.
