### PR TITLE
fix(gate): null-safe label in extended-benign FP check

### DIFF
--- a/scripts/check-rules-safety.ts
+++ b/scripts/check-rules-safety.ts
@@ -331,7 +331,7 @@ async function checkExtendedBenignFP(
     return fps;
   }
   for (const s of samples) {
-    const label = `${s.source}:${s.source_id.slice(0, 40)}`;
+    const label = `${s.source ?? "?"}:${(s.source_id ?? "?").slice(0, 40)}`;
     for (const id of matchAllRuleIds(engine, s.text)) {
       if (newRuleIds.has(id)) {
         if (!fps.has(id)) fps.set(id, []);
@@ -391,7 +391,7 @@ async function checkBenignCodeFP(
     return fps;
   }
   for (const s of samples) {
-    const label = `${s.source}:${s.source_id.slice(0, 40)}`;
+    const label = `${s.source ?? "?"}:${(s.source_id ?? "?").slice(0, 40)}`;
     for (const id of matchAllRuleIds(engine, s.text)) {
       if (newRuleIds.has(id)) {
         if (!fps.has(id)) fps.set(id, []);


### PR DESCRIPTION
## Bug

`scripts/check-rules-safety.ts` crashes with `TypeError: Cannot read properties of undefined (reading 'slice')` on **any PR that adds new rules**. In `checkExtendedBenignFP`, an extended-benign corpus entry without a `source_id` reaches:

```ts
const label = `${s.source}:${s.source_id.slice(0, 40)}`;
```

The label is display-only (used when reporting an FP), but the unguarded `.slice` takes down the whole safety gate before any FP check runs.

## Fix

Guard both fields: `${s.source ?? "?"}:${(s.source_id ?? "?").slice(0, 40)}` (two identical call sites). No FP logic changes — every sample is still scanned; only the label is made null-safe.

## Impact

Unblocks every new-rule PR the gate was crashing on (surfaced by #252). `tsc --noEmit` clean.