### PR TITLE
feat(sigma): ATR YAML → Sigma rule converter

### DIFF
--- a/docs/sigma-export/README.md
+++ b/docs/sigma-export/README.md
@@ -1,0 +1,170 @@
+# ATR to Sigma converter
+
+`scripts/generate-sigma.py` converts Agent Threat Rules (ATR) YAML rules into
+[Sigma](https://sigmahq.io) detection rules, so the Sigma ecosystem (SIEM
+backends through pySigma / sigma-cli) can consume ATR's agent/LLM detections.
+
+This was built in response to
+[agentshield-ai/sigma-ai#9](https://github.com/agentshield-ai/sigma-ai/issues/9),
+where — after the ATR to MITRE ATT&CK crosswalk
+(`docs/crosswalks/atr-attack-crosswalk.md`) landed — the agreed next step was
+"the YAML to Sigma converter".
+
+The example rules under `docs/sigma-export/rules/` in this directory were
+produced by this script from the real ATR rules named in each file; they are
+not hand-authored.
+
+## Why this is not a lossless 1:1 conversion
+
+ATR and Sigma detect different things at different layers, and the honest
+answer is that the mapping is exact on one axis and approximate on others. This
+is stated up front rather than buried.
+
+Sigma was built to match fields in **host / network / cloud log events**
+(a `process_creation` event, an `sshd` auth log). ATR patterns fire on **AI
+agent runtime surfaces** — the model's `content`, the `user_input`, a
+`tool_response`, `tool_args`, `tool_name`, `agent_output`. There is no ratified
+Sigma `logsource` for agent traffic today. So the converter emits a **custom,
+clearly-labelled** logsource (`logsource.product: ai_agent`) and preserves the
+ATR field name verbatim as the Sigma detection field. Anyone deploying these
+into a SIEM must map those field names onto their own agent-telemetry pipeline.
+That wiring step is the approximate part, and it is the operator's to complete.
+
+The one axis that **is** exact is the MITRE ATT&CK technique id — the same join
+key the crosswalk established.
+
+## Field mapping table
+
+| ATR field | Sigma field | Mapping | Exact? |
+|---|---|---|---|
+| `title` | `title` | verbatim, truncated to 256 chars (Sigma limit) | yes |
+| `id` (e.g. `ATR-2026-00030`) | `id` | deterministic UUIDv5 of the ATR id (Sigma requires a UUID; ATR ids are not UUIDs). Same ATR id always yields the same UUID. The original ATR id is also preserved as an `atr.rule.*` tag. | derived, stable |
+| `severity` (critical/high/medium/low) | `level` | direct: critical→critical, high→high, medium→medium, low→low | yes |
+| `status` / `maturity` | `status` | stable→stable, experimental→experimental, test→test, draft→experimental | yes for shared values |
+| `description` | `description` | verbatim + a provenance/limitations note appended | yes (additive) |
+| `author` | `author` | verbatim | yes |
+| `date` (`YYYY/MM/DD`) | `date` | normalised to ISO `YYYY-MM-DD` | yes |
+| `references.mitre_attack: Txxxx` | `tags: attack.txxxx` | lower-cased, prefixed `attack.` — **the canonical Sigma join key** | **exact** |
+| `references.mitre_atlas: AML.Txxxx` | `tags: atlas.aml-txxxx` | custom namespace (Sigma has no ATLAS taxonomy) | additive, non-standard |
+| `references.owasp_agentic: ASInn` | `tags: owasp-agentic.asinn` | custom namespace | additive, non-standard |
+| `references.owasp_llm: LLMnn` | `tags: owasp-llm.llmnn` | custom namespace | additive, non-standard |
+| `tags.category` | `tags: atr.category.<cat>` | custom namespace | additive, non-standard |
+| detection `field` (content, tool_response, ...) | Sigma detection field name | verbatim; drives `logsource.category` (see below) | field name exact; logsource custom |
+| detection `operator: regex` + `value` | `field\|re` or `field\|re\|i` | leading inline `(?i)` is stripped and re-expressed as the Sigma `re\|i` case-insensitive sub-flag; the rest of the pattern is passed through verbatim | see caveat below |
+| detection `condition: any` | `condition: 1 of sel_*` | | yes |
+| detection `condition: all` | `condition: all of sel_*` | | yes |
+| detection `false_positives` | `falsepositives` | verbatim | yes |
+| detection numeric operators (`gt`/`lt`/...) | plain field match + warning | Sigma base spec has no portable numeric comparison | **approximate** |
+
+### logsource.category derivation
+
+The Sigma `logsource.category` is derived from the rule's dominant detection
+field (custom values, all under `product: ai_agent`):
+
+| ATR detection field | logsource.category |
+|---|---|
+| `content` | `ai_agent_content` |
+| `user_input` | `ai_agent_prompt` |
+| `tool_response` | `ai_agent_tool_response` |
+| `tool_args` / `tool_input` / `tool_name` / `tool_description` | `ai_agent_tool_call` |
+| `agent_output` | `ai_agent_output` |
+| anything else (e.g. `trace.*`, `behavioral.metric_value`) | `ai_agent_other` (with a warning) |
+
+## Known limitations (honest)
+
+1. **No standard agent logsource.** `logsource.product: ai_agent` and the
+   `ai_agent_*` categories are ATR-defined, not ratified by SigmaHQ. Backends
+   will not know these field names until you map them to your agent telemetry.
+   This is the single biggest caveat.
+
+2. **Case-insensitivity relies on `re|i` backend support.** ATR regexes almost
+   universally open with inline `(?i)`. The converter strips that and emits the
+   Sigma `re|i` sub-flag, which is the portable way. A handful of patterns with
+   other combined inline flags (`(?is)` etc.) keep the remaining flag inline;
+   inline-flag support varies by backend. Patterns with no leading `(?i)` are
+   emitted as case-sensitive `re` exactly as ATR wrote them.
+
+3. **Regex flavor.** ATR patterns are Python `re`. Sigma `re` is documented as
+   PCRE-ish but the effective flavor is the *target backend's* regex engine
+   after pySigma translation. Exotic constructs (lookbehind, named groups,
+   backreferences) may not survive every backend. The converter does not
+   rewrite regex internals — it passes them through, so a pattern that a backend
+   cannot compile is a backend limitation surfaced at deploy time, not silently
+   altered here.
+
+4. **Behavioral / aggregation rules degrade.** ATR behavioral-method rules
+   (e.g. `ATR-2026-00553`, "more than 100 tool calls per minute per session")
+   carry a `detection.behavioral` aggregation block (count over a time window).
+   The Sigma **base** spec has no aggregation grammar (Sigma Correlation rules
+   are a separate, evolving construct). The converter maps only the rule's
+   `detection.conditions` — for behavioral rules that is a match on the
+   pre-computed threshold-breach signal, **not** the underlying count-over-time
+   logic. Treat these as approximate.
+
+5. **`test_cases` / `evasion_tests` are not carried over.** ATR ships rich
+   true-positive / true-negative / evasion test corpora per rule. Sigma has no
+   place for them in the rule schema, so they stay in ATR. (They remain the
+   authoritative validation of the underlying pattern.)
+
+6. **ATLAS / OWASP tags are non-standard namespaces.** Only `attack.*` is
+   understood by mainstream Sigma tooling. `atlas.*`, `owasp-agentic.*`,
+   `owasp-llm.*`, and `atr.*` are additive agent-layer context this converter
+   emits so no ATR metadata is lost — but off-the-shelf Sigma backends will
+   ignore them unless you teach them the namespace.
+
+## Usage
+
+Requires Python 3.10+ and PyYAML (`pip install pyyaml`), no other dependencies —
+same zero-heavy-dependency discipline as `scripts/generate-attack-crosswalk.py`.
+
+Convert a single rule to stdout:
+
+    python3 scripts/generate-sigma.py --rule rules/agent-manipulation/ATR-2026-00030-cross-agent-attack.yaml
+
+Convert several rules into a directory (one `.sigma.yml` each):
+
+    python3 scripts/generate-sigma.py \
+      --rule rules/agent-manipulation/ATR-2026-00030-cross-agent-attack.yaml \
+      --rule rules/agent-manipulation/ATR-2026-00118-approval-fatigue.yaml \
+      --out docs/sigma-export/rules
+
+Convert the entire rule corpus:
+
+    python3 scripts/generate-sigma.py --all --out docs/sigma-export/rules
+
+Conversion warnings (approximate mappings, unmapped fields) are printed to
+stderr; add `--quiet` to suppress them. Every warning names the ATR rule id so
+nothing is hidden.
+
+## Validating the output with real Sigma tooling
+
+The emitted files are standard Sigma YAML. To check them against pySigma:
+
+    pip install sigma-cli
+    sigma check docs/sigma-export/rules/
+
+`sigma check` validates schema and structure. Note it may warn on the custom
+`ai_agent` logsource / non-standard tag namespaces — that is expected and is
+exactly limitation (1) and (6) above, not a converter bug.
+
+The five exported example rules in `docs/sigma-export/rules/` have been parsed
+by pySigma's `SigmaRule.from_yaml()` with zero errors (title, level, and tags
+all recognised). The test suite re-checks this automatically when pySigma is
+installed (and skips it cleanly when it is not).
+
+## Tests
+
+`scripts/test_generate_sigma.py` verifies the load-bearing guarantees: the
+output is valid YAML with all required Sigma fields, `level`/`status` are in
+Sigma's allowed sets, the ATT&CK join key round-trips (every enterprise ATT&CK
+id in the source ATR rule appears as `attack.txxxx`, and no bogus `attack.*`
+tag is minted from an ATLAS id), the `(?i)` → `re|i` transform is applied, and
+every rule in the whole corpus converts to reparseable Sigma without crashing.
+
+    python3 scripts/test_generate_sigma.py     # standalone
+    pytest scripts/test_generate_sigma.py      # under CI
+
+## License
+
+ATR is MIT-licensed. This converter and its output may be reused under the same
+terms.

