### PR TITLE
docs: map ATR rules to NSA MCP Security CSI

### DIFF
--- a/docs/NSA-MCP-MAPPING.md
+++ b/docs/NSA-MCP-MAPPING.md
@@ -1,160 +1,100 @@
 # ATR → NSA "Model Context Protocol (MCP): Security Design Considerations" Mapping
 
-- **ATR corpus version:** v3.5.2 HEAD, 655 rules on disk across 10 detection-rule categories (`data/stats.json` reports 652 pending a reconcile; headline benchmarks below were measured at v3.5.0).
-- **NSA guidance:** *Model Context Protocol (MCP): Security Design Considerations for AI-Driven Automation*, Cybersecurity Information Sheet (CSI), NSA Artificial Intelligence Security Center (AISC), dated May 2026, posted 2026-06-02 on media.defense.gov (U/OO/6030316-26 | PP-26-1834 | Ver. 1.0).
+- **ATR corpus version:** v3.5.2 HEAD, 655 rules across 10 detection-rule categories. Headline benchmarks below were measured at v3.5.0 (2026-06-16).
+- **NSA guidance:** *Model Context Protocol (MCP): Security Design Considerations for AI-Driven Automation*, Cybersecurity Information Sheet (CSI), **NSA Artificial Intelligence Security**, **May 2026 Ver. 1.0** (U/OO/6030316-26 | PP-26-1834), posted 2026-06-02 on media.defense.gov; developed with the Carnegie Mellon University Software Engineering Institute.
 - **Document date:** 2026-06-28
 - **Maintainer:** Adam Lin (adam@agentthreatrule.org)
 - **License:** MIT
-- **Relationship to the Five Eyes mapping:** the April-2026 Five Eyes *"Careful Adoption of Agentic AI Services"* (mapped in [FIVE-EYES-MAPPING.md](./FIVE-EYES-MAPPING.md)) is the cross-government strategic guidance; this NSA CSI is the **MCP-specific technical companion**. This document maps the MCP CSI's risk areas and recommended mitigations to specific ATR rule clusters.
+- **Relationship to the Five Eyes mapping:** the NSA CSI explicitly cites *"Careful Adoption of Agentic AI Services"* (its reference [3]) as the general agentic-AI guidance and positions itself as the **MCP-specific technical companion**. ATR maps that Five Eyes guidance in [FIVE-EYES-MAPPING.md](./FIVE-EYES-MAPPING.md); this document maps the MCP CSI's verbatim section structure.
 
 ## Source verification
 
-> **Honesty note (read first).** The named risk areas and mitigations below are corroborated across the NSA press release (Article 4496698) and four independent secondary analyses (Adversa AI, GetAIGovernance, Reed Smith, Cybersecurity Dive — see References). The **primary CSI PDF on media.defense.gov returns HTTP 403 to automated fetch**, so — unlike the Five Eyes mapping, whose quotes were extracted verbatim from the primary PDF via browser — the NSA section headings here are **reconstructed from corroborated secondary sources, not yet pinned to verbatim primary text**. A primary-PDF extraction pass (via authenticated browser) is tracked in the Verification status checklist. No claim in this document depends on a heading we could not corroborate from at least two independent sources.
+> **Primary-verified.** Unlike a first draft sourced from secondary analyses, the section headings and recommendations below are extracted **verbatim from the primary CSI PDF** (17 pages, May 2026 Ver. 1.0). The CSI organizes content into **8 named security concerns**, a set of real-world examples, and **9 named recommendations** — reproduced here exactly. (The defense.gov/nsa.gov PDF endpoints return HTTP 403 to automated fetch; the document was retrieved through a browser and read locally.)
 
 ## Executive summary
 
-The NSA MCP CSI ships authoritative **risk areas and mitigation recommendations** and, like every government guidance document, **zero executable detection rules**. Its core framing — that "MCP's rapid proliferation has outpaced the development of its security model, [...] released with a flexible and underspecified design" — is precisely the gap ATR's corpus exists to close at the runtime detection layer.
+The NSA MCP CSI ships authoritative risk framing and **9 named recommendations**, and — like all government guidance — **zero executable detection rules**. Its thesis is that *"MCP's rapid proliferation has outpaced the development of its security model"* and that secure-by-default behavior *"must be enforced through implementation rigor, proper coding practices, clearer protocol specifications, and robust validation tools."* ATR is one such validation-tool layer.
 
-Two recommendations in the CSI point **directly** at ATR's role:
+Three of the CSI's recommendations point **directly** at ATR's role:
 
-1. **"Perform local MCP scans."** ATR's 655 MIT-licensed rules *are* local-MCP-scan content — machine-readable YAML signatures with regex patterns, severity, framework metadata, and test cases, already consumed by Cisco AI Defense skill-scanner, Microsoft PyRIT, and the MISP galaxy.
-2. **"Adopt a collaborative security approach, such as CISA's AI Cybersecurity Collaboration Playbook"** (the JCDC Playbook the companion Five Eyes guidance also cites). ATR is exactly the open, agentic-specific detection corpus that a JCDC-style contributor brings to the table.
+- **"Scan local network for open or vulnerable MCP servers"** — the CSI names MCP Scanner, Ramparts, CyberMCP, and Proximity as the tools for this. ATR's 655 rules are the machine-readable scan content those tools consume (ATR already ships in Cisco AI Defense's skill-scanner).
+- **"Track and patch MCP related vulnerabilities"** — the CSI recommends a *"formal process for monitoring MCP related vulnerabilities ... through CVEs, vendor advisories, or open source issue trackers ... subscribing to relevant security feeds."* That is precisely ATR's CVE flywheel (2,262 CVEs tracked across 15 feeds → 594 detection-ready signatures).
+- **"Instrument for logging and detection"** — the CSI wants *"all tool and model invocations ... logged"* with a way to *"identify suspicious patterns ... while minimizing false positives."* ATR's per-rule event taxonomy + 0-FP-gated rules are that detection layer.
 
