### PR TITLE
feat(scan): persist clean benign samples as the production-gate wild corpus (#3)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,6 @@ scripts/crawl-corpora.ts
 # LaTeX build artifacts (regenerated on build)
 docs/paper/*.log
 docs/paper/missfont.log
+
+# Wild benign corpus for the production-promotion gate (large, local-only)
+data/wild-benign/

--- a/scripts/mega-scan.mjs
+++ b/scripts/mega-scan.mjs
@@ -3,7 +3,7 @@
  * 53,000+ skills across OpenClaw + Skills.sh
  * Uses 93-rule engine with cross-context detection + base64 decode
  */
-import { readFileSync, writeFileSync, readdirSync, statSync } from 'node:fs';
+import { readFileSync, writeFileSync, readdirSync, statSync, mkdirSync, appendFileSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import { createHash } from 'node:crypto';
 import { ATREngine } from '../dist/engine.js';
@@ -79,6 +79,15 @@ async function main() {
   const threats = [];
   const startTime = Date.now();
 
+  // Persist EVERY clean benign sample to a local corpus for the production
+  // promotion gate (promote-to-stable --wild-corpus). These are public skills;
+  // the file is large + gitignored, never committed. Truncated at scan start.
+  const WILD_CORPUS_DIR = 'data/wild-benign';
+  const WILD_CORPUS_OUT = WILD_CORPUS_DIR + '/clean-corpus.jsonl';
+  mkdirSync(WILD_CORPUS_DIR, { recursive: true });
+  writeFileSync(WILD_CORPUS_OUT, '');
+  let corpusWritten = 0;
+
   for (const file of allFiles) {
     try {
       const stat = statSync(file);
@@ -118,6 +127,16 @@ async function main() {
         }
       } else {
         clean++;
+        // Stream the clean benign sample to the wild corpus (memory-safe append).
+        appendFileSync(
+          WILD_CORPUS_OUT,
+          JSON.stringify({
+            source: 'wild-scan',
+            source_id: file.split('/').slice(-2).join('/'),
+            text: content,
+          }) + '\n',
+        );
+        corpusWritten++;
       }
       
       // Progress every 5000
@@ -271,6 +290,8 @@ async function main() {
   };
   writeFileSync('data/mega-scan-report.json', JSON.stringify(report, null, 2));
   console.log('\nReport saved: data/mega-scan-report.json');
+  console.log(`Wild benign corpus: ${corpusWritten} clean samples saved to ${WILD_CORPUS_OUT}`);
+  console.log(`  Production gate: npx tsx scripts/promote-to-stable.ts --wild-corpus ${WILD_CORPUS_OUT} --write`);
 }
 
 main().catch(e => { console.error('FATAL:', e); process.exit(1); });


### PR DESCRIPTION
## Why (#3 of the local-flywheel work — the production-gate unblock)

`promote-to-stable.ts` (#242) is the test → production promotion gate: a rule only becomes `maturity: production` after 0 FP against a LARGE wild corpus (>= 20K samples). But that corpus **did not exist on disk anywhere** — `mega-scan.mjs` scans ~96K public MCP skills yet only wrote a summary report, explicitly **discarding all ~95K clean benign samples** ("we don't store them above to save memory"). So the production gate could never actually run.

## Change

The scan now streams **every clean sample** to `data/wild-benign/clean-corpus.jsonl` — a memory-safe `appendFileSync` inside the existing scan loop, in the exact `{source, source_id, text}` shape `promote-to-stable`'s `loadCorpusTexts()` reads.

- The file is large and **gitignored** — never committed. It is a local artifact.
- These are **public skills**, so the corpus is not moat data; it is produced by the (public) scan and stays local. The wild corpus DATA staying private/local is by design.

## After merge

Run the ecosystem scan (your pipeline) → it now writes the corpus → feed it to the gate:

```
npx tsx scripts/promote-to-stable.ts --wild-corpus data/wild-benign/clean-corpus.jsonl --write
```

Now the production tier is enforceable against real wild data, not just the ~5.2K public corpus.

## Verification

- `node --check scripts/mega-scan.mjs` passes.
- Format verified against `promote-to-stable.ts` (`.text` field).
- Diff is +23 lines (import + corpus setup + one append in the clean branch + a summary log) plus the `.gitignore` entry. No other behavior changed.
- Full corpus generation happens when the scan runs (heavy: re-clones the OpenClaw registry + scans ~96K skills).
