### PR TITLE
ci(stats): auto-reconcile rule count to disk — single source of truth

### DIFF
--- a/.github/workflows/reconcile-stats.yml
+++ b/.github/workflows/reconcile-stats.yml
@@ -1,0 +1,61 @@
+name: Reconcile Rule Count Stats
+
+# The rule count lives in git as rules/**/*.yaml (ground truth). stats.json
+# (ruleCount.total) and data/stats.json (rules.total) are derived caches that used
+# to drift whenever rules changed without regenerating them — patched by hand via
+# `chore(stats): reconcile ...` commits. This closes the window: on every rules
+# change to main, recompute the disk count and commit it back into both caches so
+# they can never diverge from disk.
+#
+# Safe by construction:
+#   - Only fires on rules/** changes; the reconcile commit touches stats files only,
+#     so it never re-triggers this workflow (and GITHUB_TOKEN pushes don't recurse).
+#   - Never blocks a PR (post-merge fix), so the flywheel's auto-generated PRs
+#     (maturity-promote / TC-crystallize) are unaffected.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'rules/**'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: reconcile-stats-main
+  cancel-in-progress: false
+
+jobs:
+  reconcile:
+    runs-on: ubuntu-latest
+    # Defensive: never react to our own reconcile commit.
+    if: "${{ !startsWith(github.event.head_commit.message, 'chore(stats): auto-reconcile') }}"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0  # full history so `git push origin main` fast-forwards (matches release bot)
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '22'
+
+      - name: Reconcile rule-count stats to disk
+        run: node scripts/reconcile-rule-count.mjs
+
+      - name: Commit reconciled stats if changed
+        run: |
+          if [ -z "$(git status --porcelain stats.json data/stats.json)" ]; then
+            echo "stats already in sync with disk — nothing to commit"
+            exit 0
+          fi
+          count=$(node -e 'process.stdout.write(String(JSON.parse(require("fs").readFileSync("stats.json","utf8")).ruleCount.total))')
+          git config user.name "ATR Stats Bot"
+          git config user.email "bot@agentthreatrule.org"
+          git add stats.json data/stats.json
+          git commit -m "chore(stats): auto-reconcile rule count to disk (${count} rules)"
+          git push origin main