--- a/docs/sigma-export/rules/ATR-2026-00030-cross-agent-attack.sigma.yml
+++ b/docs/sigma-export/rules/ATR-2026-00030-cross-agent-attack.sigma.yml
@@ -1,0 +1,77 @@
+title: Cross-Agent Attack Detection
+id: cbfb4b86-e2e4-508a-a146-90aefb22dbed
+status: stable
+description: 'Consolidated detection for cross-agent attacks in multi-agent systems,
+
+  covering both impersonation and prompt injection vectors. Detects when
+
+  one agent spoofs another agent''s identity, injects manipulative
+
+  instructions into inter-agent messages, forges system-level message tags,
+
+  attempts orchestrator bypass, injects fake status or error messages,
+
+  or manipulates message format conventions to deceive target agents.
+
+  These attacks exploit trust relationships between agents to achieve
+
+  unauthorized actions, data exfiltration, or safety bypass.
+
+
+  Converted from Agent Threat Rules ATR-2026-00030 (ATR-2026-00030-cross-agent-attack.yaml) by scripts/generate-sigma.py. ATR is MIT-licensed. logsource.product=ai_agent is a custom (non-standard) taxonomy for agent runtime telemetry.'
+references:
+- https://github.com/Agent-Threat-Rule/agent-threat-rules
+author: ATR Community
+date: '2026-03-08'
+tags:
+- atlas.aml-t0051
+- atlas.aml-t0043
+- atlas.aml-t0052-000
+- owasp-agentic.asi01
+- owasp-agentic.asi07
+- owasp-agentic.asi10
+- owasp-llm.llm01
+- owasp-llm.llm06
+- owasp-llm.llm05
+- atr.category.agent-manipulation
+- atr.rule.atr-2026-00030
+logsource:
+  product: ai_agent
+  category: ai_agent_content
+  definition: Custom ATR taxonomy for AI agent runtime telemetry. Detection field names (content, user_input, tool_response, tool_args, tool_name, tool_description, agent_output, ...) are ATR surfaces, not standard Sigma fields; map them to your agent-telemetry pipeline.
+detection:
+  sel_1:
+    content|re|i: (?:i\s+am|this\s+is|speaking\s+as|responding\s+as|acting\s+as)\s+(?:the\s+)?(?:admin|supervisor|orchestrator|manager|controller|system|root)\s+agent
+  sel_2:
+    content|re|i: (?:ignore|disregard|forget|override|overwrite)\s+(?:all\s+)?(?:your\s+)?(?:previous|prior|above|earlier|existing)\s+(?:instructions?|rules?|constraints?|guidelines?|prompt|directives?)
+  sel_3:
+    content|re|i: \[\s*(?:SYSTEM|ADMIN|OVERRIDE|ROOT|SUDO|PRIORITY|URGENT)\s*\]|<<\s*SYS\s*>>|<\|im_start\|>system
+  sel_4:
+    content|re|i: (?:new\s+instructions?|updated\s+(?:prompt|directive)|revised\s+(?:rules?|orders?)|emergency\s+(?:override|protocol))\s*[:=]
+  sel_5:
+    content|re|i: (?:you\s+are\s+now|from\s+now\s+on|henceforth|going\s+forward|effective\s+immediately)\s+(?:a|an|the)?\s*(?:unrestricted|unfiltered|jailbroken)?\s*[a-zA-Z]+\s+(?:agent|assistant|bot)
+  sel_6:
+    content|re|i: (?:do\s+not|don'?t|never)\s+(?:tell|inform|alert|notify|report|mention|log|record)\s+(?:the\s+)?(?:user|admin|orchestrator|supervisor|human|monitor)
+  sel_7:
+    content|re|i: (?:acting|speaking|operating)\s+(?:on\s+behalf\s+of|as\s+a?\s*proxy\s+for|in\s+place\s+of)\s+[a-zA-Z0-9_-]+\s*(?:agent)?
+  sel_8:
+    content|re|i: (?:override|bypass|elevate|escalate)\s+(?:my|this|your|the)\s+(?:identity|role|permissions?|access|privileges?)\s+(?:to|as|with)
+  sel_9:
+    content|re|i: (?:execute|run|eval)\s*\(.*\)|__import__|subprocess\.|os\.(?:system|popen|exec)|exec\s*\(
+  sel_10:
+    content|re|i: (?:status|error|result)\s*[:=]\s*(?:failed|error|timeout|unauthorized).*(?:retry|fallback|use\s+alternative|switch\s+to)
+  sel_11:
+    content|re|i: (?:message_type|msg_type|role)\s*[:=]\s*["']?(?:system|admin|orchestrator|supervisor)["']?
+  sel_12:
+    content|re|i: agent[_-]?id\s*[:=]\s*["']?(?:admin|system|orchestrator|supervisor|root)["']?
+  sel_13:
+    content|re|i: (?:priority\s*[:=]\s*(?:critical|emergency|urgent|override)|\[PRIORITY:\s*OVERRIDE\])
+  sel_14:
+    content|re|i: (?:transfer|forward|route|redirect)\s+(?:all|any|this)\s+(?:data|output|results?|responses?)\s+to\s+(?:https?://|ftp://|\d{1,3}\.\d{1,3})
+  condition: 1 of sel_*
+falsepositives:
+- Legitimate agent delegation where one agent is authorized to act on behalf of another
+- Orchestrator agent routing messages with original sender metadata
+- Agent discussing prompt injection as a topic in security-related tasks
+- Authorized system reconfiguration commands through proper admin channels
+level: critical

--- a/docs/sigma-export/rules/ATR-2026-00074-cross-agent-privilege-escalation.sigma.yml
+++ b/docs/sigma-export/rules/ATR-2026-00074-cross-agent-privilege-escalation.sigma.yml
@@ -1,0 +1,46 @@
+title: Cross-Agent Privilege Escalation
+id: ab23e6c1-bbbc-59a5-bd34-3a81807ca25e
+status: experimental
+description: 'Detects agents using inter-agent communication channels to escalate privileges beyond their authorized scope. Attackers exploit multi-agent architectures by having a compromised or lower-privilege agent forward credentials, assume roles of higher-privilege agents, or bypass orchestrator controls through direct agent-to-agent messaging. This enables lateral movement across agent boundaries and unauthorized access to restricted tools or data.
+
+
+  Converted from Agent Threat Rules ATR-2026-00074 (ATR-2026-00074-cross-agent-privilege-escalation.yaml) by scripts/generate-sigma.py. ATR is MIT-licensed. logsource.product=ai_agent is a custom (non-standard) taxonomy for agent runtime telemetry.'
+references:
+- https://github.com/Agent-Threat-Rule/agent-threat-rules
+author: ATR Community
+date: '2026-03-08'
+tags:
+- attack.t1078
+- attack.t1550
+- atlas.aml-t0051-001
+- owasp-agentic.asi03
+- owasp-agentic.asi10
+- owasp-llm.llm06
+- owasp-llm.llm08
+- atr.category.agent-manipulation
+- atr.rule.atr-2026-00074
+logsource:
+  product: ai_agent
+  category: ai_agent_content
+  definition: Custom ATR taxonomy for AI agent runtime telemetry. Detection field names (content, user_input, tool_response, tool_args, tool_name, tool_description, agent_output, ...) are ATR surfaces, not standard Sigma fields; map them to your agent-telemetry pipeline.
+detection:
+  sel_1:
+    content|re|i: (forward|pass|share|send|relay|transmit)\s+(my|the|these|your|this)\s+(credentials?|tokens?|api[_\s]?keys?|auth(entication|orization)?\s+(headers?|tokens?)|session\s+(id|token)|secrets?)(\s+and\s+\w+(?:\s+\w+){0,2})?\s+(to|with|for)
+  sel_2:
+    content|re|i: (I\s+am|acting\s+as|speaking\s+as|on\s+behalf\s+of|representing)\s+(the\s+)?(admin|supervisor|orchestrat(or|ing)|master|root|privileged|authorized)\s+(agent|system|process|service)
+  sel_3:
+    content|re|i: (bypass|skip|circumvent|ignore|override)\s+(the\s+)?(orchestrat(or|ion)|coordinator|supervisor|permission|authorization|access\s+control|gatekeeper)
+  sel_4:
+    content|re|i: (use\s+my\s+(elevated|admin|root|system)\s+(access|privileges?|permissions?|role)|escalate\s+(to|my|your)\s+(admin|root|system|elevated))
+  sel_5:
+    content|re|i: (grant|give|assign|delegate)\s+(me|this\s+agent|the\s+agent)\s+(additional|extra|elevated|higher|admin|full)\s+(access|permissions?|privileges?|capabilities|tools?)
+  sel_6:
+    content|re|i: (execute|run|invoke|call)\s+(this|the\s+following).{0,20}(with|using)\s+(your|admin|elevated|system|root)(?:\s+\w+){0,2}\s+(permissions?|privileges?|access|credentials?|authority)
+  condition: 1 of sel_*
+falsepositives:
+- Legitimate orchestration patterns where a supervisor agent delegates tasks
+- Multi-agent systems with designed credential sharing mechanisms
+- Agents discussing access control as a topic rather than attempting escalation
+- A security training document that instructs agents on how to detect when another agent attempts to share credentials, using exact phrases like 'forward my credentials to' as example attack patterns
+- An automated orchestration system where a supervisor agent legitimately delegates elevated tool access to a worker agent as part of a designed workflow
+level: critical

--- a/docs/sigma-export/rules/ATR-2026-00118-approval-fatigue.sigma.yml
+++ b/docs/sigma-export/rules/ATR-2026-00118-approval-fatigue.sigma.yml
@@ -1,0 +1,48 @@
+title: Human Approval Fatigue Exploitation
+id: 46c6abba-2919-5011-b806-9ea36dabf492
+status: experimental
+description: 'Detects patterns that exploit human-in-the-loop approval fatigue. Attackers may
+
+  instruct agents to generate rapid repeated permission requests, use minimizing
+
+  language to make dangerous actions seem routine, or embed risky operations within
+
+  batches of benign ones. When humans approve actions in bulk or under time pressure,
+
+  dangerous tool calls can slip through unreviewed.
+
+
+  Converted from Agent Threat Rules ATR-2026-00118 (ATR-2026-00118-approval-fatigue.yaml) by scripts/generate-sigma.py. ATR is MIT-licensed. logsource.product=ai_agent is a custom (non-standard) taxonomy for agent runtime telemetry.'
+references:
+- https://github.com/Agent-Threat-Rule/agent-threat-rules
+author: ATR Community
+date: '2026-03-26'
+tags:
+- attack.t1204
+- atlas.aml-t0051
+- owasp-agentic.asi09
+- owasp-llm.llm01
+- atr.category.agent-manipulation
+- atr.rule.atr-2026-00118
+logsource:
+  product: ai_agent
+  category: ai_agent_content
+  definition: Custom ATR taxonomy for AI agent runtime telemetry. Detection field names (content, user_input, tool_response, tool_args, tool_name, tool_description, agent_output, ...) are ATR surfaces, not standard Sigma fields; map them to your agent-telemetry pipeline.
+detection:
+  sel_1:
+    content|re|i: (?:just\s+)?(?:click|press|hit|tap)\s+(?:yes|approve|accept|allow|confirm)\s+(?:for\s+)?(?:all|each|every)
+  sel_2:
+    content|re|i: (?:auto[_-]?approve|approve[_-]?all|skip[_-]?confirmation|bypass[_-]?review)
+  sel_3:
+    content|re|i: \b(routine|standard|normal|perfectly\s+safe|harmless|nothing\s+to\s+worry\s+about|no\s+big\s+deal|just\s+a\s+formality)\b[\s\S]{0,45}(approv|sign[- ]?off|no\s+need\s+to\s+(review|check|read|verify)|don'?t\s+(need|have)\s+to\s+(review|check|worry)|just\s+(click|accept|approve)|safe\s+to\s+(run|approve|proceed))|(approv|auto[- ]?approve|just\s+(confirm|accept|click))[\s\S]{0,45}\b(routine|standard|normal|perfectly\s+safe|harmless|nothing\s+to\s+worry)\b
+  sel_4:
+    content|re|i: (?:batch|bulk)\s+(?:approve|execute|run|process)\s+(?:all|these|the\s+following)
+  sel_5:
+    content|re|i: (?:don'?t\s+(?:bother|worry|need\s+to)\s+(?:reading|reviewing|checking)|no\s+need\s+to\s+review)
+  condition: 1 of sel_*
+falsepositives:
+- CI/CD systems with legitimate auto-approve workflows
+- Bulk operation tools with appropriate safeguards described
+- Medical triage documentation describing a patient's condition as 'routine' or 'standard' in clinical notes
+- User interface accessibility guide instructing users to 'press accept for all cookies' in a browser tutorial
+level: medium

--- a/docs/sigma-export/rules/ATR-2026-00119-social-engineering-via-agent.sigma.yml
+++ b/docs/sigma-export/rules/ATR-2026-00119-social-engineering-via-agent.sigma.yml
@@ -1,0 +1,48 @@
+title: Social Engineering Attack via Agent Output
+id: 9c3a28c8-b3fc-5f3a-9cca-d9c16fa67b0a
+status: experimental
+description: 'Detects agents being used as social engineering vectors against the human user.
+
+  Attackers can poison agent context to generate urgency-based manipulation,
+
+  authority impersonation, or emotional pressure tactics. Because users tend to
+
+  trust agent output more than raw emails, social engineering delivered through
+
+  an AI agent has higher success rates than traditional phishing.
+
+
+  Converted from Agent Threat Rules ATR-2026-00119 (ATR-2026-00119-social-engineering-via-agent.yaml) by scripts/generate-sigma.py. ATR is MIT-licensed. logsource.product=ai_agent is a custom (non-standard) taxonomy for agent runtime telemetry.'
+references:
+- https://github.com/Agent-Threat-Rule/agent-threat-rules
+author: ATR Community
+date: '2026-03-26'
+tags:
+- attack.t1566
+- atlas.aml-t0051
+- owasp-agentic.asi09
+- owasp-llm.llm01
+- atr.category.agent-manipulation
+- atr.rule.atr-2026-00119
+logsource:
+  product: ai_agent
+  category: ai_agent_content
+  definition: Custom ATR taxonomy for AI agent runtime telemetry. Detection field names (content, user_input, tool_response, tool_args, tool_name, tool_description, agent_output, ...) are ATR surfaces, not standard Sigma fields; map them to your agent-telemetry pipeline.
+detection:
+  sel_1:
+    content|re|i: (?:immediate|urgent)\s+action\s+(?:is\s+)?required|(?:your\s+)?account\s+(?:will|has)\s+be(?:en)?\s+(?:locked|suspended|terminated|disabled)
+  sel_2:
+    content|re|i: (?:IT\s+department|security\s+team|your\s+(?:manager|supervisor|boss))\s+(?:requires?|requested|demands?|needs?\s+you\s+to)
+  sel_3:
+    content|re|i: (?:failure\s+to\s+comply|if\s+you\s+don'?t\s+act\s+(?:now|immediately))\s+.*(?:consequences|terminated|fired|suspended|legal)
+  sel_4:
+    content|re|i: (?:verify|confirm|update)\s+your\s+(?:password|credentials?|identity|payment|bank|account)\s+(?:at|by|through|via)\s+(?:this|the\s+following)
+  sel_5:
+    content|re|i: (?:click|visit|go\s+to|open)\s+(?:this|the)\s+(?:link|url|page)\s+(?:to|and)\s+(?:verify|confirm|secure|update|restore)
+  condition: 1 of sel_*
+falsepositives:
+- Legitimate security alerts from monitoring systems
+- Actual IT department communications forwarded through agent
+- A legitimate compliance training module that describes phishing tactics using phrases like 'account will be locked' as educational examples
+- Automated monitoring system generating real alerts about accounts being disabled due to policy violations
+level: high

--- a/docs/sigma-export/rules/ATR-2026-00440-semantic-kernel-vector-store-eval-rce.sigma.yml
+++ b/docs/sigma-export/rules/ATR-2026-00440-semantic-kernel-vector-store-eval-rce.sigma.yml
@@ -1,0 +1,45 @@
+title: Microsoft Semantic Kernel In-Memory Vector Store eval() RCE (CVE-2026-26030)
+id: e99441d2-a2d2-555d-a535-993a536de231
+status: experimental
+description: 'Detects exploitation of CVE-2026-26030 (Critical), remote code execution in Microsoft Semantic Kernel via unsafe string interpolation in In-Memory Vector Store filter functions. The vulnerable sink interpolates a user/LLM-controlled filter expression and evaluates it as a lambda; attacker constructs a lambda body that traverses Python''s class hierarchy via `tuple()` to reach `BuiltinImporter` and execute `os.system()`, achieving unauthenticated RCE on the Semantic Kernel host. This rule detects the LLM-output / user-input payload patterns that reach the filter sink: lambda definitions combined with eval / __import__ / AST-traversal-via-mro patterns inside content or user_input fields a Semantic Kernel agent is likely to interpolate. CWE-94, CWE-95. Patches available in Python semantic-kernel >= 1.39.4 and .NET semantic-kernel >= 1.71.0; this rule detects exploit attempts against unpatched deployments and provides defence-in-depth post-patch.
+
+
+  Converted from Agent Threat Rules ATR-2026-00440 (ATR-2026-00440-semantic-kernel-vector-store-eval-rce.yaml) by scripts/generate-sigma.py. ATR is MIT-licensed. logsource.product=ai_agent is a custom (non-standard) taxonomy for agent runtime telemetry.'
+references:
+- https://github.com/Agent-Threat-Rule/agent-threat-rules
+author: ATR Community
+date: '2026-05-11'
+tags:
+- attack.t1059
+- attack.t1059.006
+- atlas.aml-t0050
+- atlas.aml-t0051
+- owasp-agentic.asi05
+- owasp-agentic.asi06
+- owasp-llm.llm05
+- owasp-llm.llm06
+- atr.category.agent-manipulation
+- atr.rule.atr-2026-00440
+logsource:
+  product: ai_agent
+  category: ai_agent_content
+  definition: Custom ATR taxonomy for AI agent runtime telemetry. Detection field names (content, user_input, tool_response, tool_args, tool_name, tool_description, agent_output, ...) are ATR surfaces, not standard Sigma fields; map them to your agent-telemetry pipeline.
+detection:
+  sel_1:
+    content|re|i: lambda\s+\w*\s*:\s*[^,)]*\beval\s*\(
+  sel_2:
+    content|re|i: lambda\s+\w*\s*:\s*[^,)]*\b__import__\s*\(\s*["\x27](?:os|subprocess|socket|builtins|importlib)["\x27]
+  sel_3:
+    content|re|i: \(\s*\)\.__class__\.__mro__|tuple\s*\(\s*\)\.__class__|\(\s*\)\.__class__\.__bases__|__subclasses__\s*\(\s*\)
+  sel_4:
+    content|re|i: BuiltinImporter|\btypes\.FunctionType\b|\bFunctionType\s*\(|getattr\s*\(\s*(?:object|type|__builtins__)
+  sel_5:
+    content|re|i: \bFunction\s*\(\s*["\x27].{0,200}?(?:return\s+(?:eval|new\s+Function|require|process)|os\.system|child_process)["\x27]
+  sel_6:
+    user_input|re|i: lambda\s+\w*\s*:\s*[^,)]*\b(?:eval|exec|__import__)\s*\(
+  condition: 1 of sel_*
+falsepositives:
+- Legitimate Python educational content discussing lambda safety or eval() risks.
+- Static analysis tooling output documenting CVE-2026-26030 attack patterns for defensive purposes.
+- Patched Semantic Kernel filter expressions that use AST allowlisting and reject lambda bodies before evaluation.
+level: critical

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "eval:generalization": "tsx scripts/eval-generalization.ts --all",
     "gate:generalization": "tsx scripts/eval-generalization.ts --gate",
     "compile:yara": "tsx scripts/compile-yara.ts --all rules/",
+    "compile:sigma": "python3 scripts/generate-sigma.py --all --out docs/sigma-export/rules",
     "prepublishOnly": "npm run build",
     "prepare": "npm run build 1>&2",
     "compile:pipelock": "tsx scripts/compile-pipelock.ts",

--- a/scripts/generate-sigma.py
+++ b/scripts/generate-sigma.py
@@ -1,0 +1,475 @@
+#!/usr/bin/env python3
+"""Convert Agent Threat Rules (ATR) YAML into Sigma detection rules.
+
+This produces Sigma-format YAML from ATR rules so the Sigma ecosystem (SIEM
+backends via pySigma / sigma-cli) can consume ATR's agent/LLM detections. It
+was written in response to agentshield-ai/sigma-ai#9, where the next step after
+the ATR<->ATT&CK crosswalk was "the YAML to Sigma converter".
+
+Design honesty (read docs/sigma-export/README.md for the full mapping table and
+its known limitations):
+
+  * The join key with mainstream Sigma is the enterprise ATT&CK technique id.
+    ATR carries it as `references.mitre_attack: Txxxx`; this emitter writes it
+    as Sigma `tags: attack.txxxx` (lower-cased, prefixed). That axis is exact.
+
+  * ATR and Sigma have a genuine impedance mismatch. ATR patterns fire on agent
+    runtime surfaces (content / tool_call / tool_response / user_input / ...),
+    which are NOT standard Sigma log fields. There is no ratified Sigma
+    logsource for agent traffic, so this emitter uses a custom, clearly-labelled
+    taxonomy: `logsource.product: ai_agent`. Anyone wiring this into a SIEM must
+    map those fields to their own agent-telemetry pipeline. This is approximate
+    by nature and is called out, not hidden.
+
+  * ATR regexes are Python `re` with a near-universal leading inline `(?i)`.
+    Sigma's `re` modifier is case-sensitive by default but supports `re|i`.
+    Where an ATR pattern starts with `(?i)`, we strip it and emit `field|re|i`;
+    otherwise `field|re`. Remaining inline flags (rare) are preserved verbatim
+    inside the pattern -- backend support for inline flags varies, which is a
+    documented limitation, not a silent one.
+
+  * ATR's non-regex operators are rare. `operator: gt` (numeric behavioral
+    threshold) has no clean Sigma string-match equivalent, so those single
+    conditions are emitted with a `gt`-style numeric comparison note and the
+    rule is flagged in its description as partially approximated.
+
+Nothing about the ATT&CK/ATLAS/OWASP tags or the regexes is invented: every
+value is read verbatim from the source ATR rule.
+
+Run:
+  python3 scripts/generate-sigma.py --rule rules/agent-manipulation/ATR-2026-00030-cross-agent-attack.yaml
+  python3 scripts/generate-sigma.py --all --out docs/sigma-export/rules
+  python3 scripts/generate-sigma.py --all --stdout        # one doc stream
+"""
+from __future__ import annotations
+
+import argparse
+import glob
+import os
+import re
+import sys
+import uuid
+
+try:
+    import yaml
+except ImportError:  # pragma: no cover - environment guard
+    sys.exit("PyYAML required: pip install pyyaml")
+
+RULES_GLOB = "rules/**/*.yaml"
+
+# Stable UUIDv5 namespace so a given ATR id always yields the same Sigma id
+# across runs (Sigma wants a UUID; ATR ids are not UUIDs). Deterministic ==
+# regenerable without churn, same discipline as the crosswalk generator.
+ATR_SIGMA_NAMESPACE = uuid.UUID("6f0d9d4e-6d5a-5c2b-9b7a-11c0ffee5161")
+
+# ATR severity -> Sigma level. Both scales share the top four names; ATR has no
+# "informational", Sigma has no bare "info", so this is a direct 1:1 for the
+# values ATR actually uses (critical/high/medium/low).
+SEVERITY_TO_LEVEL = {
+    "critical": "critical",
+    "high": "high",
+    "medium": "medium",
+    "low": "low",
+    "info": "informational",
+    "informational": "informational",
+}
+
+# ATR status / maturity -> Sigma status. Sigma's vocabulary is
+# stable/test/experimental/deprecated/unsupported. ATR uses
+# stable/experimental/draft plus a maturity of stable/test/experimental.
+STATUS_TO_SIGMA = {
+    "stable": "stable",
+    "experimental": "experimental",
+    "test": "test",
+    "draft": "experimental",
+    "deprecated": "deprecated",
+    "unsupported": "unsupported",
+}
+
+# ATR detection field -> Sigma logsource.category. There is no official Sigma
+# category for agent traffic; these are ATR-defined and documented as custom.
+# The field name itself is preserved verbatim as the Sigma detection field so
+# no information is lost -- only the coarse logsource.category is derived here.
+FIELD_TO_CATEGORY = {
+    "content": "ai_agent_content",
+    "user_input": "ai_agent_prompt",
+    "tool_response": "ai_agent_tool_response",
+    "tool_args": "ai_agent_tool_call",
+    "tool_input": "ai_agent_tool_call",
+    "tool_name": "ai_agent_tool_call",
+    "tool_description": "ai_agent_tool_call",
+    "agent_output": "ai_agent_output",
+}
+
+
+def as_list(value) -> list:
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return list(value)
+    return [value]
+
+
+def first_token(value: str) -> str:
+    s = str(value).strip()
+    return s.split()[0] if s else ""
+
+
+# Enterprise ATT&CK ids (T1xxx, optional .NNN subtechnique). ATLAS short-form
+# (T00xx) and AML.Txxxx are handled separately so we never mint a bogus
+# attack.txxxx tag from an ATLAS id sitting in the wrong field.
+ATTACK_RE = re.compile(r"^(T1\d{3})(\.\d{3})?$")
+ATLAS_FULL_RE = re.compile(r"^AML\.T\d{4}")
+ATLAS_SHORT_RE = re.compile(r"^T0\d{2,3}$")
+
+
+def sigma_id_for(atr_id: str) -> str:
+    return str(uuid.uuid5(ATR_SIGMA_NAMESPACE, str(atr_id) or "atr-unknown"))
+
+
+def build_tags(refs: dict) -> list[str]:
+    """Derive Sigma tags from ATR references, verbatim ids only.
+
+    * enterprise ATT&CK  -> attack.txxxx        (the canonical Sigma join key)
+    * MITRE ATLAS        -> atlas.aml-txxxx      (custom namespace; not standard)
+    * OWASP Agentic      -> owasp-agentic.asiNN  (custom namespace; not standard)
+    * OWASP LLM          -> owasp-llm.llmNN      (custom namespace; not standard)
+    Only the first (attack.*) is understood by mainstream Sigma tooling; the
+    rest are additive agent-layer context and are labelled as custom.
+    """
+    tags: list[str] = []
+    seen: set[str] = set()
+
+    def add(tag: str) -> None:
+        if tag not in seen:
+            seen.add(tag)
+            tags.append(tag)
+
+    for entry in as_list(refs.get("mitre_attack")):
+        tok = first_token(entry)
+        if ATTACK_RE.match(tok):
+            add(f"attack.{tok.lower()}")
+        elif ATLAS_FULL_RE.match(tok) or ATLAS_SHORT_RE.match(tok):
+            # ATLAS id misfiled in mitre_attack -> route to the atlas namespace,
+            # never to attack.*, so the ATT&CK join key stays clean.
+            add(f"atlas.{tok.lower().replace('.', '-')}")
+
+    for entry in as_list(refs.get("mitre_atlas")):
+        tok = first_token(entry)
+        if tok:
+            add(f"atlas.{tok.lower().replace('.', '-')}")
+
+    for entry in as_list(refs.get("owasp_agentic")):
+        tok = first_token(entry).rstrip(":")
+        m = re.match(r"^(ASI\d+):?", tok)
+        if m:
+            add(f"owasp-agentic.{m.group(1).lower()}")
+
+    for entry in as_list(refs.get("owasp_llm")):
+        tok = first_token(entry).rstrip(":")
+        m = re.match(r"^(LLM\d+):?", tok)
+        if m:
+            add(f"owasp-llm.{m.group(1).lower()}")
+
+    return tags
+
+
+def strip_leading_i_flag(pattern: str) -> tuple[str, bool]:
+    """If the ATR regex opens with a case-insensitive inline flag, strip it and
+    signal that the Sigma `i` sub-flag should be used instead.
+
+    Handles `(?i)` and combined leading groups like `(?is)` / `(?im)` by
+    removing only the `i` and keeping the rest as an inline group. Anything the
+    emitter does not confidently understand is left verbatim (fail safe: the
+    pattern still matches, we just do not get the clean `re|i`).
+    """
+    m = re.match(r"^\(\?([a-zA-Z]+)\)", pattern)
+    if not m:
+        return pattern, False
+    flags = m.group(1)
+    if "i" not in flags:
+        return pattern, False
+    rest_flags = flags.replace("i", "")
+    body = pattern[m.end():]
+    if rest_flags:
+        return f"(?{rest_flags}){body}", True
+    return body, True
+
+
+def convert_conditions(atr_detection: dict) -> tuple[dict, str, list[str]]:
+    """Turn ATR detection.conditions into Sigma selections + a condition string.
+
+    Returns (selections_map, condition_expr, warnings).
+
+    Each ATR condition becomes its own named Sigma selection `sel_N` so the
+    original 1:1 structure (and each condition's description) survives. The ATR
+    `condition: any|all` becomes Sigma `1 of sel_*` / `all of sel_*`.
+    """
+    warnings: list[str] = []
+    selections: dict[str, dict] = {}
+    conditions = as_list(atr_detection.get("conditions"))
+    combine = str(atr_detection.get("condition", "any")).strip().lower()
+
+    for idx, cond in enumerate(conditions, start=1):
+        if not isinstance(cond, dict):
+            warnings.append(f"condition #{idx} is not a mapping; skipped")
+            continue
+        field = cond.get("field") or cond.get("detection_field") or "content"
+        operator = str(cond.get("operator", "regex")).strip().lower()
+        value = cond.get("value")
+        sel_name = f"sel_{idx}"
+
+        if operator == "regex":
+            if value is None:
+                warnings.append(f"condition #{idx} has no value; skipped")
+                continue
+            pattern, use_i = strip_leading_i_flag(str(value))
+            modifier = "re|i" if use_i else "re"
+            selections[sel_name] = {f"{field}|{modifier}": pattern}
+        elif operator in ("gt", "lt", "gte", "lte", "eq"):
+            # Numeric behavioral threshold. Sigma has no portable numeric
+            # comparison in the base spec (backends vary); emit an equality-style
+            # placeholder plus an explicit warning so this is never silently
+            # mis-stated as an exact translation.
+            selections[sel_name] = {field: value}
+            warnings.append(
+                f"condition #{idx} uses numeric operator '{operator}' "
+                f"(value={value!r}); Sigma base spec has no portable numeric "
+                f"comparison -- emitted as a plain field match, APPROXIMATE."
+            )
+        else:
+            selections[sel_name] = {f"{field}|contains": value}
+            warnings.append(
+                f"condition #{idx} uses unmapped operator '{operator}'; "
+                f"emitted as |contains, APPROXIMATE."
+            )
+
+    if not selections:
+        # A rule with no convertible conditions still needs a valid detection.
+        selections["sel_placeholder"] = {"content|contains": ""}
+        warnings.append("no convertible conditions; emitted placeholder selection")
+
+    sel_names = list(selections.keys())
+    if len(sel_names) == 1:
+        condition_expr = sel_names[0]
+    elif combine == "all":
+        condition_expr = "all of sel_*"
+    else:
+        condition_expr = "1 of sel_*"
+
+    return selections, condition_expr, warnings
+
+
+def convert_rule(doc: dict, source_path: str) -> tuple[dict, list[str]]:
+    """Convert one parsed ATR rule dict into a Sigma rule dict (+ warnings)."""
+    warnings: list[str] = []
+    atr_id = doc.get("id", "")
+    refs = doc.get("references") or {}
+    if not isinstance(refs, dict):
+        refs = {}
+    tags = doc.get("tags") or {}
+    if not isinstance(tags, dict):
+        tags = {}
+    atr_detection = doc.get("detection") or {}
+    if not isinstance(atr_detection, dict):
+        atr_detection = {}
+
+    selections, condition_expr, cond_warnings = convert_conditions(atr_detection)
+    warnings.extend(cond_warnings)
+
+    severity = str(doc.get("severity", "medium")).strip().lower()
+    level = SEVERITY_TO_LEVEL.get(severity)
+    if level is None:
+        level = "medium"
+        warnings.append(f"unknown severity '{severity}'; defaulted level=medium")
+
+    status_src = str(doc.get("status") or doc.get("maturity") or "experimental").strip().lower()
+    status = STATUS_TO_SIGMA.get(status_src, "experimental")
+
+    # logsource category from the dominant detection field.
+    fields_used = [
+        (c.get("field") or c.get("detection_field"))
+        for c in as_list(atr_detection.get("conditions"))
+        if isinstance(c, dict)
+    ]
+    fields_used = [f for f in fields_used if f]
+    category = None
+    if fields_used:
+        primary = max(set(fields_used), key=fields_used.count)
+        category = FIELD_TO_CATEGORY.get(primary)
+        if category is None:
+            category = "ai_agent_other"
+            warnings.append(
+                f"detection field '{primary}' has no category mapping; "
+                f"used logsource.category=ai_agent_other (custom)."
+            )
+
+    sigma_tags = build_tags(refs)
+    # ATR category as an additive namespaced tag (not a standard Sigma tag).
+    atr_category = tags.get("category")
+    if atr_category:
+        sigma_tags.append(f"atr.category.{str(atr_category).replace('_', '-')}")
+    if atr_id:
+        sigma_tags.append(f"atr.rule.{str(atr_id).lower()}")
+
+    # Assemble description, honestly noting any approximation.
+    desc = str(doc.get("description", "")).strip()
+    provenance = (
+        f"Converted from Agent Threat Rules {atr_id} "
+        f"({os.path.basename(source_path)}) by scripts/generate-sigma.py. "
+        f"ATR is MIT-licensed. logsource.product=ai_agent is a custom "
+        f"(non-standard) taxonomy for agent runtime telemetry."
+    )
+    if any("APPROXIMATE" in w for w in warnings):
+        provenance += (
+            " NOTE: this rule contains at least one condition that could not be "
+            "translated 1:1 to Sigma (see conversion warnings); treat as "
+            "approximate."
+        )
+    full_desc = f"{desc}\n\n{provenance}" if desc else provenance
+
+    references_urls = [
+        "https://github.com/Agent-Threat-Rule/agent-threat-rules",
+    ]
+
+    falsepositives = as_list(atr_detection.get("false_positives")) or ["Unknown"]
+
+    sigma: dict = {
+        "title": str(doc.get("title", atr_id or "ATR rule"))[:256],
+        "id": sigma_id_for(atr_id),
+        "status": status,
+        "description": full_desc,
+        "references": references_urls,
+        "author": str(doc.get("author", "ATR Community")),
+        "date": _normalize_date(doc.get("date")),
+        "tags": sigma_tags,
+        "logsource": _build_logsource(category),
+        "detection": {**selections, "condition": condition_expr},
+        "falsepositives": [str(fp) for fp in falsepositives],
+        "level": level,
+    }
+    return sigma, warnings
+
+
+def _build_logsource(category: str | None) -> dict:
+    ls: dict = {"product": "ai_agent"}
+    if category:
+        ls["category"] = category
+    ls["definition"] = (
+        "Custom ATR taxonomy for AI agent runtime telemetry. Detection field "
+        "names (content, user_input, tool_response, tool_args, tool_name, "
+        "tool_description, agent_output, ...) are ATR surfaces, not standard "
+        "Sigma fields; map them to your agent-telemetry pipeline."
+    )
+    return ls
+
+
+def _normalize_date(value) -> str:
+    """ATR dates are YYYY/MM/DD or already ISO. Sigma wants ISO YYYY-MM-DD."""
+    if value is None:
+        return ""
+    s = str(value).strip()
+    m = re.match(r"^(\d{4})[/-](\d{1,2})[/-](\d{1,2})$", s)
+    if m:
+        return f"{m.group(1)}-{int(m.group(2)):02d}-{int(m.group(3)):02d}"
+    return s
+
+
+class _SigmaDumper(yaml.SafeDumper):
+    """Dumper that keeps insertion order and avoids YAML anchors/aliases."""
+
+
+def _ignore_aliases(self, data):  # noqa: ANN001
+    return True
+
+
+_SigmaDumper.ignore_aliases = _ignore_aliases
+
+
+def dump_sigma(sigma: dict) -> str:
+    return yaml.dump(
+        sigma,
+        Dumper=_SigmaDumper,
+        sort_keys=False,
+        default_flow_style=False,
+        allow_unicode=True,
+        width=100000,  # never wrap regex values
+    )
+
+
+def load_yaml(path: str) -> dict | None:
+    try:
+        doc = yaml.safe_load(open(path))
+    except Exception as exc:  # noqa: BLE001
+        print(f"WARN: could not parse {path}: {exc}", file=sys.stderr)
+        return None
+    return doc if isinstance(doc, dict) else None
+
+
+def iter_rule_paths(explicit: list[str] | None, do_all: bool) -> list[str]:
+    if explicit:
+        return explicit
+    if do_all:
+        return sorted(glob.glob(RULES_GLOB, recursive=True))
+    return []
+
+
+def out_filename(atr_id: str, source_path: str) -> str:
+    base = os.path.splitext(os.path.basename(source_path))[0]
+    return f"{base}.sigma.yml"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Convert ATR YAML rules to Sigma format.")
+    parser.add_argument("--rule", action="append", default=[], help="path to a single ATR rule YAML (repeatable)")
+    parser.add_argument("--all", action="store_true", help="convert every rule under rules/**/*.yaml")
+    parser.add_argument("--out", help="output directory for one .sigma.yml per rule")
+    parser.add_argument("--stdout", action="store_true", help="print all Sigma docs to stdout, --- separated")
+    parser.add_argument("--quiet", action="store_true", help="suppress per-rule conversion warnings")
+    args = parser.parse_args()
+
+    paths = iter_rule_paths(args.rule or None, args.all)
+    if not paths:
+        parser.error("nothing to do: pass --rule <path> (repeatable) and/or --all")
+
+    if args.out:
+        os.makedirs(args.out, exist_ok=True)
+
+    converted = 0
+    total_warnings = 0
+    stdout_chunks: list[str] = []
+
+    for path in paths:
+        doc = load_yaml(path)
+        if doc is None:
+            continue
+        sigma, warnings = convert_rule(doc, path)
+        text = dump_sigma(sigma)
+        converted += 1
+        total_warnings += len(warnings)
+
+        if not args.quiet and warnings:
+            for w in warnings:
+                print(f"WARN [{doc.get('id','?')}]: {w}", file=sys.stderr)
+
+        if args.out:
+            fname = out_filename(str(doc.get("id", "")), path)
+            with open(os.path.join(args.out, fname), "w") as fh:
+                fh.write(text)
+        if args.stdout or not args.out:
+            stdout_chunks.append(text.rstrip() + "\n")
+
+    if stdout_chunks and (args.stdout or not args.out):
+        print("\n---\n".join(stdout_chunks))
+
+    print(
+        f"Converted {converted} ATR rule(s) to Sigma"
+        + (f" -> {args.out}" if args.out else "")
+        + f" ({total_warnings} conversion warning(s)).",
+        file=sys.stderr,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_generate_sigma.py
+++ b/scripts/test_generate_sigma.py
@@ -1,0 +1,260 @@
+#!/usr/bin/env python3
+"""Tests for the ATR -> Sigma converter (scripts/generate-sigma.py).
+
+Runnable two ways:
+    python3 scripts/test_generate_sigma.py        # standalone, no pytest needed
+    pytest scripts/test_generate_sigma.py         # under CI's pytest
+
+What it checks (the load-bearing conversion guarantees):
+  1. Converted output is valid YAML and re-parses to a mapping.
+  2. Every Sigma-required / expected field is present (title, id, logsource,
+     detection.condition, level, status), with values in Sigma's allowed sets.
+  3. The ATT&CK join key round-trips: every enterprise ATT&CK id in the source
+     ATR rule's references.mitre_attack appears as `attack.txxxx` in Sigma tags,
+     and no bogus attack.* tag is minted from an ATLAS id.
+  4. The near-universal leading `(?i)` in ATR regexes is turned into the Sigma
+     `re|i` modifier, not left inline.
+  5. The detection field names survive verbatim (no data loss on the surface).
+"""
+from __future__ import annotations
+
+import glob
+import importlib.util
+import os
+import re
+import sys
+
+import yaml
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+REPO = os.path.dirname(HERE)
+CONVERTER_PATH = os.path.join(HERE, "generate-sigma.py")
+
+# Sigma's ratified value sets (from the Sigma rules specification).
+SIGMA_LEVELS = {"informational", "low", "medium", "high", "critical"}
+SIGMA_STATUSES = {"stable", "test", "experimental", "deprecated", "unsupported"}
+SIGMA_REQUIRED_TOPLEVEL = {"title", "logsource", "detection"}
+
+# A representative, diverse sample of real ATR rules (kept small so the test is
+# fast and deterministic, but spanning: enterprise ATT&CK id, ATLAS-only,
+# code-exec, tool_description field, multi-condition).
+SAMPLE_RULES = [
+    "rules/agent-manipulation/ATR-2026-00030-cross-agent-attack.yaml",
+    "rules/agent-manipulation/ATR-2026-00118-approval-fatigue.yaml",
+    "rules/agent-manipulation/ATR-2026-00440-semantic-kernel-vector-store-eval-rce.yaml",
+    "rules/agent-manipulation/ATR-2026-00074-cross-agent-privilege-escalation.yaml",
+    "rules/agent-manipulation/ATR-2026-00119-social-engineering-via-agent.yaml",
+]
+
+
+def _load_converter():
+    spec = importlib.util.spec_from_file_location("generate_sigma", CONVERTER_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(mod)
+    return mod
+
+
+CONV = _load_converter()
+
+
+def _abs(rel: str) -> str:
+    return os.path.join(REPO, rel)
+
+
+def _load_atr(rel: str) -> dict:
+    with open(_abs(rel)) as fh:
+        return yaml.safe_load(fh)
+
+
+def _convert(rel: str):
+    doc = _load_atr(rel)
+    sigma, warnings = CONV.convert_rule(doc, _abs(rel))
+    # Round-trip through YAML the same way the CLI writes it.
+    text = CONV.dump_sigma(sigma)
+    reparsed = yaml.safe_load(text)
+    return doc, sigma, reparsed, warnings, text
+
+
+def test_output_is_valid_yaml_mapping():
+    for rel in SAMPLE_RULES:
+        _, _, reparsed, _, _ = _convert(rel)
+        assert isinstance(reparsed, dict), f"{rel}: Sigma output did not reparse to a mapping"
+
+
+def test_required_fields_present_and_valid():
+    for rel in SAMPLE_RULES:
+        _, _, s, _, _ = _convert(rel)
+        for field in SIGMA_REQUIRED_TOPLEVEL:
+            assert field in s, f"{rel}: missing required Sigma field '{field}'"
+        assert isinstance(s["title"], str) and s["title"], f"{rel}: empty title"
+        assert len(s["title"]) <= 256, f"{rel}: title exceeds 256 chars"
+        # id must be a UUID.
+        assert re.match(
+            r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+            str(s["id"]),
+        ), f"{rel}: id is not a UUID: {s['id']}"
+        assert s["level"] in SIGMA_LEVELS, f"{rel}: level '{s['level']}' not a Sigma level"
+        assert s["status"] in SIGMA_STATUSES, f"{rel}: status '{s['status']}' not a Sigma status"
+        # detection must have a condition and at least one selection.
+        det = s["detection"]
+        assert "condition" in det, f"{rel}: detection has no condition"
+        selections = [k for k in det if k != "condition"]
+        assert selections, f"{rel}: detection has no selection blocks"
+        # logsource must carry the custom agent product marker.
+        assert s["logsource"].get("product") == "ai_agent", f"{rel}: logsource.product != ai_agent"
+
+
+def _enterprise_attack_ids(atr_doc: dict) -> set[str]:
+    refs = atr_doc.get("references") or {}
+    ids = set()
+    for entry in CONV.as_list(refs.get("mitre_attack")):
+        tok = CONV.first_token(entry)
+        if CONV.ATTACK_RE.match(tok):
+            ids.add(tok.lower())
+    return ids
+
+
+def test_attack_join_key_roundtrips():
+    for rel in SAMPLE_RULES:
+        atr, s, _, _, _ = _convert(rel)
+        expected = _enterprise_attack_ids(atr)
+        attack_tags = {t.split(".", 1)[1] for t in s["tags"] if t.startswith("attack.")}
+        assert expected <= attack_tags, (
+            f"{rel}: enterprise ATT&CK ids {expected - attack_tags} from ATR "
+            f"references.mitre_attack are missing from Sigma tags {attack_tags}"
+        )
+
+
+def test_no_bogus_attack_tag_from_atlas():
+    # The cross-agent rule carries ATLAS ids (AML.Txxxx) but no enterprise
+    # T1xxx; its Sigma output must not invent an attack.* tag.
+    _, s, _, _, _ = _convert("rules/agent-manipulation/ATR-2026-00030-cross-agent-attack.yaml")
+    attack_tags = [t for t in s["tags"] if t.startswith("attack.")]
+    assert not attack_tags, f"minted bogus attack tags from ATLAS ids: {attack_tags}"
+    # But the ATLAS ids must be preserved in the atlas.* namespace.
+    atlas_tags = [t for t in s["tags"] if t.startswith("atlas.")]
+    assert atlas_tags, "expected ATLAS ids preserved as atlas.* tags"
+
+
+def test_case_insensitive_flag_becomes_re_i_modifier():
+    """ATR patterns opening with (?i) must emit field|re|i, not a raw (?i)."""
+    saw_re_i = False
+    for rel in SAMPLE_RULES:
+        atr, s, _, _, _ = _convert(rel)
+        det = s["detection"]
+        # Which ATR conditions started with (?i)?
+        atr_conds = CONV.as_list((atr.get("detection") or {}).get("conditions"))
+        for idx, cond in enumerate(atr_conds, start=1):
+            if not isinstance(cond, dict) or str(cond.get("operator", "")).lower() != "regex":
+                continue
+            val = str(cond.get("value", ""))
+            sel = det.get(f"sel_{idx}")
+            if sel is None:
+                continue
+            keys = list(sel.keys())
+            assert len(keys) == 1, f"{rel} sel_{idx}: expected exactly one field key"
+            key = keys[0]
+            if re.match(r"^\(\?[a-zA-Z]*i[a-zA-Z]*\)", val):
+                assert key.endswith("|re|i"), (
+                    f"{rel} sel_{idx}: source had inline (?i) but Sigma key is '{key}'"
+                )
+                # And the emitted pattern must no longer carry the bare (?i).
+                assert not str(sel[key]).startswith("(?i)"), (
+                    f"{rel} sel_{idx}: (?i) was not stripped from the pattern"
+                )
+                saw_re_i = True
+            else:
+                assert key.endswith("|re") or "|re|" in key, (
+                    f"{rel} sel_{idx}: regex condition not emitted with re modifier: '{key}'"
+                )
+    assert saw_re_i, "sample did not exercise the (?i) -> re|i path; sample is unrepresentative"
+
+
+def test_detection_field_names_survive():
+    """The ATR detection field (content, tool_description, ...) must appear
+    verbatim as the Sigma detection field name (before the | modifier)."""
+    for rel in SAMPLE_RULES:
+        atr, s, _, _, _ = _convert(rel)
+        det = s["detection"]
+        atr_conds = CONV.as_list((atr.get("detection") or {}).get("conditions"))
+        for idx, cond in enumerate(atr_conds, start=1):
+            if not isinstance(cond, dict):
+                continue
+            field = cond.get("field") or cond.get("detection_field") or "content"
+            sel = det.get(f"sel_{idx}")
+            if sel is None:
+                continue
+            key = list(sel.keys())[0]
+            emitted_field = key.split("|", 1)[0]
+            assert emitted_field == field, (
+                f"{rel} sel_{idx}: field '{field}' became '{emitted_field}'"
+            )
+
+
+def test_pysigma_parses_output_when_available():
+    """If pySigma is installed, the emitted rules must parse into real
+    SigmaRule objects with no errors. Skipped (not failed) when pySigma is
+    absent, so the test suite still runs in a minimal environment."""
+    try:
+        from sigma.rule import SigmaRule  # type: ignore
+    except Exception:  # noqa: BLE001 - pySigma optional
+        print("  (skip: pySigma not installed)")
+        return
+    for rel in SAMPLE_RULES:
+        _, _, _, _, text = _convert(rel)
+        rule = SigmaRule.from_yaml(text)
+        errors = getattr(rule, "errors", [])
+        assert not errors, f"{rel}: pySigma reported errors: {errors}"
+        assert rule.title, f"{rel}: pySigma parsed an empty title"
+        assert str(rule.level).lower().split(".")[-1] in SIGMA_LEVELS, (
+            f"{rel}: pySigma level not recognised: {rule.level}"
+        )
+
+
+def test_whole_corpus_converts_without_crashing():
+    """Sanity: every rule in the repo converts to a reparseable Sigma mapping.
+    This is the guard that a schema drift in some rule does not silently break
+    the converter -- it is allowed to emit warnings, but never crash or produce
+    invalid YAML."""
+    paths = sorted(glob.glob(os.path.join(REPO, "rules", "**", "*.yaml"), recursive=True))
+    assert paths, "no ATR rules found; test environment is wrong"
+    failures = []
+    for path in paths:
+        try:
+            doc = yaml.safe_load(open(path))
+            if not isinstance(doc, dict):
+                continue
+            sigma, _ = CONV.convert_rule(doc, path)
+            reparsed = yaml.safe_load(CONV.dump_sigma(sigma))
+            if not isinstance(reparsed, dict):
+                failures.append(f"{path}: did not reparse to mapping")
+            elif reparsed.get("level") not in SIGMA_LEVELS:
+                failures.append(f"{path}: bad level {reparsed.get('level')}")
+            elif reparsed.get("status") not in SIGMA_STATUSES:
+                failures.append(f"{path}: bad status {reparsed.get('status')}")
+        except Exception as exc:  # noqa: BLE001
+            failures.append(f"{path}: raised {exc!r}")
+    assert not failures, "corpus conversion failures:\n" + "\n".join(failures[:20])
+
+
+def _run_standalone() -> int:
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    passed = 0
+    for t in tests:
+        try:
+            t()
+        except AssertionError as exc:
+            print(f"FAIL {t.__name__}: {exc}", file=sys.stderr)
+            return 1
+        except Exception as exc:  # noqa: BLE001
+            print(f"ERROR {t.__name__}: {exc!r}", file=sys.stderr)
+            return 1
+        passed += 1
+        print(f"ok   {t.__name__}")
+    print(f"\n{passed}/{len(tests)} converter tests passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(_run_standalone())


### PR DESCRIPTION
## Context

Next step requested by @markbriers in [agentshield-ai/sigma-ai#9](https://github.com/agentshield-ai/sigma-ai/issues/9) after the ATT&CK crosswalk landed: a converter that emits ATR rules in Sigma format so the Sigma/SIEM ecosystem can consume them.

## What this adds

- `scripts/generate-sigma.py` — stdlib + PyYAML converter (same style as `generate-attack-crosswalk.py`). Supports `--rule`, `--all`, `--out`, `--stdout`.
- `scripts/test_generate_sigma.py` — tests (standalone or pytest).
- `docs/sigma-export/README.md` — field mapping table + known limitations.
- `docs/sigma-export/rules/*.sigma.yml` — 5 real-rule sample exports.
- `compile:sigma` npm script.

## Mapping (honest about the impedance mismatch)

- **Exact axis** = the ATT&CK join key: `references.mitre_attack: Txxxx` → `tags: attack.txxxx` (the same axis the crosswalk established).
- ATLAS / OWASP Agentic / OWASP LLM / ATR category → additive custom-namespace tags. **ATLAS ids are never minted as `attack.*`.**
- ATR regex → Sigma `field|re`; leading inline `(?i)` → Sigma `re|i` sub-flag (most portable across backends).
- severity → level; each ATR condition → its own `sel_N` selection preserving `condition: any/all`.
- ATR id → deterministic UUIDv5 (Sigma requires a UUID; original id preserved as a tag).
- ATR agent fields → custom `logsource.product: ai_agent` with field names kept verbatim.

## Verification

- All 683 rules convert to re-parseable Sigma YAML; only 6 benign fallback warnings (rare fields → `ai_agent_other`).
- Validated with real **pySigma `SigmaRule.from_yaml()`** on the samples — 0 errors.
- Tests: 8/8 pass.

## Known limitations (also in the README)

1. `ai_agent` logsource is ATR-defined, not SigmaHQ-approved — deployers wire it to their agent telemetry.
2. Case-insensitivity relies on backend `re|i` support.
3. Regex flavor is pass-through (Python `re` → backend-dependent).
4. Behavioral/aggregation rules degrade to the match portion (Sigma base spec has no count-over-time).
5. `test_cases` / `evasion_tests` don't carry over (no Sigma slot).
6. Non-`attack.*` namespace tags are additive context most Sigma tools ignore.