### PR TITLE
docs(adopters): add AG2 (AutoGen) — ATRGuardrail shipped in ag2-classic

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -128,6 +128,14 @@ deployment publicly (merged PR, public docs, conference talk, etc.).
 Open-source developer tools, frameworks, and SDKs that have integrated ATR.
 Listed when the integration code has been merged or released.
 
+### AG2 (AutoGen)
+- **Org**: AG2 (ag2ai)
+- **Type**: adapter
+- **Integration**: `ATRGuardrail` contrib capability that scans tool output and LLM input against the ATR ruleset via the `pyatr` engine; merged into the ag2-classic framework and since maintained by an AG2 maintainer
+- **Evidence**: <https://github.com/ag2ai/ag2classic/blob/main/autogen/agentchat/contrib/capabilities/atr_guardrail.py>
+- **Since**: 2026-06-28
+- **Status**: shipped
+
 ### BerriAI LiteLLM
 - **Org**: BerriAI
 - **Type**: sidecar-proxy


### PR DESCRIPTION
Adds AG2 to ADOPTERS.md (Tier 2, status shipped).

Evidence: the ATRGuardrail contrib capability is merged on ag2-classic main and has since been maintained by an AG2 maintainer (who committed a follow-up fix). This is a real in-tree integration, not a self-declared claim.

- File: https://github.com/ag2ai/ag2classic/blob/main/autogen/agentchat/contrib/capabilities/atr_guardrail.py
- Requested by the AG2 maintainer in ag2ai/ag2#2828

Type: adapter. Integration scans tool output and LLM input against the ATR ruleset via the pyatr engine.