--- a/data/stats.json
+++ b/data/stats.json
@@ -2,7 +2,7 @@
   "version": "3.5.0",
   "generatedAt": "2026-06-16T11:05:13.632Z",
   "rules": {
-    "total": 675,
+    "total": 683,
     "categories": 10,
     "byCategory": {
       "agent-manipulation": 106,

--- a/package.json
+++ b/package.json
@@ -86,7 +86,8 @@
     "compile:yara": "tsx scripts/compile-yara.ts --all rules/",
     "prepublishOnly": "npm run build",
     "prepare": "npm run build 1>&2",
-    "compile:pipelock": "tsx scripts/compile-pipelock.ts"
+    "compile:pipelock": "tsx scripts/compile-pipelock.ts",
+    "reconcile-stats": "node scripts/reconcile-rule-count.mjs"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.12.0",

--- a/scripts/reconcile-rule-count.mjs
+++ b/scripts/reconcile-rule-count.mjs
@@ -1,0 +1,83 @@
+#!/usr/bin/env node
+/**
+ * reconcile-rule-count.mjs — keep the ATR rule count consistent across the repo.
+ *
+ * Ground truth for the rule count is the set of `rules/**\/*.yaml` files in git
+ * (every rule file carries a top-level `id: ATR-...`). Two derived caches restate
+ * that number:
+ *   - stats.json           -> ruleCount.total   (propagated to README / docs / MCP)
+ *   - data/stats.json      -> rules.total       (used by the website + tooling)
+ *
+ * These caches drift whenever rules are added/removed without regenerating them,
+ * and were historically fixed by hand with `chore(stats): reconcile ...` commits.
+ * This script recomputes the disk count and writes it into BOTH caches so they
+ * can never diverge from disk. Run it in CI on every push to main
+ * (.github/workflows/reconcile-stats.yml) to close the drift window automatically.
+ *
+ * Scope: only the `total` field — the number that is cited and that drifts. The
+ * status breakdown (stable/experimental/draft) and byCategory remain owned by the
+ * existing generators (sync-stats.ts / sync-stats-from-measurements.ts).
+ *
+ * Usage:
+ *   node scripts/reconcile-rule-count.mjs           # reconcile in place (write)
+ *   node scripts/reconcile-rule-count.mjs --check    # report drift, exit 1, write nothing
+ */
+import { readFileSync, writeFileSync, readdirSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const RULES_DIR = join(REPO_ROOT, 'rules');
+const ID_RE = /^id:\s*ATR-/m;
+const CHECK = process.argv.includes('--check');
+
+/** Count rule files on disk (a rule = a *.yaml carrying a top-level `id: ATR-`). */
+function countRules(dir) {
+  let n = 0;
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const p = join(dir, entry.name);
+    if (entry.isDirectory()) n += countRules(p);
+    else if (entry.isFile() && entry.name.endsWith('.yaml') && ID_RE.test(readFileSync(p, 'utf8'))) n++;
+  }
+  return n;
+}
+
+const diskCount = countRules(RULES_DIR);
+let drift = false;
+
+/**
+ * Reconcile one cache file's `total` to the disk count.
+ * Edits only the total's digits in place (surgical) so the diff is a single line
+ * and the file's existing formatting is preserved exactly.
+ */
+function reconcile(relPath, blockKey) {
+  const abs = join(REPO_ROOT, relPath);
+  const text = readFileSync(abs, 'utf8');
+  const json = JSON.parse(text);
+  const block = json[blockKey] || {};
+  const before = block.total;
+  if (before === diskCount) {
+    console.log(`[reconcile] ${relPath}: ${blockKey}.total=${before} — in sync`);
+    return;
+  }
+  drift = true;
+  console.log(`[reconcile] ${relPath}: ${blockKey}.total ${before} -> ${diskCount}${CHECK ? ' (drift)' : ' (fixed)'}`);
+  if (CHECK) return;
+  // Surgical replace: the "total": N inside the target block (total is the first key).
+  const re = new RegExp(`("${blockKey}"\\s*:\\s*\\{[^{}]*?"total"\\s*:\\s*)${before}\\b`);
+  const next = text.replace(re, `$1${diskCount}`);
+  if (next === text) {
+    console.error(`[reconcile] FATAL: could not locate ${blockKey}.total in ${relPath}`);
+    process.exit(2);
+  }
+  writeFileSync(abs, next);
+}
+
+reconcile('stats.json', 'ruleCount');
+reconcile('data/stats.json', 'rules');
+
+console.log(`[reconcile] disk rule count = ${diskCount}`);
+if (CHECK && drift) {
+  console.error('[reconcile] FAIL: stats caches drift from disk. Fix: node scripts/reconcile-rule-count.mjs');
+  process.exit(1);
+}


### PR DESCRIPTION
Problem

The ATR rule count is duplicated in two derived caches that drift from the
rules/**/*.yaml ground truth whenever rules are added or removed without
regenerating them:
  - stats.json      -> ruleCount.total   (propagated to README / docs / MCP)
  - data/stats.json -> rules.total       (used by the website + tooling)

Historically this was fixed by hand with recurring "chore(stats): reconcile
data/stats.json rule count to disk (X -> Y)" commits. The root stats.json total
is refreshed by the release bot at publish time, but publish is intentionally
throttled to TC-crystallized commits, so between a rules merge and the next
publish both caches lag disk. At the time of writing, main disk = 683 but
data/stats.json = 675.

Fix

Close the drift window automatically instead of patching it by hand.

  - scripts/reconcile-rule-count.mjs — counts the rule files on disk (a rule is
    a *.yaml carrying a top-level "id: ATR-") and writes that count into both
    caches' total field. Zero dependencies, surgical single-line edit (preserves
    existing formatting), plus a --check mode that reports drift and exits 1
    without writing. npm run reconcile-stats.

  - .github/workflows/reconcile-stats.yml — runs the script on every push to main
    under rules/**, and commits the reconciled total back to main.

Safe by construction

  - Never blocks a PR (post-merge fix), so the flywheel's auto-generated PRs
    (maturity-promote / TC-crystallize) are unaffected. Verified that those PRs
    do not touch stats files, so a blocking gate would have jammed them.
  - The reconcile commit touches stats files only, so it can never re-trigger the
    workflow (paths filter is rules/**), and GITHUB_TOKEN pushes do not recurse.
  - Scope limited to the total field — the number that is cited and that drifts.
    The status breakdown and byCategory remain owned by the existing generators
    (sync-stats.ts / sync-stats-from-measurements.ts).

Also reconciles the current drift in this PR: data/stats.json 675 -> 683.

Test

  node scripts/reconcile-rule-count.mjs --check   # detects drift, exits 1
  node scripts/reconcile-rule-count.mjs           # fixes data/stats.json 675 -> 683
  node scripts/reconcile-rule-count.mjs --check   # clean, exits 0

Left as draft for review.
