### PR TITLE
chore(stats): reconcile data/stats.json rule count to disk (652->655)

### DIFF
--- a/data/stats.json
+++ b/data/stats.json
@@ -2,7 +2,7 @@
   "version": "3.5.0",
   "generatedAt": "2026-06-16T11:05:13.632Z",
   "rules": {
-    "total": 652,
+    "total": 655,
     "categories": 10,
     "byCategory": {
       "agent-manipulation": 106,
@@ -14,7 +14,7 @@
       "privilege-escalation": 35,
       "prompt-injection": 223,
       "skill-compromise": 45,
-      "tool-poisoning": 65
+      "tool-poisoning": 68
     }
   },
   "ecosystem": {


### PR DESCRIPTION
## Summary
`data/stats.json` reported **652** rules; the filesystem, root `stats.json`, and `grep '^id: ATR-'` all agree at **655**. This is the file CLAUDE.md tells every external citation to cross-check, so the 3-rule lag was a recurring "don't cite a number" blocker.

## Root cause
`data/stats.json` is a 2026-06-16 (v3.5.0) snapshot. Three `tool-poisoning` rules were added since (65 → 68), bumping the disk total to 655, but the bot-owned `rules.*` fields had not been regenerated. Diagnosis confirmed the drift is isolated to `tool-poisoning` — every other category already matched disk.

## Change
- `rules.total` 652 → 655
- `rules.byCategory.tool-poisoning` 65 → 68
- byCategory now sums to 655 == total

## Explicitly NOT changed
`version`, `generatedAt`, and the `benchmarks` array are the v3.5.0 measurement snapshot (each benchmark carries its own `atr_version` tag) and are left untouched. The auto-crystallize bot fully regenerates this file on its next run; this is a manual count-only reconcile to unblock external citation now.

## Test plan
- [x] byCategory sum == total (655)
- [x] matches `find rules -name "*.yaml" | wc -l` (655)
- [x] matches root `stats.json` ruleCount.total (655)