-This document does **not** claim NSA endorsement of ATR. It is a community detection-rule starter set for operators implementing the CSI.
-
----
-
-## Part A — NSA MCP risk areas → ATR rule clusters
-
-### A1. Arbitrary code execution
-
-**NSA concern (paraphrased):** MCP's inverted client-server pattern plus dynamic tool invocation exposes hosts to arbitrary-code-execution paths, including via crafted tool inputs and unverified task propagation between servers.
-
-**Why this needs detection rules:** sandboxing and least-privilege are architectural controls, but the concrete RCE *attempt* is observable at runtime — `eval`/dynamic-code primitives, shell-metacharacter injection, deserialization payloads.
-
-**ATR clusters:**
-- `privilege-escalation/` (35 rules) — `ATR-2026-00110` eval-injection, `ATR-2026-00111` shell-escape, `ATR-2026-00112` dynamic-import-exploitation, `ATR-2026-00436` enclave-vm-sandbox-escape-rce
-- `tool-poisoning/` (68 rules) — `ATR-2026-00277` echo-template-command-injection, `ATR-2026-00415` flowise-custom-mcp-stdio-rce
-- `model-security/` (3 rules) — `ATR-2026-00433` modelcache-torch-load-deserialization-rce
-
-**Strength:** STRONG — concrete CVE-class RCE flaws ship as rules within hours of disclosure (Semantic Kernel MSRC → npm-published in 2h16m, 2026-05-11).
-
-### A2. Authentication & authorization weaknesses
-
-**NSA concern:** many MCP servers expose tools with weak or no authentication; credentials and tokens are mishandled across the trust boundary.
-
-**ATR clusters:**
-- `privilege-escalation/` — `ATR-2026-00040` privilege-escalation, `ATR-2026-00451` litellm-admin-sqli (CISA KEV CVE-2026-42208)
-- `context-exfiltration/` (104 rules) — `ATR-2026-00021` api-key-exposure, `ATR-2026-00114` oauth-token-abuse, `ATR-2026-00115` env-var-harvesting, `ATR-2026-00534` alibaba-rds-mcp-unauthenticated-metadata-exfil (Akamai 2026-06 disclosure)
-
-**Strength:** STRONG for runtime credential/token abuse. **Honest limit:** ATR detects *abuse* of credentials; it does not *issue or attest* agent identity (W3C DID / agent-attestation territory).
-
-### A3. Insecure context handling & serialization
-
-**NSA concern:** unsafe deserialization and context handling across MCP messages create injection and code-execution surfaces.
-
-**ATR clusters:**
-- `model-security/` — `ATR-2026-00433` torch-load deserialization RCE
-- `tool-poisoning/` — `ATR-2026-00106` schema-description-contradiction, `ATR-2026-00270` xss-in-tool-response
-- `prompt-injection/` — `ATR-2026-00084` structured-data-injection (injection through structured input fields / serialized payloads)
-
-**Strength:** MODERATE — deserialization-RCE precedents covered; generic serialization-format hardening is architectural.
-
-### A4. Trust boundaries, implicit trust & tool poisoning
-
-**NSA concern:** agentic systems introduce dynamic tool invocation and *implicit* trust relationships; one server can propagate unverified tasks into another, and poisoned tool descriptions cross trust boundaries.
-
-**ATR clusters:**
-- `tool-poisoning/` — `ATR-2026-00010` mcp-malicious-response, `ATR-2026-00106` schema-description-contradiction, `ATR-2026-00161` important-tag-cross-tool-shadowing
-- `agent-manipulation/` (106 rules) — `ATR-2026-00030` cross-agent-attack, `ATR-2026-00074` cross-agent-privilege-escalation, `ATR-2026-00116` a2a-message-validation, `ATR-2026-00117` agent-identity-spoofing
-
-**Strength:** STRONG — tool-poisoning and cross-agent propagation are core ATR coverage (this maps closely to ATR's SAFE-MCP Initial Access / Lateral Movement coverage; see [SAFE-MCP-MAPPING.md](./SAFE-MCP-MAPPING.md)).
-
-### A5. Approval & human-oversight gaps
-
-**NSA concern:** agents take high-impact actions without adequate human-in-the-loop checkpoints; consent flows are weak or fatigued.
-
-**ATR clusters:**
-- `excessive-autonomy/` (29 rules) — `ATR-2026-00098` unauthorized-financial-action, `ATR-2026-00099` high-risk-tool-gate (forces an `ask` verdict on financial/destructive/communication/permission/system tool categories), `ATR-2026-00428` nl-unauthorized-shell-execution
-- `agent-manipulation/` — `ATR-2026-00118` approval-fatigue
-
-**Strength:** STRONG at raising the signal. **Honest limit:** ATR flags the high-impact call (`response.actions: require_auth_challenge`); the operator-side approval UX is implementation-defined.
-
-### A6. Logging, monitoring & visibility deficiencies
-
-**NSA concern:** insufficient observability — tool and model invocations are not logged with parameters and identities, and audit trails can be evaded.
-
-**ATR contribution (two layers):**
-- **Structured event taxonomy** — every ATR rule emits a stable `id`, `severity`, `category`, and `response.actions`; these are the audit-log primitives the CSI's observability recommendation depends on.
-- **Audit-evasion detection** — `ATR-2026-00085` audit-evasion, `ATR-2026-00094` audit-bypass, `ATR-2026-00105` silent-action-concealment.
-
-**Strength:** LIMITED-to-MODERATE — ATR supplies the event taxonomy and catches evasion attempts; log retention, tamper-resistance, and signed audit storage are operator-side (this is where the [ai-rmf-oscal-catalog](https://github.com/Agent-Threat-Rule/ai-rmf-oscal-catalog) OSCAL evidence layer connects — see Part C).
-
-### A7. Configuration & deployment pitfalls
-
-**NSA concern:** insecure defaults, unvetted third-party servers, and supply-chain exposure at deploy time.
-
-**ATR clusters:**
-- `skill-compromise/` (45 rules) — `ATR-2026-00060` skill-impersonation, `ATR-2026-00062` hidden-capability, `ATR-2026-00065` skill-update-attack (rug-pull), `ATR-2026-00095` mcp-supply-chain-poisoning, `ATR-2026-00419` cursor-mcp-zero-click-config
-- `excessive-autonomy/` — `ATR-2026-00500` ssrf-via-agent-url-fetch-instruction
-
-**Strength:** STRONG for supply-chain and skill-integrity precursors; secure-default *enforcement* is operator policy.
+This document does **not** claim NSA endorsement (the CSI carries an explicit non-endorsement disclaimer). It is a community detection-rule starter set for operators implementing the CSI.
 
 ---
 
-## Part B — NSA recommended mitigations → how ATR operationalizes each
+## Part A — the CSI's 8 "Security concerns in MCP design, implementation, and practices" → ATR
 
-| NSA recommended mitigation | ATR contribution | Coverage |
-|---|---|---|
-| **Perform local MCP scans** | The 655-rule corpus **is** local-scan content (YAML signatures, already in Cisco skill-scanner, PyRIT, MISP galaxy) | DIRECT |
-| **Input validation against schemas / ranges / context** | `prompt-injection/` input rules + `ATR-2026-00084` structured-data-injection flag malformed / injected inputs at the agent boundary | STRONG |
-| **Observability — log all tool/model invocations with params + identities** | Stable per-rule event taxonomy (`id`/`severity`/`category`/`response`) + audit-evasion detection (00085/00094/00105) | PARTIAL (taxonomy + evasion; retention is operator-side) |
-| **Outgoing proxy controls / DLP / output filtering** | `context-exfiltration/` (104 rules) + `ATR-2026-00500` ssrf + `ATR-2026-00102` disguised-analytics-exfiltration detect the exfil the proxy/DLP must block | STRONG signal layer |
-| **Deny-by-default allowlists / least privilege** | `ATR-2026-00099` high-risk-tool-gate enforces an explicit `ask` on high-risk tool categories | DIRECT |
-| **Sandboxing** | Architectural; ATR detects escape *attempts* (00110 eval, 00111 shell, 00436 enclave-escape) | COMPLEMENTARY |
-| **Message integrity (inter-server)** | `agent-manipulation/` A2A rules (00116 a2a-message-validation, 00076 inter-agent-message-spoofing) | MODERATE |
-| **Data classification zones** | Architectural; ATR detects cross-zone exfil via `context-exfiltration/` | COMPLEMENTARY |
+| # | NSA security concern (verbatim) | ATR rule clusters (verified IDs) | Strength |
+|---|---|---|---|
+| A1 | **Access control** — no protocol-level identity binding; missing RBAC/CRUD; *"unverified task propagation"* between servers | `privilege-escalation/` 00040 priv-esc; `context-exfiltration/` 00114 oauth-token-abuse; `agent-manipulation/` 00030 cross-agent-attack, 00074 cross-agent-priv-esc | STRONG (abuse-side; identity issuance is infra) |
+| A2 | **Insecure context or data serialization** — serialized content with comments/prompts opens injection / embedded code | `model-security/` 00433 torch-load-deser-rce; `prompt-injection/` 00084 structured-data-injection | MODERATE |
+| A3 | **Poor approval workflows** — capability/data-access changes to a trusted server made without re-approval | `excessive-autonomy/` 00099 high-risk-tool-gate, 00098 unauthorized-financial-action; `agent-manipulation/` 00118 approval-fatigue | STRONG (signal-side) |
+| A4 | **Token or session security** — optional OAuth bearer tokens, no lifecycle/replay control | `context-exfiltration/` 00114 oauth-token-abuse | MODERATE (lifecycle mgmt is infra) |
+| A5 | **Misconfigurations and poor implementation** — trivial servers repurposed; no task/data isolation | `skill-compromise/` 00095 supply-chain-poisoning, 00065 skill-update-attack; `tool-poisoning/` 00419 cursor-mcp-zero-click-config | STRONG |
+| A6 | **Inconsistent behaviors** — non-deterministic interpretation an attacker can precondition | `prompt-injection/` 00005 multi-turn, 00081 semantic-multi-turn; `agent-manipulation/` 00032 goal-hijacking | MODERATE |
+| A7 | **Poor or missing audit logs** — logging left to implementers; needs traceable sequence + anomaly detection | `prompt-injection/` 00085 audit-evasion, 00094 audit-bypass; `tool-poisoning/` 00105 silent-action-concealment; + every rule's stable `id`/`severity`/`category`/`response` taxonomy | MODERATE |
+| A8 | **Denial of service and fatigue-based techniques** — prompt storms, recursive tasks, "lethargy" resource exhaustion | `excessive-autonomy/` 00050 runaway-loop, 00051 resource-exhaustion, 00052 cascading-failure | STRONG |
+
+The CSI's real-world examples section maps cleanly onto existing ATR coverage too: *Tool parameter injection* → 00066/00277; *Tool invocation path confusion / naming collisions* → 00089 polymorphic-aliasing, 00106 schema-description-contradiction; *Unrestricted GitHub repo access* → 00064 over-permissioned-skill; *WhatsApp MCP rug-pull* → 00065 skill-update-attack; *Poisoning output for downstream automation* → 00083 indirect-tool-injection, 00063 multi-skill-chain; *CVE-2025-49596 MCP-Inspector RCE* → **known gap** (tracked as SAFE-T1109 in [SAFE-MCP-MAPPING.md](./SAFE-MCP-MAPPING.md)).
 
 ---
 
-## Part C — The OSCAL / NIST tie-in (why this mapping matters beyond NSA)
+## Part B — the CSI's 9 "Recommendations" → how ATR operationalizes each
 
-The NSA CSI's observability and accountability recommendations are exactly what NIST's **SP 800-53 Control Overlays for Securing AI Systems (COSAiS)** and the **OSCAL** assessment layer formalize. ATR already maintains:
+| # | NSA recommendation (verbatim) | ATR contribution | Coverage |
+|---|---|---|---|
+| R1 | **Choose supported MCP projects when possible** | `skill-compromise/` 00060 impersonation, 00062 hidden-capability flag unmaintained / trojanized projects | COMPLEMENTARY |
+| R2 | **Design for boundaries** (trust zones, data-classification zones, prefer local server, filtering outgoing proxy / DLP) | `context-exfiltration/` (104 rules) incl. 00500 ssrf, 00102 disguised-analytics, 00261 markdown-image-exfil detect the cross-zone leakage the proxy/DLP must block | STRONG signal (zone architecture is operator-side) |
+| R3 | **Validate parameters** (against schemas, ranges, intended context; block ambiguous-source forwarding) | `prompt-injection/` input rules + 00084 structured-data-injection, 00066 parameter-injection | STRONG |
+| R4 | **Constrain and sandbox tool execution** (AppContainers/seccomp/AppArmor/SELinux; least privilege; deny at runtime) | architectural; ATR detects escape *attempts*: 00110 eval, 00111 shell-escape, 00436 enclave-sandbox-escape | COMPLEMENTARY |
+| R5 | **Sign and verify MCP messages** (crypto signatures in payload, time-bound, replay metadata; OWASP ASVS V7) | `agent-manipulation/` 00116 a2a-message-validation, 00076 inter-agent-message-spoofing detect unsigned/spoofed message abuse | MODERATE (signing is infra) |
+| R6 | **Filter and monitor output pipelines and chained execution** (treat each output as untrusted; detect indirect injection / toolchain pivot) | **ATR core:** `prompt-injection/` 00002 indirect, 00083 indirect-tool-injection, 00080 encoding-evasion; `tool-poisoning/` 00010 malicious-response; 00063 multi-skill-chain | DIRECT |
+| R7 | **Instrument for logging and detection** (log all invocations w/ params + identities + hashes; SIEM; minimize FP) | per-rule event taxonomy (`id`/`severity`/`category`/`response`) + audit-evasion detection (00085/00094/00105); ATR rules are 0-FP-gated, matching the CSI's "minimize false positives" | STRONG |
+| R8 | **Track and patch MCP related vulnerabilities** (CVE / advisory / OSS-tracker monitoring; security-feed subscription; versioned inventory) | **ATR CVE flywheel:** 2,262 CVEs tracked across 15 feeds → 88 active rules + 594 detection-ready proposals. Proof: 00451 litellm-admin-sqli (CISA KEV), 00534 alibaba-rds-mcp (Akamai 2026-06), Semantic Kernel MSRC → rule in ~2h | DIRECT |
+| R9 | **Scan local network for open or vulnerable MCP servers** (CSI names MCP Scanner, Ramparts, CyberMCP, Proximity) | **ATR is the scan content** those tools consume — 655 machine-readable rules, already integrated in Cisco AI Defense's skill-scanner | DIRECT |
 
-- [`ai-rmf-oscal-catalog`](https://github.com/Agent-Threat-Rule/ai-rmf-oscal-catalog) (CC0) — ATR's detection rules expressed as an OSCAL-consumable AI-RMF control profile.
+**The headline:** R6–R9 are ATR's exact wheelhouse, and R8/R9 read almost as a specification of what ATR already does — a CVE-fed, continuously-updated, machine-executable rule corpus that local scanners consume.
+
+---
+
+## Part C — the OSCAL / NIST tie-in
+
+R7 (logging/observability) and the CSI's audit-log concern (A7) are what NIST's **SP 800-53 Control Overlays for Securing AI Systems (COSAiS)** and the **OSCAL** assessment layer formalize. ATR already maintains:
+
+- [`ai-rmf-oscal-catalog`](https://github.com/Agent-Threat-Rule/ai-rmf-oscal-catalog) (CC0) — ATR rules as an OSCAL-consumable AI-RMF control profile.
 - An in-progress NIST OSCAL community contribution (AI-RMF profile examples, PR #338).
 
-This NSA MCP mapping is the **MCP-specific evidence exhibit** for that NIST track: it shows, control-area by control-area, that ATR's rules are the machine-executable enforcement layer beneath the controls NSA recommends and NIST is overlaying. It is the artifact to bring to the COSAiS community channel (`overlays-securing-ai@list.nist.gov` / the #NIST-Overlays-Securing-AI Slack).
+This NSA MCP mapping is the **MCP-specific evidence exhibit** for that NIST track and the artifact to bring to the COSAiS community channel (`overlays-securing-ai@list.nist.gov` / the #NIST-Overlays-Securing-AI Slack).
 
 ---
 
 ## What ATR does NOT cover (be honest)
 
-- **Cryptographic agent identity / attestation.** Detection-side, not identity-side (W3C DID / agent-attestation frameworks).
-- **The human-approval UX** for high-impact actions. ATR raises the signal; the operator builds the gate.
-- **Sandbox / network isolation, secure defaults, log retention & tamper-resistance.** Architectural and operator-side; ATR detects precursors and evasion, not infrastructure posture.
-- **Paraphrase bypass of canonical payloads.** Regex-and-pattern detection is one layer, not the only layer.
-- **Multimodal (image/audio) injection** and **non-English coverage** remain partial (Japanese/German extension in progress).
-- **Primary-PDF verbatim pinning** of NSA headings is pending (see Source verification).
+- **Cryptographic agent identity / message signing** (A1, R5) — detection-side, not identity/PKI-side.
+- **The human-approval UX** for high-impact actions (A3) — ATR raises the signal; the operator builds the gate.
+- **Sandbox / network isolation, secure defaults, log retention & tamper-resistance** (R4, A7) — architectural; ATR detects precursors and evasion, not infrastructure posture.
+- **CVE-2025-49596 (MCP-Inspector RCE)** — a named CSI example with no ATR rule yet (tracked gap SAFE-T1109).
+- **Paraphrase bypass, multimodal (image/audio) injection, non-English coverage** — partial; one defense layer, not the only one.
 
 ---
 
 ## References
 
-- NSA CSI, *Model Context Protocol (MCP): Security Design Considerations for AI-Driven Automation* (primary PDF, defense.gov media library, 2026-06-02): https://media.defense.gov/2026/Jun/02/2003943289/-1/-1/0/CSI_MCP_SECURITY.PDF
-- NSA press release (Article 4496698): https://www.nsa.gov/Press-Room/Press-Releases-Statements/Press-Release-View/Article/4496698/
-- Secondary corroboration: Adversa AI (Top MCP security resources, 2026-06), GetAIGovernance, Reed Smith Viewpoints, Cybersecurity Dive (NIST control-overlays coverage).
+- NSA CSI, *Model Context Protocol (MCP): Security Design Considerations for AI-Driven Automation*, May 2026 Ver. 1.0 (U/OO/6030316-26 | PP-26-1834). Primary PDF: https://media.defense.gov/2026/Jun/02/2003943289/-1/-1/0/CSI_MCP_SECURITY.PDF · Press release: https://www.nsa.gov/Press-Room/Press-Releases-Statements/Press-Release-View/Article/4496698/
+- The CSI's own references include the Five Eyes *Careful Adoption of Agentic AI Services* [3], OWASP ASVS V7, OASIS CoSAI [25], and Docker's MCP security analysis [24].
 - CISA AI Cybersecurity Collaboration Playbook (JCDC): https://www.cisa.gov/resources-tools/resources/ai-cybersecurity-collaboration-playbook
-- ATR rule corpus: https://github.com/Agent-Threat-Rule/agent-threat-rules
+- ATR corpus: https://github.com/Agent-Threat-Rule/agent-threat-rules
 - Sibling mappings: [FIVE-EYES-MAPPING.md](./FIVE-EYES-MAPPING.md) · [SAFE-MCP-MAPPING.md](./SAFE-MCP-MAPPING.md) · [MITRE-ATLAS-MAPPING.md](./MITRE-ATLAS-MAPPING.md) · [OWASP-AGENTIC-MAPPING.md](./OWASP-AGENTIC-MAPPING.md)
 - ATR OSCAL AI-RMF catalogue (CC0): https://github.com/Agent-Threat-Rule/ai-rmf-oscal-catalog
 
 ## Verification status
 
-- [x] NSA CSI risk areas corroborated across ≥2 independent secondary sources each.
-- [x] Recommended-mitigation list corroborated (local MCP scans, input validation, observability, outgoing proxy/DLP, deny-by-default, sandboxing, message integrity, data classification).
-- [x] All 16 cited ATR rule IDs verified to exist at v3.5.2 HEAD (2026-06-28).
-- [x] Per-category counts pinned to disk truth at HEAD (655 total; prompt-injection 223, agent-manipulation 106, context-exfiltration 104, tool-poisoning 68, skill-compromise 45, model-abuse 37, privilege-escalation 35, excessive-autonomy 29, data-poisoning 5, model-security 3).
-- [ ] **Primary-PDF verbatim extraction** of NSA section headings (defense.gov 403s automated fetch; pending authenticated-browser pass).
-- [ ] Reconcile `data/stats.json` 652 vs disk 655 before external citation of a single headline number.
-- [ ] Second-reviewer sanity-check of STRONG / MODERATE / LIMITED strength ratings.
+- [x] **Primary CSI PDF extracted verbatim** (17 pages, May 2026 Ver. 1.0) — 8 security concerns + 9 recommendations reproduced exactly.
+- [x] All cited ATR rule IDs verified to exist at v3.5.2 HEAD (2026-06-28).
+- [x] Per-category counts pinned to disk truth (655 total).
+- [x] CSI cross-references confirmed: Five Eyes guidance [3], OWASP ASVS V7, OASIS CoSAI [25], CVE-2025-49596.
+- [ ] Second-reviewer sanity-check of STRONG / MODERATE / COMPLEMENTARY strength ratings.
+- [ ] Add reverse index (ATR rule → CSI concern/recommendation), matching the SAFE-MCP mapping's cross-reference table.

--- a/docs/NSA-MCP-MAPPING.md
+++ b/docs/NSA-MCP-MAPPING.md
@@ -1,0 +1,160 @@
+# ATR → NSA "Model Context Protocol (MCP): Security Design Considerations" Mapping
+
+- **ATR corpus version:** v3.5.2 HEAD, 655 rules on disk across 10 detection-rule categories (`data/stats.json` reports 652 pending a reconcile; headline benchmarks below were measured at v3.5.0).
+- **NSA guidance:** *Model Context Protocol (MCP): Security Design Considerations for AI-Driven Automation*, Cybersecurity Information Sheet (CSI), NSA Artificial Intelligence Security Center (AISC), dated May 2026, posted 2026-06-02 on media.defense.gov (U/OO/6030316-26 | PP-26-1834 | Ver. 1.0).
+- **Document date:** 2026-06-28
+- **Maintainer:** Adam Lin (adam@agentthreatrule.org)
+- **License:** MIT
+- **Relationship to the Five Eyes mapping:** the April-2026 Five Eyes *"Careful Adoption of Agentic AI Services"* (mapped in [FIVE-EYES-MAPPING.md](./FIVE-EYES-MAPPING.md)) is the cross-government strategic guidance; this NSA CSI is the **MCP-specific technical companion**. This document maps the MCP CSI's risk areas and recommended mitigations to specific ATR rule clusters.
+
+## Source verification
+
+> **Honesty note (read first).** The named risk areas and mitigations below are corroborated across the NSA press release (Article 4496698) and four independent secondary analyses (Adversa AI, GetAIGovernance, Reed Smith, Cybersecurity Dive — see References). The **primary CSI PDF on media.defense.gov returns HTTP 403 to automated fetch**, so — unlike the Five Eyes mapping, whose quotes were extracted verbatim from the primary PDF via browser — the NSA section headings here are **reconstructed from corroborated secondary sources, not yet pinned to verbatim primary text**. A primary-PDF extraction pass (via authenticated browser) is tracked in the Verification status checklist. No claim in this document depends on a heading we could not corroborate from at least two independent sources.
+
+## Executive summary
+
+The NSA MCP CSI ships authoritative **risk areas and mitigation recommendations** and, like every government guidance document, **zero executable detection rules**. Its core framing — that "MCP's rapid proliferation has outpaced the development of its security model, [...] released with a flexible and underspecified design" — is precisely the gap ATR's corpus exists to close at the runtime detection layer.
+
+Two recommendations in the CSI point **directly** at ATR's role:
+
+1. **"Perform local MCP scans."** ATR's 655 MIT-licensed rules *are* local-MCP-scan content — machine-readable YAML signatures with regex patterns, severity, framework metadata, and test cases, already consumed by Cisco AI Defense skill-scanner, Microsoft PyRIT, and the MISP galaxy.
+2. **"Adopt a collaborative security approach, such as CISA's AI Cybersecurity Collaboration Playbook"** (the JCDC Playbook the companion Five Eyes guidance also cites). ATR is exactly the open, agentic-specific detection corpus that a JCDC-style contributor brings to the table.
+
+This document does **not** claim NSA endorsement of ATR. It is a community detection-rule starter set for operators implementing the CSI.
+
+---
+
+## Part A — NSA MCP risk areas → ATR rule clusters
+
+### A1. Arbitrary code execution
+
+**NSA concern (paraphrased):** MCP's inverted client-server pattern plus dynamic tool invocation exposes hosts to arbitrary-code-execution paths, including via crafted tool inputs and unverified task propagation between servers.
+
+**Why this needs detection rules:** sandboxing and least-privilege are architectural controls, but the concrete RCE *attempt* is observable at runtime — `eval`/dynamic-code primitives, shell-metacharacter injection, deserialization payloads.
+
+**ATR clusters:**
+- `privilege-escalation/` (35 rules) — `ATR-2026-00110` eval-injection, `ATR-2026-00111` shell-escape, `ATR-2026-00112` dynamic-import-exploitation, `ATR-2026-00436` enclave-vm-sandbox-escape-rce
+- `tool-poisoning/` (68 rules) — `ATR-2026-00277` echo-template-command-injection, `ATR-2026-00415` flowise-custom-mcp-stdio-rce
+- `model-security/` (3 rules) — `ATR-2026-00433` modelcache-torch-load-deserialization-rce
+
+**Strength:** STRONG — concrete CVE-class RCE flaws ship as rules within hours of disclosure (Semantic Kernel MSRC → npm-published in 2h16m, 2026-05-11).
+
+### A2. Authentication & authorization weaknesses
+
+**NSA concern:** many MCP servers expose tools with weak or no authentication; credentials and tokens are mishandled across the trust boundary.
+
+**ATR clusters:**
+- `privilege-escalation/` — `ATR-2026-00040` privilege-escalation, `ATR-2026-00451` litellm-admin-sqli (CISA KEV CVE-2026-42208)
+- `context-exfiltration/` (104 rules) — `ATR-2026-00021` api-key-exposure, `ATR-2026-00114` oauth-token-abuse, `ATR-2026-00115` env-var-harvesting, `ATR-2026-00534` alibaba-rds-mcp-unauthenticated-metadata-exfil (Akamai 2026-06 disclosure)
+
+**Strength:** STRONG for runtime credential/token abuse. **Honest limit:** ATR detects *abuse* of credentials; it does not *issue or attest* agent identity (W3C DID / agent-attestation territory).
+
+### A3. Insecure context handling & serialization
+
+**NSA concern:** unsafe deserialization and context handling across MCP messages create injection and code-execution surfaces.
+
+**ATR clusters:**
+- `model-security/` — `ATR-2026-00433` torch-load deserialization RCE
+- `tool-poisoning/` — `ATR-2026-00106` schema-description-contradiction, `ATR-2026-00270` xss-in-tool-response
+- `prompt-injection/` — `ATR-2026-00084` structured-data-injection (injection through structured input fields / serialized payloads)
+
+**Strength:** MODERATE — deserialization-RCE precedents covered; generic serialization-format hardening is architectural.
+
+### A4. Trust boundaries, implicit trust & tool poisoning
+
+**NSA concern:** agentic systems introduce dynamic tool invocation and *implicit* trust relationships; one server can propagate unverified tasks into another, and poisoned tool descriptions cross trust boundaries.
+
+**ATR clusters:**
+- `tool-poisoning/` — `ATR-2026-00010` mcp-malicious-response, `ATR-2026-00106` schema-description-contradiction, `ATR-2026-00161` important-tag-cross-tool-shadowing
+- `agent-manipulation/` (106 rules) — `ATR-2026-00030` cross-agent-attack, `ATR-2026-00074` cross-agent-privilege-escalation, `ATR-2026-00116` a2a-message-validation, `ATR-2026-00117` agent-identity-spoofing
+
+**Strength:** STRONG — tool-poisoning and cross-agent propagation are core ATR coverage (this maps closely to ATR's SAFE-MCP Initial Access / Lateral Movement coverage; see [SAFE-MCP-MAPPING.md](./SAFE-MCP-MAPPING.md)).
+
+### A5. Approval & human-oversight gaps
+
+**NSA concern:** agents take high-impact actions without adequate human-in-the-loop checkpoints; consent flows are weak or fatigued.
+
+**ATR clusters:**
+- `excessive-autonomy/` (29 rules) — `ATR-2026-00098` unauthorized-financial-action, `ATR-2026-00099` high-risk-tool-gate (forces an `ask` verdict on financial/destructive/communication/permission/system tool categories), `ATR-2026-00428` nl-unauthorized-shell-execution
+- `agent-manipulation/` — `ATR-2026-00118` approval-fatigue
+
+**Strength:** STRONG at raising the signal. **Honest limit:** ATR flags the high-impact call (`response.actions: require_auth_challenge`); the operator-side approval UX is implementation-defined.
+
+### A6. Logging, monitoring & visibility deficiencies
+
+**NSA concern:** insufficient observability — tool and model invocations are not logged with parameters and identities, and audit trails can be evaded.
+
+**ATR contribution (two layers):**
+- **Structured event taxonomy** — every ATR rule emits a stable `id`, `severity`, `category`, and `response.actions`; these are the audit-log primitives the CSI's observability recommendation depends on.
+- **Audit-evasion detection** — `ATR-2026-00085` audit-evasion, `ATR-2026-00094` audit-bypass, `ATR-2026-00105` silent-action-concealment.
+
+**Strength:** LIMITED-to-MODERATE — ATR supplies the event taxonomy and catches evasion attempts; log retention, tamper-resistance, and signed audit storage are operator-side (this is where the [ai-rmf-oscal-catalog](https://github.com/Agent-Threat-Rule/ai-rmf-oscal-catalog) OSCAL evidence layer connects — see Part C).
+
+### A7. Configuration & deployment pitfalls
+
+**NSA concern:** insecure defaults, unvetted third-party servers, and supply-chain exposure at deploy time.
+
+**ATR clusters:**
+- `skill-compromise/` (45 rules) — `ATR-2026-00060` skill-impersonation, `ATR-2026-00062` hidden-capability, `ATR-2026-00065` skill-update-attack (rug-pull), `ATR-2026-00095` mcp-supply-chain-poisoning, `ATR-2026-00419` cursor-mcp-zero-click-config
+- `excessive-autonomy/` — `ATR-2026-00500` ssrf-via-agent-url-fetch-instruction
+
+**Strength:** STRONG for supply-chain and skill-integrity precursors; secure-default *enforcement* is operator policy.
+
+---
+
+## Part B — NSA recommended mitigations → how ATR operationalizes each
+
+| NSA recommended mitigation | ATR contribution | Coverage |
+|---|---|---|
+| **Perform local MCP scans** | The 655-rule corpus **is** local-scan content (YAML signatures, already in Cisco skill-scanner, PyRIT, MISP galaxy) | DIRECT |
+| **Input validation against schemas / ranges / context** | `prompt-injection/` input rules + `ATR-2026-00084` structured-data-injection flag malformed / injected inputs at the agent boundary | STRONG |
+| **Observability — log all tool/model invocations with params + identities** | Stable per-rule event taxonomy (`id`/`severity`/`category`/`response`) + audit-evasion detection (00085/00094/00105) | PARTIAL (taxonomy + evasion; retention is operator-side) |
+| **Outgoing proxy controls / DLP / output filtering** | `context-exfiltration/` (104 rules) + `ATR-2026-00500` ssrf + `ATR-2026-00102` disguised-analytics-exfiltration detect the exfil the proxy/DLP must block | STRONG signal layer |
+| **Deny-by-default allowlists / least privilege** | `ATR-2026-00099` high-risk-tool-gate enforces an explicit `ask` on high-risk tool categories | DIRECT |
+| **Sandboxing** | Architectural; ATR detects escape *attempts* (00110 eval, 00111 shell, 00436 enclave-escape) | COMPLEMENTARY |
+| **Message integrity (inter-server)** | `agent-manipulation/` A2A rules (00116 a2a-message-validation, 00076 inter-agent-message-spoofing) | MODERATE |
+| **Data classification zones** | Architectural; ATR detects cross-zone exfil via `context-exfiltration/` | COMPLEMENTARY |
+
+---
+
+## Part C — The OSCAL / NIST tie-in (why this mapping matters beyond NSA)
+
+The NSA CSI's observability and accountability recommendations are exactly what NIST's **SP 800-53 Control Overlays for Securing AI Systems (COSAiS)** and the **OSCAL** assessment layer formalize. ATR already maintains:
+
+- [`ai-rmf-oscal-catalog`](https://github.com/Agent-Threat-Rule/ai-rmf-oscal-catalog) (CC0) — ATR's detection rules expressed as an OSCAL-consumable AI-RMF control profile.
+- An in-progress NIST OSCAL community contribution (AI-RMF profile examples, PR #338).
+
+This NSA MCP mapping is the **MCP-specific evidence exhibit** for that NIST track: it shows, control-area by control-area, that ATR's rules are the machine-executable enforcement layer beneath the controls NSA recommends and NIST is overlaying. It is the artifact to bring to the COSAiS community channel (`overlays-securing-ai@list.nist.gov` / the #NIST-Overlays-Securing-AI Slack).
+
+---
+
+## What ATR does NOT cover (be honest)
+
+- **Cryptographic agent identity / attestation.** Detection-side, not identity-side (W3C DID / agent-attestation frameworks).
+- **The human-approval UX** for high-impact actions. ATR raises the signal; the operator builds the gate.
+- **Sandbox / network isolation, secure defaults, log retention & tamper-resistance.** Architectural and operator-side; ATR detects precursors and evasion, not infrastructure posture.
+- **Paraphrase bypass of canonical payloads.** Regex-and-pattern detection is one layer, not the only layer.
+- **Multimodal (image/audio) injection** and **non-English coverage** remain partial (Japanese/German extension in progress).
+- **Primary-PDF verbatim pinning** of NSA headings is pending (see Source verification).
+
+---
+
+## References
+
+- NSA CSI, *Model Context Protocol (MCP): Security Design Considerations for AI-Driven Automation* (primary PDF, defense.gov media library, 2026-06-02): https://media.defense.gov/2026/Jun/02/2003943289/-1/-1/0/CSI_MCP_SECURITY.PDF
+- NSA press release (Article 4496698): https://www.nsa.gov/Press-Room/Press-Releases-Statements/Press-Release-View/Article/4496698/
+- Secondary corroboration: Adversa AI (Top MCP security resources, 2026-06), GetAIGovernance, Reed Smith Viewpoints, Cybersecurity Dive (NIST control-overlays coverage).
+- CISA AI Cybersecurity Collaboration Playbook (JCDC): https://www.cisa.gov/resources-tools/resources/ai-cybersecurity-collaboration-playbook
+- ATR rule corpus: https://github.com/Agent-Threat-Rule/agent-threat-rules
+- Sibling mappings: [FIVE-EYES-MAPPING.md](./FIVE-EYES-MAPPING.md) · [SAFE-MCP-MAPPING.md](./SAFE-MCP-MAPPING.md) · [MITRE-ATLAS-MAPPING.md](./MITRE-ATLAS-MAPPING.md) · [OWASP-AGENTIC-MAPPING.md](./OWASP-AGENTIC-MAPPING.md)
+- ATR OSCAL AI-RMF catalogue (CC0): https://github.com/Agent-Threat-Rule/ai-rmf-oscal-catalog
+
+## Verification status
+
+- [x] NSA CSI risk areas corroborated across ≥2 independent secondary sources each.
+- [x] Recommended-mitigation list corroborated (local MCP scans, input validation, observability, outgoing proxy/DLP, deny-by-default, sandboxing, message integrity, data classification).
+- [x] All 16 cited ATR rule IDs verified to exist at v3.5.2 HEAD (2026-06-28).
+- [x] Per-category counts pinned to disk truth at HEAD (655 total; prompt-injection 223, agent-manipulation 106, context-exfiltration 104, tool-poisoning 68, skill-compromise 45, model-abuse 37, privilege-escalation 35, excessive-autonomy 29, data-poisoning 5, model-security 3).
+- [ ] **Primary-PDF verbatim extraction** of NSA section headings (defense.gov 403s automated fetch; pending authenticated-browser pass).
+- [ ] Reconcile `data/stats.json` 652 vs disk 655 before external citation of a single headline number.
+- [ ] Second-reviewer sanity-check of STRONG / MODERATE / LIMITED strength ratings.

--- a/scripts/audit-mappings.ts
+++ b/scripts/audit-mappings.ts
@@ -34,6 +34,7 @@ const CROSSWALK_DOCS = [
   "SAFE-MCP-MAPPING.md",
   "FIVE-EYES-MAPPING.md",
   "OWASP-AST10-MAPPING.md",
+  "NSA-MCP-MAPPING.md",
 ] as const;
 
 interface RuleMapping {


### PR DESCRIPTION
## Summary
Adds `docs/NSA-MCP-MAPPING.md` — maps the **NSA Model Context Protocol (MCP): Security Design Considerations** CSI (May 2026) to specific ATR rule clusters and IDs. Companion to the existing Five Eyes mapping; the MCP-specific technical counterpart.

## What it contains
- **Part A** — NSA's 7 risk areas → ATR rule clusters (with verified rule IDs)
- **Part B** — NSA's recommended mitigations → how ATR operationalizes each (local MCP scans, input validation, observability, outgoing proxy/DLP, deny-by-default, sandboxing, message integrity, data classification)
- **Part C** — the OSCAL / NIST tie-in (connects to `ai-rmf-oscal-catalog` + OSCAL community PR #338)
- Honest "What ATR does NOT cover" + source-verification provenance

## Honesty note
The NSA CSI primary PDF on defense.gov returns HTTP 403 to automated fetch, so section headings are reconstructed from **corroborated secondary sources** (NSA press release + 4 independent analyses), not yet pinned to verbatim primary text. This is disclosed in the doc and tracked as a verification TODO (authenticated-browser primary extraction pending).

## Test plan
- [x] All 16 cited ATR rule IDs verified to exist at v3.5.2 HEAD
- [x] Per-category counts pinned to disk truth (655 total)
- [x] All repo links use the correct `Agent-Threat-Rule` org
- [ ] Primary-PDF verbatim extraction of NSA headings
- [ ] Reconcile `data/stats.json` 652 vs disk 655 before single-number external citation