### PR TITLE
website: adopter wall from ADOPTERS.md single source + full stale-fact refresh

### DIFF
--- a/.github/workflows/verify-adopters.yml
+++ b/.github/workflows/verify-adopters.yml
@@ -1,0 +1,58 @@
+name: Verify Adopters Evidence
+
+# Re-verify every ADOPTERS.md evidence link against GitHub so the website's
+# "evidence re-verified on <date>" stamp stays honest without human effort.
+# shipped must be MERGED, in-review must be OPEN, plain links must resolve.
+# The refreshed data/adopters-verification.json is auto-committed (same bot
+# convention as reconcile-stats); a non-zero drift count fails the run so
+# drift surfaces as a red check instead of rotting silently.
+
+on:
+  schedule:
+    - cron: '0 3 * * 1' # weekly, Monday 03:00 UTC
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - 'ADOPTERS.md'
+      - 'scripts/verify-adopters.mjs'
+
+permissions:
+  contents: write
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Re-verify every evidence link
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: node scripts/verify-adopters.mjs
+
+      - name: Commit refreshed verification data
+        if: github.ref == 'refs/heads/main'
+        run: |
+          if git diff --quiet data/adopters-verification.json; then
+            echo "verification data unchanged — nothing to commit"
+            exit 0
+          fi
+          git config user.name "ATR Stats Bot"
+          git config user.email "bot@agentthreatrule.org"
+          git add data/adopters-verification.json
+          git commit -m "chore(adopters): auto re-verify evidence links"
+          git push origin main
+
+      - name: Fail on drift
+        run: |
+          drift=$(node -e 'process.stdout.write(String(JSON.parse(require("fs").readFileSync("data/adopters-verification.json","utf8")).drift.length))')
+          echo "drift entries: ${drift}"
+          if [ "${drift}" != "0" ]; then
+            echo "ADOPTERS.md declares a status that GitHub no longer supports — fix the entries listed in data/adopters-verification.json drift[]"
+            exit 1
+          fi

--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -89,6 +89,14 @@ Adopters whose adoption is itself a public-good interoperability artefact
 - **Since**: 2026-06-16
 - **Status**: in-review
 
+### FINOS Common Cloud Controls
+- **Org**: FINOS (Fintech Open Source Foundation, a Linux Foundation project)
+- **Type**: reference
+- **Integration**: ATR guideline-mappings merged into the Common Cloud Controls catalogue (CN01/CN02/CN04/CN06) with Gemara MappingReference entries
+- **Evidence**: <https://github.com/finos/common-cloud-controls/pull/986>
+- **Since**: 2026-07-02
+- **Status**: shipped
+
 ---
 
 ## Tier 1 — Production deployments
@@ -192,14 +200,6 @@ Listed when the integration code has been merged or released.
 - **Since**: 2026-06-16
 - **Status**: in-review
 
-### Google ADK
-- **Org**: Google
-- **Type**: adapter
-- **Integration**: Sample ATR security-guardrail plugin for the Google Agent Development Kit
-- **Evidence**: <https://github.com/google/adk-python/pull/6130>
-- **Since**: 2026-06-16
-- **Status**: in-review
-
 ### Cisco mcp-scanner
 - **Org**: Cisco
 - **Type**: rule-import
@@ -214,6 +214,30 @@ Listed when the integration code has been merged or released.
 - **Integration**: Three ATR-derived MCP detections contributed to the Splunk Suspicious MCP Activity analytic story
 - **Evidence**: <https://github.com/splunk/security_content/pull/4128>
 - **Since**: 2026-06-16
+- **Status**: in-review
+
+### rulezet (CIRCL)
+- **Org**: CIRCL (rulezet rule-management platform)
+- **Type**: adapter
+- **Integration**: `atr_format.py` importer/converter mirroring the existing `sigma_format` module (24 unit tests) — ATR rules are manageable as a first-class format in rulezet
+- **Evidence**: <https://github.com/rulezet/rulezet-core/pull/50>
+- **Since**: 2026-06-18
+- **Status**: shipped
+
+### NVIDIA NeMo Guardrails
+- **Org**: NVIDIA
+- **Type**: rule-import
+- **Integration**: Agent Threat Rules detection rail for the NeMo Guardrails library
+- **Evidence**: <https://github.com/NVIDIA-NeMo/Guardrails/pull/1992>
+- **Since**: 2026-06-04
+- **Status**: in-review
+
+### Cisco a2a-scanner
+- **Org**: Cisco
+- **Type**: rule-import
+- **Integration**: ATR detection pack for scanning agent-to-agent (A2A) protocol traffic
+- **Evidence**: <https://github.com/cisco-ai-defense/a2a-scanner/pull/14>
+- **Since**: 2026-06-26
 - **Status**: in-review
 
 ---
@@ -288,6 +312,30 @@ discoverability.
 - **Since**: 2026-04-10
 - **Status**: shipped
 
+### AMD GAIA
+- **Org**: AMD
+- **Type**: reference
+- **Integration**: Official GAIA integrations doc — guarding the Lemonade model endpoint with an offline ATR input/output guard (prompt-injection detection pattern)
+- **Evidence**: <https://github.com/amd/gaia/pull/1809>
+- **Since**: 2026-06-24
+- **Status**: shipped
+
+### ProjectRecon/awesome-ai-agents-security
+- **Org**: ProjectRecon (independent)
+- **Type**: reference
+- **Integration**: ATR listed in the Static Analysis & Linters section
+- **Evidence**: <https://github.com/ProjectRecon/awesome-ai-agents-security/pull/17>
+- **Since**: 2026-06-12
+- **Status**: shipped
+
+### raphabot/awesome-cybersecurity-agentic-ai
+- **Org**: raphabot (independent)
+- **Type**: reference
+- **Integration**: ATR listed in the Tools section
+- **Evidence**: <https://github.com/raphabot/awesome-cybersecurity-agentic-ai/pull/24>
+- **Since**: 2026-06-28
+- **Status**: shipped
+
 ---
 
 ## Tier 4 — Commercial implementations
@@ -313,3 +361,4 @@ noted here with the reason and the original "Since" date preserved.
 - **Semgrep** (was Tier 2 · since 2026-05-10) — no merged PR or verifiable evidence link could be located. Removed 2026-06-14.
 - **Puliczek/awesome-mcp-security** (was Tier 3 · since 2026-04-21) — ATR is not present in the project README; listing could not be verified. Removed 2026-06-14.
 - **aaif-goose (block/goose)** (was Tier 2 · since 2026-05-19) — evidence PR aaif-goose/goose#9304 is goose's generic PreToolUse denial hook; the PR body does not reference ATR, so it is not an ATR-specific integration. Removed 2026-06-16.
+- **Google ADK** (was Tier 2 · since 2026-06-16) — evidence PR google/adk-python#6130 was closed without merge. Removed 2026-07-05.

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ ATR (Agent Threat Rules) is an open detection rule format for AI agent security 
 
 ## Status of This Document
 
-ATR is published as a **Working Draft** at version `3.0.0-alpha.1`. The rule format defined in `ATR-SPEC-v1.md` is stable and shipped in production at two Fortune 500 organizations (Microsoft, Cisco) and one standards-body deployment (MISP / CIRCL); full list with PR links in [§6 Adoption](#6-adoption). Governance is currently single-maintainer (BDFL) transitioning to a Technical Steering Committee per [GOVERNANCE.md](GOVERNANCE.md).
+ATR is published as a **Working Draft** at version `3.0.0-alpha.1`. The rule format defined in `ATR-SPEC-v1.md` is stable and shipped in production at Microsoft, Cisco, and Gen Digital, and in standards-body integrations (MISP / CIRCL, OWASP Agent Security Regression Harness, SigmaHQ, FINOS Common Cloud Controls); full list with PR links in [§6 Adoption](#6-adoption). Governance is currently single-maintainer (BDFL) transitioning to a Technical Steering Committee per [GOVERNANCE.md](GOVERNANCE.md).
 
 All numbers in this document are sourced from [`data/stats.json`](data/stats.json), which is the canonical record of the project's current state. Where this README and `stats.json` disagree, `stats.json` is authoritative.
 
@@ -46,7 +46,7 @@ ATR is publishing proposal-stage standardization scaffolding ahead of OASIS Open
 - [`certification/`](certification/) — proposed ATR-Certified™ program guide
 - [`engines/`](engines/) — Python and Go reference impl interface contracts (TypeScript is the existing engine at `src/`)
 
-**All scaffolding is tagged PROPOSED v1.0 / v2.0 and is NOT ratified.** The 9-seat TSC has not been formed. The trust marks are not registered. Existing v1.1 governance ([`GOVERNANCE.md`](GOVERNANCE.md)) continues to operate. The rule format, npm package, TypeScript engine API, and all 652 rules are unchanged — existing ecosystem integrations (Microsoft AGT, Cisco AI Defense, MISP CIRCL, OWASP A-S-R-H, precize, Sage) work without modification.
+**All scaffolding is tagged PROPOSED v1.0 / v2.0 and is NOT ratified.** The 9-seat TSC has not been formed. The trust marks are not registered. Existing v1.1 governance ([`GOVERNANCE.md`](GOVERNANCE.md)) continues to operate. The rule format, npm package, TypeScript engine API, and the full rule corpus are unchanged — existing ecosystem integrations (Microsoft AGT, Cisco AI Defense, MISP CIRCL, OWASP A-S-R-H, precize, Sage) work without modification.
 
 See [`STANDARDIZATION-STATUS.md`](STANDARDIZATION-STATUS.md) for the full status matrix mapping every new artifact to `{STABLE IN PRODUCTION, PROPOSED, SKELETON, PRELIMINARY}` and timeline for OASIS submission, community comment, and ratification.
 
@@ -267,7 +267,7 @@ test_cases:
 
 ## 6. Adoption
 
-Production deployments and standards-body integrations, as of 2026-05-21:
+Production deployments and standards-body integrations, as of 2026-07-05 (every PR state re-verified against GitHub on that date):
 
 | Organization | Integration | Reference |
 |---|---|---|
@@ -275,6 +275,12 @@ Production deployments and standards-body integrations, as of 2026-05-21:
 | Cisco AI Defense (skill-scanner) | Full rule pack in production (merged 2026-04-22); original PoC (merged 2026-04-03) | [PR #99](https://github.com/cisco-ai-defense/skill-scanner/pull/99) · [PR #79](https://github.com/cisco-ai-defense/skill-scanner/pull/79) |
 | MISP (CIRCL) | Threat-intel cluster (galaxy, merged 2026-05-10) + rule-ID tagging vocabulary (taxonomies, merged 2026-05-10) | [galaxy #1207](https://github.com/MISP/misp-galaxy/pull/1207) · [taxonomies #323](https://github.com/MISP/misp-taxonomies/pull/323) |
 | Gen Digital Sage (Norton / Avast / AVG parent) | Rule pack merged 2026-05-11 | [PR #33](https://github.com/gendigitalinc/sage/pull/33) |
+| OWASP Agent Security Regression Harness | ATR referenced as the canonical agent-threat detection ruleset in the threat catalogue (merged 2026-05-11) | [PR #74](https://github.com/OWASP/agent-security-regression-harness/pull/74) |
+| Microsoft PyRIT | ATR adversarial-payload dataset loader for the red-team orchestration framework (merged 2026-05-27) | [PR #1715](https://github.com/microsoft/PyRIT/pull/1715) |
+| SigmaHQ | Cross-listed in the Sigma tools directory as a sibling detection-rule format (merged 2026-06-11) | [PR #6015](https://github.com/SigmaHQ/sigma/pull/6015) |
+| rulezet (CIRCL) | `atr_format` importer/converter — ATR as a first-class rule format in the rulezet platform (merged 2026-06-18) | [PR #50](https://github.com/rulezet/rulezet-core/pull/50) |
+| AMD GAIA | Official integrations doc — guarding the Lemonade model endpoint with an offline ATR I/O guard (merged 2026-06-24) | [PR #1809](https://github.com/amd/gaia/pull/1809) |
+| FINOS Common Cloud Controls (Linux Foundation) | ATR guideline-mappings for CCC catalogue entries with Gemara MappingReference (merged 2026-07-02) | [PR #986](https://github.com/finos/common-cloud-controls/pull/986) |
 
 ### Featured loop — Microsoft Copilot SWE Agent → ATR (2026-05-11)
 
@@ -284,7 +290,7 @@ This is Microsoft Copilot operating inside AGT, not an MSRC endorsement. Coverag
 
 ### Under maintainer review (open PRs)
 
-[NVIDIA garak #1676](https://github.com/NVIDIA/garak/pull/1676) · [OWASP LLM Top 10 #814](https://github.com/OWASP/www-project-top-10-for-large-language-model-applications/pull/814) · [IBM mcp-context-forge #4109](https://github.com/IBM/mcp-context-forge/pull/4109) · [Meta PurpleLlama #206](https://github.com/meta-llama/PurpleLlama/pull/206) · [Microsoft PyRIT #1715](https://github.com/microsoft/PyRIT/pull/1715) · [BerriAI LiteLLM #28050](https://github.com/BerriAI/litellm/pull/28050) · [promptfoo #8529](https://github.com/promptfoo/promptfoo/pull/8529) · [Cybercentre Canada CCCS-Yara #100](https://github.com/CybercentreCanada/CCCS-Yara/pull/100)
+[NVIDIA garak #1676](https://github.com/NVIDIA/garak/pull/1676) · [NVIDIA NeMo Guardrails #1992](https://github.com/NVIDIA-NeMo/Guardrails/pull/1992) · [OWASP LLM Top 10 #814](https://github.com/OWASP/www-project-top-10-for-large-language-model-applications/pull/814) · [OWASP AI Exchange #181](https://github.com/OWASP/www-project-ai-security-and-privacy-guide/pull/181) · [Meta PurpleLlama #206](https://github.com/meta-llama/PurpleLlama/pull/206) · [BerriAI LiteLLM #28050](https://github.com/BerriAI/litellm/pull/28050) · [promptfoo #8529](https://github.com/promptfoo/promptfoo/pull/8529) · [Microsoft agent-framework #6528](https://github.com/microsoft/agent-framework/pull/6528) · [OpenAI guardrails-python #77](https://github.com/openai/openai-guardrails-python/pull/77) · [Cisco mcp-scanner #194](https://github.com/cisco-ai-defense/mcp-scanner/pull/194) · [Cisco a2a-scanner #14](https://github.com/cisco-ai-defense/a2a-scanner/pull/14) · [Splunk security_content #4128](https://github.com/splunk/security_content/pull/4128) · [NIST OSCAL oscal-content #338](https://github.com/usnistgov/oscal-content/pull/338) · [OpenTelemetry semantic-conventions-genai #165](https://github.com/open-telemetry/semantic-conventions-genai/pull/165)
 
 ### Integrating ATR into your project
 
@@ -306,7 +312,7 @@ ATR maps its rules onto established frameworks so adopters can answer "we deploy
 
 | Framework | Coverage | Mapping document |
 |---|---|---|
-| [OWASP Agentic Top 10 (2026)](https://genai.owasp.org/resource/owasp-top-10-for-agentic-applications-for-2026/) | 10/10 categories, 866 mappings across 652 tagged rules | [docs/OWASP-AGENTIC-MAPPING.md](docs/OWASP-AGENTIC-MAPPING.md) |
+| [OWASP Agentic Top 10 (2026)](https://genai.owasp.org/resource/owasp-top-10-for-agentic-applications-for-2026/) | 10/10 categories, 1,179 mappings across all 683 tagged rules | [docs/OWASP-AGENTIC-MAPPING.md](docs/OWASP-AGENTIC-MAPPING.md) |
 | [SAFE-MCP (OpenSSF)](https://github.com/safe-agentic-framework/safe-mcp) | 78/85 techniques (91.8%) | [docs/SAFE-MCP-MAPPING.md](docs/SAFE-MCP-MAPPING.md) |
 | [OWASP LLM Top 10 (2025)](https://owasp.org/www-project-top-10-for-large-language-model-applications/) | Per-rule references | Per-rule `references.owasp_llm` field |
 | [MITRE ATLAS](https://atlas.mitre.org/) | Per-rule references | Per-rule `references.mitre_atlas` field |
@@ -320,14 +326,14 @@ ATR maps its rules onto established frameworks so adopters can answer "we deploy
 | Prompt Injection | 223 | Instruction override, persona hijacking, encoded payloads (base-N, ROT, Unicode tags, zalgo, ecoji), CJK attacks, latent injection, glitch tokens, leakreplay |
 | Agent Manipulation | 106 | DAN family, AutoDAN, DanInTheWild, tense framing, grandma roleplay, doctor-XML puppetry, goal hijacking, Sybil consensus, lambda+eval RCE |
 | Skill Compromise | 45 | Typosquatting, context poisoning, subcommand overflow, rug pull, supply-chain attacks, credential-exfil combos, HuggingFace unsafe artifacts |
-| Context Exfiltration | 104 | API-key generation/completion, system-prompt theft, credential harvesting, env-var exfil, markdown-URL exfil, XSS in tool response, cross-user memory leakage |
-| Tool Poisoning | 65 | Malicious MCP responses, consent bypass, hidden LLM instructions, schema contradictions, ANSI escape elicitation, vector-store filter injection |
-| Privilege Escalation | 35 | Scope creep, delayed execution bypass, admin function access, shell escape, SQL injection in admin endpoints, autostart file write |
+| Context Exfiltration | 109 | API-key generation/completion, system-prompt theft, credential harvesting, env-var exfil, markdown-URL exfil, XSS in tool response, cross-user memory leakage |
+| Tool Poisoning | 85 | Malicious MCP responses, consent bypass, hidden LLM instructions, schema contradictions, ANSI escape elicitation, vector-store filter injection |
+| Privilege Escalation | 41 | Scope creep, delayed execution bypass, admin function access, shell escape, SQL injection in admin endpoints, autostart file write |
 | Model Abuse | 37 | Malware code generation (malwaregen), EICAR/GTUBE signatures, AV-evasion gen |
 | Excessive Autonomy | 29 | Runaway loops, resource exhaustion, unauthorized financial actions |
 | Model Security | 3 | Behavior extraction, malicious fine-tuning data |
 | Data Poisoning | 5 | RAG / knowledge-base tampering, memory manipulation, persistence-aware override |
-| **Total** | **652** |  |
+| **Total** | **683** |  |
 
 ### CVE coverage (selected)
 
@@ -437,7 +443,7 @@ npx tsx scripts/measurement/verify.ts       # validate every measurement file
 npx tsx scripts/sync-stats-from-measurements.ts                              # refresh stats.json benchmarks[]
 ```
 
-Raw data: [`data/full-scan-v2-2026-04-14.json`](data/full-scan-v2-2026-04-14.json) (96,096-skill scan); ecosystem report on the 751 confirmed malware specimens in [`docs/research/openclaw-malware-campaign-2026-04.md`](docs/research/openclaw-malware-campaign-2026-04.md).
+Raw data: [`data/full-scan-v2-2026-04-14.json`](data/full-scan-v2-2026-04-14.json) (96,096-skill scan; 1,302 flagged, 552 confirmed malicious after manual review); full malware-campaign report in [`docs/research/openclaw-malware-campaign-2026-04.md`](docs/research/openclaw-malware-campaign-2026-04.md).
 
 ATR is honest about what it cannot detect. Regex catalogs miss paraphrased attacks, semantic rephrasings of credential exfiltration, and novel attack shapes not present in the training corpus. `PromptBench` (3,280 character- and word-level robustness perturbations) is a different threat class from prompt injection and sits largely outside ATR's content scope; ATR still matches the 23.2% that carry injection-shaped payloads, at 100% precision. See [LIMITATIONS.md](LIMITATIONS.md) for the documented evasion-test corpus (64 techniques as of 2026-05) and the layering recommendation: ATR is the content layer; pair with credential brokering, sandbox execution, and human-in-the-loop for high-blast-radius actions.
 

--- a/data/adopters-verification.json
+++ b/data/adopters-verification.json
@@ -1,0 +1,306 @@
+{
+  "$comment": "AUTO by scripts/verify-adopters.mjs — every ADOPTERS.md evidence link re-checked against GitHub. Do not edit by hand.",
+  "verified_at": "2026-07-05",
+  "total": 33,
+  "ok": 33,
+  "drift": [],
+  "results": [
+    {
+      "name": "MISP / CIRCL",
+      "tier": "S",
+      "evidence": "https://github.com/MISP/misp-taxonomies/pull/323",
+      "declared": "shipped",
+      "kind": "pr",
+      "observed": "merged",
+      "ok": true
+    },
+    {
+      "name": "OWASP Agent Security Regression Harness",
+      "tier": "S",
+      "evidence": "https://github.com/OWASP/agent-security-regression-harness/pull/74",
+      "declared": "shipped",
+      "kind": "pr",
+      "observed": "merged",
+      "ok": true
+    },
+    {
+      "name": "NIST AI RMF — community OSCAL catalog (submission in review)",
+      "tier": "S",
+      "evidence": "https://github.com/usnistgov/oscal-content/pull/338",
+      "declared": "in-review",
+      "kind": "pr",
+      "observed": "open",
+      "ok": true
+    },
+    {
+      "name": "OpenTelemetry — semantic-conventions-genai",
+      "tier": "S",
+      "evidence": "https://github.com/open-telemetry/semantic-conventions-genai/pull/165",
+      "declared": "in-review",
+      "kind": "pr",
+      "observed": "open",
+      "ok": true
+    },
+    {
+      "name": "OWASP AI Exchange",
+      "tier": "S",
+      "evidence": "https://github.com/OWASP/www-project-ai-security-and-privacy-guide/pull/181",
+      "declared": "in-review",
+      "kind": "pr",
+      "observed": "open",
+      "ok": true
+    },
+    {
+      "name": "FINOS Common Cloud Controls",
+      "tier": "S",
+      "evidence": "https://github.com/finos/common-cloud-controls/pull/986",
+      "declared": "shipped",
+      "kind": "pr",
+      "observed": "merged",
+      "ok": true
+    },
+    {
+      "name": "Cisco AI Defense",
+      "tier": "1",
+      "evidence": "https://github.com/cisco-ai-defense/skill-scanner/pull/99",
+      "declared": "shipped",
+      "kind": "pr",
+      "observed": "merged",
+      "ok": true
+    },
+    {
+      "name": "Microsoft Agent Governance Toolkit",
+      "tier": "1",
+      "evidence": "https://github.com/microsoft/agent-governance-toolkit/pull/1277",
+      "declared": "shipped",
+      "kind": "pr",
+      "observed": "merged",
+      "ok": true
+    },
+    {
+      "name": "Gen Digital Sage",
+      "tier": "1",
+      "evidence": "https://github.com/gendigitalinc/sage/pull/33",
+      "declared": "shipped",
+      "kind": "pr",
+      "observed": "merged",
+      "ok": true
+    },
+    {
+      "name": "AG2 (AutoGen)",
+      "tier": "2",
+      "evidence": "https://github.com/ag2ai/ag2classic/blob/main/autogen/agentchat/contrib/capabilities/atr_guardrail.py",
+      "declared": "shipped",
+      "kind": "link",
+      "observed": "reachable",
+      "ok": true
+    },
+    {
+      "name": "BerriAI LiteLLM",
+      "tier": "2",
+      "evidence": "https://github.com/BerriAI/litellm/pull/28050",
+      "declared": "in-review",
+      "kind": "pr",
+      "observed": "open",
+      "ok": true
+    },
+    {
+      "name": "Promptfoo",
+      "tier": "2",
+      "evidence": "https://github.com/promptfoo/promptfoo/pull/8529",
+      "declared": "in-review",
+      "kind": "pr",
+      "observed": "open",
+      "ok": true
+    },
+    {
+      "name": "NVIDIA garak",
+      "tier": "2",
+      "evidence": "https://github.com/NVIDIA/garak/pull/1676",
+      "declared": "in-review",
+      "kind": "pr",
+      "observed": "open",
+      "ok": true
+    },
+    {
+      "name": "SigmaHQ",
+      "tier": "2",
+      "evidence": "https://github.com/SigmaHQ/sigma/pull/6015",
+      "declared": "shipped",
+      "kind": "pr",
+      "observed": "merged",
+      "ok": true
+    },
+    {
+      "name": "Microsoft PyRIT",
+      "tier": "2",
+      "evidence": "https://github.com/microsoft/PyRIT/pull/1715",
+      "declared": "shipped",
+      "kind": "pr",
+      "observed": "merged",
+      "ok": true
+    },
+    {
+      "name": "Microsoft Agent Framework",
+      "tier": "2",
+      "evidence": "https://github.com/microsoft/agent-framework/pull/6528",
+      "declared": "in-review",
+      "kind": "pr",
+      "observed": "open",
+      "ok": true
+    },
+    {
+      "name": "OpenAI Guardrails",
+      "tier": "2",
+      "evidence": "https://github.com/openai/openai-guardrails-python/pull/77",
+      "declared": "in-review",
+      "kind": "pr",
+      "observed": "open",
+      "ok": true
+    },
+    {
+      "name": "Cisco mcp-scanner",
+      "tier": "2",
+      "evidence": "https://github.com/cisco-ai-defense/mcp-scanner/pull/194",
+      "declared": "in-review",
+      "kind": "pr",
+      "observed": "open",
+      "ok": true
+    },
+    {
+      "name": "Splunk security_content",
+      "tier": "2",
+      "evidence": "https://github.com/splunk/security_content/pull/4128",
+      "declared": "in-review",
+      "kind": "pr",
+      "observed": "open",
+      "ok": true
+    },
+    {
+      "name": "rulezet (CIRCL)",
+      "tier": "2",
+      "evidence": "https://github.com/rulezet/rulezet-core/pull/50",
+      "declared": "shipped",
+      "kind": "pr",
+      "observed": "merged",
+      "ok": true
+    },
+    {
+      "name": "NVIDIA NeMo Guardrails",
+      "tier": "2",
+      "evidence": "https://github.com/NVIDIA-NeMo/Guardrails/pull/1992",
+      "declared": "in-review",
+      "kind": "pr",
+      "observed": "open",
+      "ok": true
+    },
+    {
+      "name": "Cisco a2a-scanner",
+      "tier": "2",
+      "evidence": "https://github.com/cisco-ai-defense/a2a-scanner/pull/14",
+      "declared": "in-review",
+      "kind": "pr",
+      "observed": "open",
+      "ok": true
+    },
+    {
+      "name": "ottosulin/awesome-ai-security",
+      "tier": "3",
+      "evidence": "https://github.com/ottosulin/awesome-ai-security/pull/192",
+      "declared": "shipped",
+      "kind": "pr",
+      "observed": "merged",
+      "ok": true
+    },
+    {
+      "name": "e2b-dev/awesome-ai-agents",
+      "tier": "3",
+      "evidence": "https://github.com/e2b-dev/awesome-ai-agents/pull/959",
+      "declared": "in-review",
+      "kind": "pr",
+      "observed": "open",
+      "ok": true
+    },
+    {
+      "name": "e2b-dev/awesome-ai-sdks",
+      "tier": "3",
+      "evidence": "https://github.com/e2b-dev/awesome-ai-sdks/pull/194",
+      "declared": "in-review",
+      "kind": "pr",
+      "observed": "open",
+      "ok": true
+    },
+    {
+      "name": "CryptoAILab/Awesome-LM-SSP",
+      "tier": "3",
+      "evidence": "https://github.com/CryptoAILab/Awesome-LM-SSP/pull/108",
+      "declared": "shipped",
+      "kind": "pr",
+      "observed": "merged",
+      "ok": true
+    },
+    {
+      "name": "precize/Agentic-AI-Top10-Vulnerability",
+      "tier": "3",
+      "evidence": "https://github.com/precize/Agentic-AI-Top10-Vulnerability/pull/14",
+      "declared": "shipped",
+      "kind": "pr",
+      "observed": "merged",
+      "ok": true
+    },
+    {
+      "name": "wearetyomsmnv/Awesome-LLM-agent-Security",
+      "tier": "3",
+      "evidence": "https://github.com/wearetyomsmnv/Awesome-LLM-agent-Security/pull/6",
+      "declared": "shipped",
+      "kind": "pr",
+      "observed": "merged",
+      "ok": true
+    },
+    {
+      "name": "nibzard/awesome-agentic-patterns",
+      "tier": "3",
+      "evidence": "https://github.com/nibzard/awesome-agentic-patterns/pull/58",
+      "declared": "shipped",
+      "kind": "pr",
+      "observed": "merged",
+      "ok": true
+    },
+    {
+      "name": "TalEliyahu/Awesome-AI-Security",
+      "tier": "3",
+      "evidence": "https://github.com/TalEliyahu/Awesome-AI-Security/pull/53",
+      "declared": "shipped",
+      "kind": "pr",
+      "observed": "merged",
+      "ok": true
+    },
+    {
+      "name": "AMD GAIA",
+      "tier": "3",
+      "evidence": "https://github.com/amd/gaia/pull/1809",
+      "declared": "shipped",
+      "kind": "pr",
+      "observed": "merged",
+      "ok": true
+    },
+    {
+      "name": "ProjectRecon/awesome-ai-agents-security",
+      "tier": "3",
+      "evidence": "https://github.com/ProjectRecon/awesome-ai-agents-security/pull/17",
+      "declared": "shipped",
+      "kind": "pr",
+      "observed": "merged",
+      "ok": true
+    },
+    {
+      "name": "raphabot/awesome-cybersecurity-agentic-ai",
+      "tier": "3",
+      "evidence": "https://github.com/raphabot/awesome-cybersecurity-agentic-ai/pull/24",
+      "declared": "shipped",
+      "kind": "pr",
+      "observed": "merged",
+      "ok": true
+    }
+  ]
+}

--- a/scripts/verify-adopters.mjs
+++ b/scripts/verify-adopters.mjs
@@ -1,0 +1,212 @@
+#!/usr/bin/env node
+/**
+ * verify-adopters.mjs — re-verify every ADOPTERS.md evidence link against
+ * GitHub and record the result in data/adopters-verification.json.
+ *
+ * Why: ADOPTERS.md is the single source of truth for the website's adopter
+ * wall. Its Status fields (shipped / in-review) are claims about external
+ * repositories, and those repositories move — PRs merge, close, or get
+ * superseded. This script turns "we claim" into "we checked, on this date":
+ *   - shipped   + evidence PR   -> PR must be MERGED
+ *   - in-review + evidence PR   -> PR must be OPEN
+ *   - any       + evidence issue-> issue must be OPEN (conversation alive)
+ *   - any       + plain link    -> URL must resolve (HTTP < 400)
+ *
+ * Output: data/adopters-verification.json (consumed by the website's
+ * /ecosystem page to print the verification date, and by CI to alert on
+ * drift). The script always exits 0 and always writes the file — drift is
+ * data, not an error here. The workflow gates on the drift count separately
+ * so the honest state still gets committed and published.
+ *
+ * Auth: set GITHUB_TOKEN to avoid the 60 req/h unauthenticated API limit.
+ * Run: node scripts/verify-adopters.mjs
+ */
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const ADOPTERS_PATH = join(REPO_ROOT, 'ADOPTERS.md');
+const OUT_PATH = join(REPO_ROOT, 'data', 'adopters-verification.json');
+
+const TIER_HEADINGS = [
+  { heading: 'Tier S', tier: 'S' },
+  { heading: 'Tier 1', tier: '1' },
+  { heading: 'Tier 2', tier: '2' },
+  { heading: 'Tier 3', tier: '3' },
+  { heading: 'Tier 4', tier: '4' },
+];
+
+function extractField(block, fieldName) {
+  const re = new RegExp(`\\*\\*${fieldName}\\*\\*\\s*:\\s*([^\\n]+)`, 'i');
+  const m = block.match(re);
+  return m ? m[1].trim() : undefined;
+}
+
+/** First canonical URL out of an Evidence value (mirrors website/lib/adopters.ts). */
+function firstUrl(evidence) {
+  const angle = evidence.match(/<(https?:\/\/[^>\s]+)>/);
+  if (angle) return angle[1];
+  const link = evidence.match(/^\[.*?\]\((.+?)\)/);
+  if (link) return link[1];
+  const bare = evidence.match(/https?:\/\/[^\s>)]+/);
+  return bare ? bare[0] : undefined;
+}
+
+function parseAdopters(raw) {
+  const entries = [];
+  let currentTier = null;
+  let block = [];
+  let name = null;
+
+  const flush = () => {
+    if (!name || !currentTier) return;
+    const body = block.join('\n');
+    const evidence = extractField(body, 'Evidence');
+    const status = (extractField(body, 'Status') || 'shipped').toLowerCase();
+    if (!evidence) return;
+    entries.push({ name, tier: currentTier, evidence: firstUrl(evidence), status });
+  };
+
+  for (const line of raw.split('\n')) {
+    const top = /^## (.+)$/.exec(line);
+    if (top) {
+      flush();
+      name = null;
+      block = [];
+      const match = TIER_HEADINGS.find((t) => top[1].startsWith(t.heading));
+      currentTier = match ? match.tier : null;
+      continue;
+    }
+    const h3 = /^###\s+(.+?)\s*$/.exec(line);
+    if (h3) {
+      flush();
+      name = h3[1];
+      block = [];
+      continue;
+    }
+    if (name) block.push(line);
+  }
+  flush();
+  return entries;
+}
+
+const API_HEADERS = {
+  Accept: 'application/vnd.github+json',
+  'User-Agent': 'atr-adopters-verify',
+  ...(process.env.GITHUB_TOKEN
+    ? { Authorization: `Bearer ${process.env.GITHUB_TOKEN}` }
+    : {}),
+};
+
+async function checkPr(owner, repo, num) {
+  const res = await fetch(
+    `https://api.github.com/repos/${owner}/${repo}/pulls/${num}`,
+    { headers: API_HEADERS },
+  );
+  if (!res.ok) return { observed: `api-${res.status}` };
+  const pr = await res.json();
+  if (pr.merged_at) return { observed: 'merged' };
+  return { observed: pr.state === 'open' ? 'open' : 'closed' };
+}
+
+async function checkIssue(owner, repo, num) {
+  const res = await fetch(
+    `https://api.github.com/repos/${owner}/${repo}/issues/${num}`,
+    { headers: API_HEADERS },
+  );
+  if (!res.ok) return { observed: `api-${res.status}` };
+  const issue = await res.json();
+  return { observed: issue.state === 'open' ? 'open' : 'closed' };
+}
+
+async function checkLink(url) {
+  try {
+    const res = await fetch(url, {
+      method: 'GET',
+      headers: { 'User-Agent': 'atr-adopters-verify' },
+      redirect: 'follow',
+    });
+    return { observed: res.status < 400 ? 'reachable' : `http-${res.status}` };
+  } catch {
+    return { observed: 'unreachable' };
+  }
+}
+
+function isOk(kind, declared, observed) {
+  if (kind === 'pr') {
+    if (declared === 'shipped') return observed === 'merged';
+    if (declared === 'in-review') return observed === 'open';
+    return false;
+  }
+  if (kind === 'issue') return observed === 'open';
+  if (kind === 'link') return observed === 'reachable';
+  return false;
+}
+
+async function main() {
+  const raw = readFileSync(ADOPTERS_PATH, 'utf8');
+  const entries = parseAdopters(raw);
+  const results = [];
+
+  for (const entry of entries) {
+    if (!entry.evidence) {
+      results.push({ ...entry, kind: 'none', observed: 'missing', ok: false });
+      continue;
+    }
+    const prMatch = entry.evidence.match(
+      /github\.com\/([^/]+)\/([^/]+)\/pull\/(\d+)/,
+    );
+    const issueMatch = entry.evidence.match(
+      /github\.com\/([^/]+)\/([^/]+)\/issues\/(\d+)/,
+    );
+    let kind;
+    let observed;
+    if (prMatch) {
+      kind = 'pr';
+      ({ observed } = await checkPr(prMatch[1], prMatch[2], prMatch[3]));
+    } else if (issueMatch) {
+      kind = 'issue';
+      ({ observed } = await checkIssue(issueMatch[1], issueMatch[2], issueMatch[3]));
+    } else {
+      kind = 'link';
+      ({ observed } = await checkLink(entry.evidence));
+    }
+    const ok = isOk(kind, entry.status, observed);
+    results.push({
+      name: entry.name,
+      tier: entry.tier,
+      evidence: entry.evidence,
+      declared: entry.status,
+      kind,
+      observed,
+      ok,
+    });
+    console.log(
+      `${ok ? '[ok]   ' : '[DRIFT]'} ${entry.name} — declared ${entry.status}, observed ${observed} (${kind})`,
+    );
+  }
+
+  const drift = results.filter((r) => !r.ok);
+  const out = {
+    $comment:
+      'AUTO by scripts/verify-adopters.mjs — every ADOPTERS.md evidence link re-checked against GitHub. Do not edit by hand.',
+    verified_at: new Date().toISOString().slice(0, 10),
+    total: results.length,
+    ok: results.length - drift.length,
+    drift: drift.map((d) => ({
+      name: d.name,
+      declared: d.declared,
+      observed: d.observed,
+      evidence: d.evidence,
+    })),
+    results,
+  };
+  writeFileSync(OUT_PATH, `${JSON.stringify(out, null, 2)}\n`);
+  console.log(
+    `\nwrote ${OUT_PATH} — ${out.ok}/${out.total} verified, ${drift.length} drift`,
+  );
+}
+
+await main();

--- a/website/app/[locale]/about/page.tsx
+++ b/website/app/[locale]/about/page.tsx
@@ -1,4 +1,5 @@
 import { Reveal } from "@/components/Reveal";
+import { loadSiteStats } from "@/lib/stats";
 import { locales, type Locale } from "@/lib/i18n";
 import type { Metadata } from "next";
 import Link from "next/link";
@@ -157,12 +158,23 @@ const MILESTONES: Milestone[] = [
   {
     date: "2026-06",
     title: {
-      en: "v3.5.0 · 652 rules across 10 categories",
-      zh: "v3.5.0 · 652 條規則,跨 10 個類別",
+      en: "v3.5.0 · detection lanes ship",
+      zh: "v3.5.0 · 偵測車道上線",
     },
     detail: {
-      en: "Current release line: 652 detection rules across 10 categories, specification 3.5.0 (Working Draft). Introduced detection lanes (enforce / alert / hunt) — maturity-driven precision, with false-positive rates reported per lane rather than as a single figure.",
-      zh: "目前釋出線:652 條偵測規則,跨 10 個類別,規範 3.5.0（Working Draft）。引入偵測車道(enforce / alert / hunt)——以成熟度驅動精確度,誤報率逐車道揭露,而非用單一數字概括。",
+      en: "v3.5.0 (652 rules at release) introduced detection lanes (enforce / alert / hunt) — maturity-driven precision, with false-positive rates reported per lane rather than as a single figure.",
+      zh: "v3.5.0（發布時 652 條規則）引入偵測車道(enforce / alert / hunt)——以成熟度驅動精確度,誤報率逐車道揭露,而非用單一數字概括。",
+    },
+  },
+  {
+    date: "2026-07",
+    title: {
+      en: "Adoption re-verified · auto-publish flywheel",
+      zh: "採用全面現驗 · 自動發布飛輪",
+    },
+    detail: {
+      en: "Every adopter PR state re-verified against GitHub — new shipped integrations recorded across FINOS, SigmaHQ, rulezet/CIRCL, AMD GAIA, and AG2. The crystallization flywheel now auto-publishes new rules to npm on merge; rule count, spec version, and the adopter wall on this site are all rebuilt from repo state at deploy time.",
+      zh: "所有採用者 PR 狀態對 GitHub 全面現驗——FINOS、SigmaHQ、rulezet/CIRCL、AMD GAIA、AG2 等新出貨整合入列。結晶飛輪已在 merge 時自動發布新規則到 npm;本站的規則數、規範版本、採用者牆全部在部署時從 repo 狀態重建。",
     },
   },
 ];
@@ -175,6 +187,7 @@ export default async function AboutPage({
   const { locale: rawLocale } = await params;
   const locale = (locales.includes(rawLocale as Locale) ? rawLocale : "en") as Locale;
   const zh = locale === "zh";
+  const ruleCount = loadSiteStats().ruleCount;
 
   return (
     <div className="pt-20 pb-20 px-5 md:px-6 max-w-[860px] mx-auto">
@@ -213,8 +226,8 @@ export default async function AboutPage({
         </p>
         <p className="text-sm md:text-base text-graphite leading-[1.8] mt-4">
           {zh
-            ? "標準由社群驅動，並透過每日自動結晶飛輪持續擴張——紅隊大掃描與 CVE 攝取兩條管線各自跑完完整 sweep，把規則集從 462 條長到 652 條（新增 190 條）。"
-            : "The standard is community-driven and grows through daily auto-crystallization flywheels — a red-team mega-scan pipeline and a CVE-ingestion pipeline each ran full sweeps, expanding the ruleset from 462 to 652 rules (190 new rules)."}
+            ? <>標準由社群驅動，並透過每日自動結晶飛輪持續擴張——紅隊大掃描與 CVE 攝取兩條管線各自跑完完整 sweep，把規則集從 462 條長到 {ruleCount} 條。</>
+            : <>The standard is community-driven and grows through daily auto-crystallization flywheels — a red-team mega-scan pipeline and a CVE-ingestion pipeline each ran full sweeps, expanding the ruleset from 462 to {ruleCount} rules.</>}
         </p>
         <p className="text-sm md:text-base text-graphite leading-[1.8] mt-4">
           {zh

--- a/website/app/[locale]/ecosystem/page.tsx
+++ b/website/app/[locale]/ecosystem/page.tsx
@@ -4,6 +4,7 @@ import {
   loadAdopters,
   tierLabel,
   tierDescription,
+  adopterLogoUrl,
   type Adopter,
   type AdopterTier,
 } from "@/lib/adopters";
@@ -114,8 +115,19 @@ export default async function EcosystemPage({ params }: { params: Promise<{ loca
               <div className="grid grid-cols-1 md:grid-cols-2 gap-px bg-fog">
                 {entries.map((a) => (
                   <article key={a.name} className="bg-paper p-5">
-                    <div className="flex items-baseline justify-between gap-3 mb-1">
-                      <h2 className="font-display text-base font-semibold text-ink">
+                    <div className="flex items-center gap-3 mb-1">
+                      {adopterLogoUrl(a) && (
+                        <img
+                          src={adopterLogoUrl(a)}
+                          alt=""
+                          width={28}
+                          height={28}
+                          loading="lazy"
+                          referrerPolicy="no-referrer"
+                          className="rounded-sm ring-1 ring-fog shrink-0"
+                        />
+                      )}
+                      <h2 className="font-display text-base font-semibold text-ink flex-1">
                         {a.name}
                       </h2>
                       <StatusBadge status={a.status} zh={zh} />
@@ -177,8 +189,19 @@ export default async function EcosystemPage({ params }: { params: Promise<{ loca
             <div className="grid grid-cols-1 md:grid-cols-2 gap-px bg-fog">
               {commercial.map((a) => (
                 <article key={a.name} className="bg-paper p-5">
-                  <div className="flex items-baseline justify-between gap-3 mb-1">
-                    <h2 className="font-display text-base font-semibold text-ink">
+                  <div className="flex items-center gap-3 mb-1">
+                    {adopterLogoUrl(a) && (
+                      <img
+                        src={adopterLogoUrl(a)}
+                        alt=""
+                        width={28}
+                        height={28}
+                        loading="lazy"
+                        referrerPolicy="no-referrer"
+                        className="rounded-sm ring-1 ring-fog shrink-0"
+                      />
+                    )}
+                    <h2 className="font-display text-base font-semibold text-ink flex-1">
                       {a.name}
                     </h2>
                     <StatusBadge status={a.status} zh={zh} />

--- a/website/app/[locale]/ecosystem/page.tsx
+++ b/website/app/[locale]/ecosystem/page.tsx
@@ -2,12 +2,19 @@ import { Reveal } from "@/components/Reveal";
 import { locales, type Locale } from "@/lib/i18n";
 import {
   loadAdopters,
+  loadAdoptersVerification,
   tierLabel,
   tierDescription,
   adopterLogoUrl,
   type Adopter,
   type AdopterTier,
+  type IntegrationType,
 } from "@/lib/adopters";
+import {
+  IntegrationTypeIcon,
+  integrationTypeLabel,
+  integrationTypeHint,
+} from "@/components/IntegrationTypeIcon";
 import type { Metadata } from "next";
 
 export function generateStaticParams() {
@@ -25,6 +32,7 @@ export default async function EcosystemPage({ params }: { params: Promise<{ loca
   const locale = (locales.includes(raw as Locale) ? raw : "en") as Locale;
   const zh = locale === "zh";
   const adopters = loadAdopters();
+  const verification = loadAdoptersVerification();
 
   // Pair tiers with their entries in display order. Tier S is most prominent,
   // tier 4 (commercial) is separated visually so vendor implementations do not
@@ -67,7 +75,7 @@ export default async function EcosystemPage({ params }: { params: Promise<{ loca
         </p>
       </Reveal>
       <Reveal delay={0.25}>
-        <p className="font-data text-xs text-stone tracking-wide mb-10">
+        <p className="font-data text-xs text-stone tracking-wide mb-5">
           {zh ? "共計" : "Total"}: <span className="text-ink font-bold">{adopters.count}</span> {zh ? "個採用者" : "adopters"}
           {" · "}
           <a
@@ -78,7 +86,59 @@ export default async function EcosystemPage({ params }: { params: Promise<{ loca
           >
             ADOPTERS.md →
           </a>
+          {verification && (
+            <>
+              {" · "}
+              <a
+                href="https://github.com/Agent-Threat-Rule/agent-threat-rules/blob/main/data/adopters-verification.json"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-green hover:underline"
+                title={
+                  zh
+                    ? "scripts/verify-adopters.mjs 每週對 GitHub 重驗每個證據連結:shipped 必須是 MERGED,in-review 必須是 OPEN"
+                    : "scripts/verify-adopters.mjs re-checks every evidence link against GitHub weekly: shipped must be MERGED, in-review must be OPEN"
+                }
+              >
+                {zh
+                  ? `證據連結 ${verification.verifiedAt} 對 GitHub 現驗 ${verification.ok}/${verification.total}`
+                  : `evidence re-verified against GitHub ${verification.verifiedAt} — ${verification.ok}/${verification.total}`}
+              </a>
+            </>
+          )}
         </p>
+      </Reveal>
+
+      {/* Integration-shape legend — the Type field decoded for engineers */}
+      <Reveal delay={0.28}>
+        <div className="grid grid-cols-2 md:grid-cols-3 gap-x-8 gap-y-3 mb-10 max-w-[820px]">
+          {(
+            [
+              "engine",
+              "rule-import",
+              "category-subset",
+              "adapter",
+              "reference",
+              "sidecar-proxy",
+            ] as IntegrationType[]
+          ).map((ty) => (
+            <div key={ty} className="flex items-start gap-2">
+              <IntegrationTypeIcon
+                type={ty}
+                size={14}
+                className="text-stone mt-[3px] shrink-0"
+              />
+              <div>
+                <span className="font-data text-[11px] text-ink">
+                  {integrationTypeLabel(ty, locale)}
+                </span>
+                <span className="block text-[11px] text-stone leading-snug">
+                  {integrationTypeHint(ty, locale)}
+                </span>
+              </div>
+            </div>
+          ))}
+        </div>
       </Reveal>
 
       {/* Tier S / 1 / 2 / 3 — the standard's reach */}
@@ -141,7 +201,30 @@ export default async function EcosystemPage({ params }: { params: Promise<{ loca
                         </>
                       )}
                       {" · "}
-                      <span className="text-ink/70">{a.type}</span>
+                      <span
+                        className="text-ink/70 inline-flex items-center gap-1 align-middle"
+                        title={integrationTypeHint(a.type, locale)}
+                      >
+                        <IntegrationTypeIcon type={a.type} size={12} className="shrink-0" />
+                        {integrationTypeLabel(a.type, locale)}
+                      </span>
+                      {verification?.okByName[a.name] && (
+                        <>
+                          {" · "}
+                          <span
+                            className="text-green normal-case"
+                            title={
+                              zh
+                                ? "此證據連結最近一次自動重驗時,GitHub 上的狀態與宣稱相符"
+                                : "On the last automated re-check, the GitHub state of this evidence matched the declared status"
+                            }
+                          >
+                            {zh
+                              ? `證據現驗 ${verification.verifiedAt}`
+                              : `verified ${verification.verifiedAt}`}
+                          </span>
+                        </>
+                      )}
                     </p>
                     <p className="text-sm text-stone leading-relaxed mb-3">
                       {a.integration}

--- a/website/app/[locale]/integrate/page.tsx
+++ b/website/app/[locale]/integrate/page.tsx
@@ -2,6 +2,7 @@ import { Reveal } from "@/components/Reveal";
 import { loadSiteStats } from "@/lib/stats";
 import { locales, t, type Locale } from "@/lib/i18n";
 import type { Metadata } from "next";
+import Link from "next/link";
 
 export function generateStaticParams() {
   return locales.map((locale) => ({ locale }));
@@ -557,6 +558,73 @@ jobs:
               </a>
             </div>
           </div>
+        </div>
+      </Reveal>
+
+      {/* Self-serve close: what to do after you ship. No sales step anywhere
+          in the loop — integrate, ask if stuck, then list yourself. */}
+      <Reveal>
+        <div className="mt-12 border border-fog px-6 py-6">
+          <div className="font-data text-xs text-stone tracking-[2px] uppercase mb-4">
+            {locale === "zh" ? "出貨之後" : "After you ship"}
+          </div>
+          <ol className="grid grid-cols-1 md:grid-cols-3 gap-6 list-none">
+            <li>
+              <div className="font-data text-xs text-stone mb-1">1</div>
+              <h3 className="font-display text-sm font-semibold text-ink mb-1">
+                {locale === "zh" ? "卡住了?開 Integration Request" : "Stuck? Open an Integration Request"}
+              </h3>
+              <p className="text-sm text-stone leading-relaxed mb-2">
+                {locale === "zh"
+                  ? "spec walkthrough、design review、你的語言的 sample code。維護者七天內回覆。"
+                  : "Spec walkthrough, design review, sample code for your language. Maintainers respond within seven days."}
+              </p>
+              <a
+                href="https://github.com/Agent-Threat-Rule/agent-threat-rules/issues/new?template=integration-request.yml"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="font-data text-xs text-blue hover:underline"
+              >
+                {locale === "zh" ? "開 issue →" : "Open issue →"}
+              </a>
+            </li>
+            <li>
+              <div className="font-data text-xs text-stone mb-1">2</div>
+              <h3 className="font-display text-sm font-semibold text-ink mb-1">
+                {locale === "zh" ? "上線了?自己列進 ADOPTERS.md" : "Shipped? List yourself in ADOPTERS.md"}
+              </h3>
+              <p className="text-sm text-stone leading-relaxed mb-2">
+                {locale === "zh"
+                  ? "採用者自行提 PR,維護者不預先審核——schema 對、附公開可驗證的證據連結就 merge。你的 PR 本身就是紀錄。"
+                  : "Adopters self-declare via PR — no pre-approval. A schema-conforming entry with a verifiable evidence link gets merged. Your PR is the record."}
+              </p>
+              <a
+                href="https://github.com/Agent-Threat-Rule/agent-threat-rules/blob/main/.github/PULL_REQUEST_TEMPLATE/adopter.md"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="font-data text-xs text-blue hover:underline"
+              >
+                {locale === "zh" ? "adopter PR 模板 →" : "Adopter PR template →"}
+              </a>
+            </li>
+            <li>
+              <div className="font-data text-xs text-stone mb-1">3</div>
+              <h3 className="font-display text-sm font-semibold text-ink mb-1">
+                {locale === "zh" ? "進採用者牆,證據週週重驗" : "You join the wall — evidence re-verified weekly"}
+              </h3>
+              <p className="text-sm text-stone leading-relaxed mb-2">
+                {locale === "zh"
+                  ? "生態頁直接讀 ADOPTERS.md 渲染,CI 每週對 GitHub 重驗每個證據連結並蓋上日期。"
+                  : "The ecosystem page renders straight from ADOPTERS.md, and CI re-verifies every evidence link against GitHub weekly, stamping the date."}
+              </p>
+              <Link
+                href={`/${locale}/ecosystem`}
+                className="font-data text-xs text-blue hover:underline"
+              >
+                {locale === "zh" ? "看採用者牆 →" : "See the wall →"}
+              </Link>
+            </li>
+          </ol>
         </div>
       </Reveal>
     </div>

--- a/website/app/[locale]/page.tsx
+++ b/website/app/[locale]/page.tsx
@@ -7,7 +7,9 @@ import { StatsHydrator } from "@/components/StatsHydrator";
 import { NumberScramble } from "@/components/NumberScramble";
 import { Flywheel } from "@/components/Flywheel";
 import { HeroGrid } from "@/components/DotGrid";
+import { EcosystemWall } from "@/components/EcosystemWall";
 import { loadSiteStats } from "@/lib/stats";
+import { getSpecMeta } from "@/lib/spec-meta";
 import { loadAllRules, getCategories, categoryDisplayName } from "@/lib/rules";
 import { locales, type Locale } from "@/lib/i18n";
 import Link from "next/link";
@@ -76,6 +78,20 @@ export default async function Home({ params }: { params: Promise<{ locale: strin
   );
   const categoryCount = taxonomy.length;
   const mergedCount = stats.ecosystemIntegrations.filter(e => e.type === "merged").length;
+  const specVersion = getSpecMeta().version;
+  // Tier 1 in ADOPTERS.md = shipped in a publicly-available product.
+  const productionCount = stats.ecosystemIntegrations.filter(
+    (e) => e.tier === "1" && e.type === "merged",
+  ).length;
+  // The home logo wall shows standards bodies, production deployments, and
+  // tooling/SDK integrations (tiers S/1/2). Catalogue and documentation
+  // references (tier 3) are summarised as a count with a pointer to /ecosystem.
+  const wallIntegrations = stats.ecosystemIntegrations.filter(
+    (e) => e.tier === "S" || e.tier === "1" || e.tier === "2",
+  );
+  const tier3Merged = stats.ecosystemIntegrations.filter(
+    (e) => e.tier === "3" && e.type === "merged",
+  ).length;
   // Pull garak recall from the version-pinned measurement (data/measurements/garak/latest.json)
   // rather than hardcoding — keeps the hero stat honest as the corpus is re-run.
   const garakMeasurement = stats.benchmarks.find((b) => b.source === "garak");
@@ -142,11 +158,11 @@ export default async function Home({ params }: { params: Promise<{ locale: strin
             <Link
               href={`${prefix}/spec`}
               className="mt-5 inline-flex flex-wrap items-center justify-center gap-x-2 gap-y-1 font-data text-[10px] md:text-[11px] tracking-[0.08em] uppercase text-stone hover:text-ink transition-colors px-3 py-1.5 border border-fog rounded-[2px] group"
-              aria-label={zh ? "規格 Working Draft v3.5.0" : "Specification Working Draft v3.5.0"}
+              aria-label={zh ? `規格 Working Draft v${specVersion}` : `Specification Working Draft v${specVersion}`}
             >
               <span className="text-ink font-semibold">Working Draft</span>
               <span className="text-fog">·</span>
-              <span>v3.5.0</span>
+              <span>v{specVersion}</span>
               <span className="text-fog">·</span>
               <span>{zh ? "正式網址" : "canonical"} <span className="text-ink group-hover:underline">/spec</span></span>
             </Link>
@@ -451,25 +467,23 @@ export default async function Home({ params }: { params: Promise<{ locale: strin
             </div>
           </Reveal>
 
-          {/* Standards bodies — one compact row */}
+          {/* Ecosystem wall — standards bodies, production deployments, and
+              tooling integrations, derived from ADOPTERS.md (single source of
+              truth) with the merging org's logo on every shipped entry. */}
           <Reveal delay={0.3}>
             <div className="mt-8 md:mt-10">
-              <div className="font-data text-[11px] md:text-xs text-stone tracking-[1.5px] md:tracking-[2px] uppercase mb-3">
-                {zh ? "標準同儕引用 ATR" : "Standards bodies referencing ATR"}
+              <div className="font-data text-[11px] md:text-xs text-stone tracking-[1.5px] md:tracking-[2px] uppercase mb-4">
+                {zh ? "誰在出貨這個標準" : "Who ships the standard"}
               </div>
-              <div className="grid grid-cols-2 md:grid-cols-4 gap-px bg-fog">
-                {[
-                  { name: "MISP / CIRCL", detail: zh ? "Taxonomy + Galaxy 已合併" : "Taxonomy + Galaxy merged", href: "https://github.com/MISP/misp-galaxy/pull/1207" },
-                  { name: "OWASP A-S-R-H", detail: zh ? "已合併" : "Merged", href: "https://github.com/OWASP/agent-security-regression-harness/pull/74" },
-                  { name: "NIST AI RMF (OSCAL)", detail: zh ? "oscal-content#338 審查中(非 NIST 背書)" : "oscal-content#338 in review (not a NIST endorsement)", href: "https://github.com/usnistgov/oscal-content/pull/338" },
-                  { name: "OpenTelemetry GenAI", detail: zh ? "agent.threat.detection.* 審查中" : "agent.threat.detection.* in review", href: "https://github.com/open-telemetry/semantic-conventions-genai/pull/165" },
-                ].map((item) => (
-                  <a key={item.name} href={item.href} target="_blank" rel="noopener noreferrer" className="bg-paper p-4 md:p-5 hover:bg-ash/40 transition-colors block">
-                    <div className="font-display text-sm font-semibold text-ink mb-1">{item.name}</div>
-                    <p className="font-data text-xs text-stone leading-relaxed text-pretty">{item.detail}</p>
-                  </a>
-                ))}
-              </div>
+              <EcosystemWall integrations={wallIntegrations} locale={locale} />
+              <p className="font-data text-xs text-stone mt-5">
+                {zh
+                  ? `另有 ${tier3Merged} 個公開目錄與文件索引收錄 ATR — `
+                  : `Plus ${tier3Merged} public catalogues and documentation indices listing ATR — `}
+                <Link href={`${prefix}/ecosystem`} className="text-blue hover:underline">
+                  {zh ? "完整採用清單" : "full adopter list"}
+                </Link>
+              </p>
             </div>
           </Reveal>
 
@@ -477,7 +491,7 @@ export default async function Home({ params }: { params: Promise<{ locale: strin
           <Reveal delay={0.35}>
             <div className="grid grid-cols-2 md:grid-cols-4 gap-px bg-fog mt-8 md:mt-10">
               {[
-                { num: "2", label: zh ? "已在生產環境" : "in production", sub: zh ? "Microsoft · Cisco" : "Microsoft, Cisco" },
+                { num: String(productionCount), label: zh ? "已在生產環境" : "in production", sub: zh ? "Microsoft · Cisco · Gen Digital" : "Microsoft, Cisco, Gen Digital" },
                 { num: String(stats.ruleCount), label: zh ? "條偵測規則" : "detection rules", sub: zh ? `跨 ${categoryCount} 個類別` : `across ${categoryCount} categories` },
                 { num: stats.megaScanTotal.toLocaleString(), label: zh ? "skills 已掃描" : "skills scanned", sub: zh ? "跨多個 registry" : "across registries" },
                 { num: `${mergedCount}/${stats.ecosystemIntegrations.length}`, label: zh ? "生態系 PR" : "ecosystem PRs", sub: zh ? "已合併" : "merged" },
@@ -523,8 +537,8 @@ export default async function Home({ params }: { params: Promise<{ locale: strin
           <Reveal delay={0.15}>
             <p className="text-sm md:text-base text-graphite font-light max-w-[640px] mb-6 md:mb-8 leading-[1.8] text-pretty">
               {zh
-                ? <>紅隊大掃描與 CVE 匯入兩條管線每天運轉:新攻擊被語義層抓到後,「結晶」成 regex 規則回流標準——從每次 500ms 的推理,變成 5ms 的 pattern match。自動結晶化把標準從 462 條長到 {stats.ruleCount} 條,全部隨 npm <span className="font-data text-graphite">agent-threat-rules@3.5.0</span> 發布。</>
-                : <>A red-team mega-scan pipeline and a CVE-ingestion pipeline run daily: when the semantic layer catches a novel attack, it crystallizes into a regex rule and flows back into the standard — turning a 500ms inference into a 5ms pattern match. Auto-crystallization grew the standard from 462 to {stats.ruleCount} rules, all shipped in npm <span className="font-data text-graphite">agent-threat-rules@3.5.0</span>.</>}
+                ? <>紅隊大掃描與 CVE 匯入兩條管線每天運轉:新攻擊被語義層抓到後,「結晶」成 regex 規則回流標準——從每次 500ms 的推理,變成 5ms 的 pattern match。自動結晶化把標準從 462 條長到 {stats.ruleCount} 條,全部隨 npm <span className="font-data text-graphite">agent-threat-rules@{specVersion}</span> 發布。</>
+                : <>A red-team mega-scan pipeline and a CVE-ingestion pipeline run daily: when the semantic layer catches a novel attack, it crystallizes into a regex rule and flows back into the standard — turning a 500ms inference into a 5ms pattern match. Auto-crystallization grew the standard from 462 to {stats.ruleCount} rules, all shipped in npm <span className="font-data text-graphite">agent-threat-rules@{specVersion}</span>.</>}
             </p>
           </Reveal>
           <Reveal delay={0.18}>
@@ -542,7 +556,7 @@ export default async function Home({ params }: { params: Promise<{ locale: strin
             <div className="flex flex-wrap items-center gap-x-3 gap-y-1.5 font-data text-[11px] md:text-xs text-stone mb-8 md:mb-10">
               <span className="inline-flex items-center gap-1.5">
                 <span className="w-1.5 h-1.5 rounded-full bg-green inline-block" aria-hidden="true" />
-                <span className="text-ink font-semibold">agent-threat-rules@3.5.0</span>
+                <span className="text-ink font-semibold">agent-threat-rules@{specVersion}</span>
               </span>
               <span className="text-fog">·</span>
               <span><span className="text-ink font-semibold">{stats.ruleCount}</span> {zh ? "條規則" : "rules"}</span>

--- a/website/app/[locale]/page.tsx
+++ b/website/app/[locale]/page.tsx
@@ -163,6 +163,12 @@ export default async function Home({ params }: { params: Promise<{ locale: strin
               <span className="text-ink font-semibold">Working Draft</span>
               <span className="text-fog">·</span>
               <span>v{specVersion}</span>
+              {stats.lastRegenerated && (
+                <>
+                  <span className="text-fog">·</span>
+                  <span>{zh ? `最新發布 ${stats.lastRegenerated}` : `latest release ${stats.lastRegenerated}`}</span>
+                </>
+              )}
               <span className="text-fog">·</span>
               <span>{zh ? "正式網址" : "canonical"} <span className="text-ink group-hover:underline">/spec</span></span>
             </Link>

--- a/website/app/[locale]/quality-standard/page.tsx
+++ b/website/app/[locale]/quality-standard/page.tsx
@@ -1,5 +1,6 @@
 import { Reveal } from "@/components/Reveal";
 import { DocumentStatus } from "@/components/spec/DocumentStatus";
+import { getSpecMeta } from "@/lib/spec-meta";
 import { locales, t, type Locale } from "@/lib/i18n";
 import type { Metadata } from "next";
 
@@ -272,7 +273,7 @@ export default async function QualityStandardPage({
             rel="noopener noreferrer"
             className="font-data text-xs text-stone hover:text-ink transition-colors border border-fog px-4 py-2.5 rounded-sm"
           >
-            npm install agent-threat-rules@3.5.0
+            {`npm install agent-threat-rules@${getSpecMeta().version}`}
           </a>
         </div>
       </Reveal>
@@ -877,7 +878,7 @@ export default async function QualityStandardPage({
             </span>
           </div>
           <pre className="font-data text-xs md:text-sm text-ink p-5 overflow-x-auto">
-            npm install agent-threat-rules@3.5.0
+            {`npm install agent-threat-rules@${getSpecMeta().version}`}
           </pre>
         </div>
       </Reveal>

--- a/website/app/[locale]/research/page.tsx
+++ b/website/app/[locale]/research/page.tsx
@@ -2,6 +2,7 @@ import { Reveal } from "@/components/Reveal";
 import { CountUp } from "@/components/CountUp";
 import { StatsHydrator } from "@/components/StatsHydrator";
 import { loadSiteStats } from "@/lib/stats";
+import { getSpecMeta } from "@/lib/spec-meta";
 import { locales, t, type Locale } from "@/lib/i18n";
 import type { Metadata } from "next";
 
@@ -309,8 +310,8 @@ export default async function ResearchPage({ params }: { params: Promise<{ local
       <Reveal delay={0.15}>
         <p className="text-sm text-graphite leading-[1.7] mb-6 max-w-[760px]">
           {locale === "zh"
-            ? `這個掃描不是一份報告，是一條每天運轉的迴圈。新攻擊出現 → 結晶成偵測規則 → 回流標準：紅隊巨量掃描與 CVE 攝取兩條飛輪各自跑完整輪後轉為每日更新，把規則集從 462 條推進到目前的 ${stats.ruleCount} 條（新增 190 條，npm agent-threat-rules@3.5.0）。這就是「標準活著」的意思——不是一次性的快照，而是與威脅同速演化的層。`
-            : `This scan is not a report — it is a loop that runs every day. New attack appears → crystallizes into a detection rule → flows back into the standard. A red-team mega-scan flywheel and a CVE-ingestion flywheel each completed a full sweep, then moved to daily updates, taking the ruleset from 462 to the current ${stats.ruleCount} (190 new rules, npm agent-threat-rules@3.5.0). This is what it means for a standard to be alive: not a one-time snapshot, but a layer that evolves at the speed of the threats it covers.`}
+            ? `這個掃描不是一份報告，是一條每天運轉的迴圈。新攻擊出現 → 結晶成偵測規則 → 回流標準：紅隊巨量掃描與 CVE 攝取兩條飛輪各自跑完整輪後轉為每日更新，把規則集從 462 條推進到目前的 ${stats.ruleCount} 條（新增 ${stats.ruleCount - 462} 條，npm agent-threat-rules@${getSpecMeta().version}）。這就是「標準活著」的意思——不是一次性的快照，而是與威脅同速演化的層。`
+            : `This scan is not a report — it is a loop that runs every day. New attack appears → crystallizes into a detection rule → flows back into the standard. A red-team mega-scan flywheel and a CVE-ingestion flywheel each completed a full sweep, then moved to daily updates, taking the ruleset from 462 to the current ${stats.ruleCount} (${stats.ruleCount - 462} new rules, npm agent-threat-rules@${getSpecMeta().version}). This is what it means for a standard to be alive: not a one-time snapshot, but a layer that evolves at the speed of the threats it covers.`}
         </p>
       </Reveal>
       <Reveal delay={0.2}>

--- a/website/components/IntegrationTypeIcon.tsx
+++ b/website/components/IntegrationTypeIcon.tsx
@@ -1,0 +1,150 @@
+import type { IntegrationType } from "@/lib/adopters";
+
+/**
+ * Minimal stroke icons for the ADOPTERS.md integration-type enum, so an
+ * engineer scanning the ecosystem page can read the SHAPE of each
+ * integration at a glance (run the engine? import the rules? convert the
+ * format?) before reading any prose. Pure inline SVG — no icon library,
+ * no client JS.
+ */
+
+const STROKE = {
+  fill: "none",
+  stroke: "currentColor",
+  strokeWidth: 1.5,
+  strokeLinecap: "round" as const,
+  strokeLinejoin: "round" as const,
+};
+
+function pathsFor(type: IntegrationType): React.ReactNode {
+  switch (type) {
+    case "engine":
+      // CPU chip: die + pins
+      return (
+        <>
+          <rect x="4.5" y="4.5" width="7" height="7" rx="1" {...STROKE} />
+          <path d="M6.5 4.5v-2M9.5 4.5v-2M6.5 13.5v-2M9.5 13.5v-2M4.5 6.5h-2M4.5 9.5h-2M13.5 6.5h-2M13.5 9.5h-2" {...STROKE} />
+        </>
+      );
+    case "rule-import":
+      // Arrow down into a tray
+      return (
+        <>
+          <path d="M8 2.5v7M5.5 7L8 9.5 10.5 7" {...STROKE} />
+          <path d="M2.5 10.5v2a1 1 0 0 0 1 1h9a1 1 0 0 0 1-1v-2" {...STROKE} />
+        </>
+      );
+    case "category-subset":
+      // Funnel
+      return (
+        <path d="M2.5 3.5h11L9.5 8.5v4l-3 1v-5L2.5 3.5Z" {...STROKE} />
+      );
+    case "adapter":
+      // Plug
+      return (
+        <>
+          <path d="M5.5 2.5v3M10.5 2.5v3" {...STROKE} />
+          <path d="M4 5.5h8v2.5a4 4 0 0 1-8 0V5.5Z" {...STROKE} />
+          <path d="M8 12v2" {...STROKE} />
+        </>
+      );
+    case "reference":
+      // Open book
+      return (
+        <path d="M8 3.5c-1.2-1-3.2-1-5.5-.7v9.7c2.3-.3 4.3-.3 5.5.7 1.2-1 3.2-1 5.5-.7V2.8c-2.3-.3-4.3-.3-5.5.7Zm0 0v10" {...STROKE} />
+      );
+    case "sidecar-proxy":
+      // Shield beside a service box
+      return (
+        <>
+          <rect x="2" y="4.5" width="6" height="7" rx="1" {...STROKE} />
+          <path d="M11.5 4l2.5 1v3c0 2-1.2 3.3-2.5 4-1.3-.7-2.5-2-2.5-4V5l2.5-1Z" {...STROKE} />
+        </>
+      );
+    default:
+      // "other" — node with link
+      return (
+        <>
+          <circle cx="8" cy="8" r="2.5" {...STROKE} />
+          <path d="M10.5 8h3M2.5 8h3" {...STROKE} />
+        </>
+      );
+  }
+}
+
+/** Human label for an integration type. */
+export function integrationTypeLabel(
+  type: IntegrationType,
+  locale: "en" | "zh",
+): string {
+  const labels: Record<IntegrationType, { en: string; zh: string }> = {
+    engine: { en: "engine", zh: "引擎實作" },
+    "rule-import": { en: "rule-import", zh: "規則匯入" },
+    "category-subset": { en: "category-subset", zh: "類別子集" },
+    adapter: { en: "adapter", zh: "格式轉接" },
+    reference: { en: "reference", zh: "文件引用" },
+    "sidecar-proxy": { en: "sidecar-proxy", zh: "旁路代理" },
+    other: { en: "other", zh: "其他" },
+  };
+  return labels[type][locale];
+}
+
+/** One-line, engineer-facing meaning of each integration shape. */
+export function integrationTypeHint(
+  type: IntegrationType,
+  locale: "en" | "zh",
+): string {
+  const hints: Record<IntegrationType, { en: string; zh: string }> = {
+    engine: {
+      en: "Implements a conforming ATR evaluation engine",
+      zh: "實作一個符合規範的 ATR 評估引擎",
+    },
+    "rule-import": {
+      en: "Consumes the ATR rule corpus inside its own scanner",
+      zh: "把 ATR 規則集吃進自己的掃描器",
+    },
+    "category-subset": {
+      en: "Imports a subset of ATR categories",
+      zh: "匯入部分 ATR 類別",
+    },
+    adapter: {
+      en: "Converts ATR to/from another rule format",
+      zh: "在 ATR 與其他規則格式之間轉換",
+    },
+    reference: {
+      en: "References ATR in a catalogue, taxonomy, or docs",
+      zh: "在目錄、分類法或文件中引用 ATR",
+    },
+    "sidecar-proxy": {
+      en: "Runs ATR as a proxy/callback layer beside the agent",
+      zh: "以代理/回呼層在 agent 旁運行 ATR",
+    },
+    other: {
+      en: "Integration shape not covered by the enum",
+      zh: "枚舉未涵蓋的整合形狀",
+    },
+  };
+  return hints[type][locale];
+}
+
+export function IntegrationTypeIcon({
+  type,
+  size = 16,
+  className,
+}: {
+  type: IntegrationType;
+  size?: number;
+  className?: string;
+}) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 16 16"
+      aria-hidden="true"
+      className={className}
+    >
+      {pathsFor(type)}
+    </svg>
+  );
+}

--- a/website/lib/adopters.ts
+++ b/website/lib/adopters.ts
@@ -146,12 +146,17 @@ function parseEntry(block: string, tier: AdopterTier): Adopter | null {
   }
 
   // Evidence values may be wrapped in angle brackets `<url>`, the markdown
-  // autolink form, or a `[label](url)` pair. Normalise to the URL.
+  // autolink form, a `[label](url)` pair, or carry trailing prose ("<url>
+  // (and predecessor PoC #79)") or multiple autolinks ("<url> and <url>").
+  // Normalise to the FIRST canonical URL so links and derived logos never
+  // receive a malformed value.
   let evidenceUrl = evidence;
-  const angleMatch = evidence.match(/^<(.+)>$/);
-  if (angleMatch) evidenceUrl = angleMatch[1];
+  const angleMatch = evidence.match(/<(https?:\/\/[^>\s]+)>/);
   const linkMatch = evidence.match(/^\[.*?\]\((.+?)\)/);
-  if (linkMatch) evidenceUrl = linkMatch[1];
+  const bareMatch = evidence.match(/https?:\/\/[^\s>)]+/);
+  if (angleMatch) evidenceUrl = angleMatch[1];
+  else if (linkMatch) evidenceUrl = linkMatch[1];
+  else if (bareMatch) evidenceUrl = bareMatch[0];
 
   const categories = categoriesRaw
     ? categoriesRaw
@@ -271,6 +276,22 @@ export function loadAdopters(): AdoptersData {
     tier4: byTier["4"],
     count,
   };
+}
+
+/**
+ * Derive a display logo for an adopter from its evidence URL: the GitHub
+ * organisation avatar of the repo the evidence lives in. Zero-maintenance
+ * and honest — it is the org whose repository merged (or is reviewing) the
+ * integration. Returns undefined for non-GitHub evidence so callers can
+ * render a text-only fallback.
+ */
+export function adopterLogoUrl(
+  adopter: Adopter,
+  size = 128,
+): string | undefined {
+  const match = adopter.evidence.match(/^https:\/\/github\.com\/([^/]+)\//);
+  if (!match) return undefined;
+  return `https://github.com/${match[1]}.png?size=${size}`;
 }
 
 /**

--- a/website/lib/adopters.ts
+++ b/website/lib/adopters.ts
@@ -279,6 +279,55 @@ export function loadAdopters(): AdoptersData {
 }
 
 /**
+ * Verification stamp produced by scripts/verify-adopters.mjs (run weekly in
+ * CI and on every ADOPTERS.md change): every evidence link re-checked
+ * against GitHub — shipped must be MERGED, in-review must be OPEN. The
+ * website surfaces the date and the per-entry result so "adopter" is a
+ * checked claim, not a remembered one.
+ */
+export interface AdoptersVerification {
+  /** YYYY-MM-DD the evidence links were last re-verified. */
+  verifiedAt: string;
+  /** Entries checked / entries that matched their declared status. */
+  total: number;
+  ok: number;
+  /** Per-adopter result keyed by entry name; true = evidence matches claim. */
+  okByName: Record<string, boolean>;
+}
+
+/**
+ * Load data/adopters-verification.json. Returns null when the file is
+ * missing or unparsable — the page then simply omits the stamp rather
+ * than failing the build or (worse) showing a fabricated date.
+ */
+export function loadAdoptersVerification(): AdoptersVerification | null {
+  try {
+    const raw = JSON.parse(
+      readFileSync(
+        join(process.cwd(), "..", "data", "adopters-verification.json"),
+        "utf-8",
+      ),
+    ) as {
+      verified_at?: string;
+      total?: number;
+      ok?: number;
+      results?: Array<{ name: string; ok: boolean }>;
+    };
+    if (!raw.verified_at || !Array.isArray(raw.results)) return null;
+    const okByName: Record<string, boolean> = {};
+    for (const r of raw.results) okByName[r.name] = r.ok;
+    return {
+      verifiedAt: raw.verified_at,
+      total: raw.total ?? raw.results.length,
+      ok: raw.ok ?? raw.results.filter((r) => r.ok).length,
+      okByName,
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Derive a display logo for an adopter from its evidence URL: the GitHub
  * organisation avatar of the repo the evidence lives in. Zero-maintenance
  * and honest — it is the org whose repository merged (or is reviewing) the

--- a/website/lib/i18n.ts
+++ b/website/lib/i18n.ts
@@ -219,7 +219,7 @@ export const messages: Record<Locale, Record<string, string>> = {
     "coverage.label": "Standards Coverage",
     "coverage.heading": "The frameworks name the threat. ATR runs it.",
     "coverage.sub":
-      "MITRE ATLAS, OWASP, NIST AI RMF, ISO 42001 — six frameworks classify what can go wrong. ATR is the executable layer underneath: detection that fires on a real agent artifact. Every one of the 652 rules carries mappings into all six frameworks, enforced in CI.",
+      "MITRE ATLAS, OWASP, NIST AI RMF, ISO 42001 — six frameworks classify what can go wrong. ATR is the executable layer underneath: detection that fires on a real agent artifact. Every rule carries mappings into all six frameworks, enforced in CI.",
     "integrate.label": "Integrate",
     "integrate.heading": "Four paths. Same destination.",
     "research.label": "Research",
@@ -607,7 +607,7 @@ export const messages: Record<Locale, Record<string, string>> = {
     "coverage.heading":
       "\u6846\u67B6\u5B9A\u7FA9\u5A01\u8105\uff0CATR \u8B93\u5B83\u8DD1\u8D77\u4F86\u3002",
     "coverage.sub":
-      "MITRE ATLAS\u3001OWASP\u3001NIST AI RMF\u3001ISO 42001\u2014\u2014\u516D\u500B\u6846\u67B6\u5206\u985E\u300C\u4EC0\u9EBC\u6703\u51FA\u932F\u300D\u3002ATR \u662F\u5176\u4E0B\u53EF\u57F7\u884C\u7684\u90A3\u4E00\u5C64\uFF1A\u80FD\u5728\u771F\u5BE6 agent \u6210\u54C1\u4E0A\u958B\u706B\u7684\u5075\u6E2C\u3002652 \u689D\u898F\u5247\u6BCF\u4E00\u689D\u90FD\u5E36\u6709\u9019\u516D\u500B\u6846\u67B6\u7684\u5C0D\u61C9\uff0C\u4E26\u7531 CI \u5F37\u5236\u3002",
+      "MITRE ATLAS\u3001OWASP\u3001NIST AI RMF\u3001ISO 42001\u2014\u2014\u516D\u500B\u6846\u67B6\u5206\u985E\u300C\u4EC0\u9EBC\u6703\u51FA\u932F\u300D\u3002ATR \u662F\u5176\u4E0B\u53EF\u57F7\u884C\u7684\u90A3\u4E00\u5C64\uFF1A\u80FD\u5728\u771F\u5BE6 agent \u6210\u54C1\u4E0A\u958B\u706B\u7684\u5075\u6E2C\u3002\u6BCF\u4E00\u689D\u898F\u5247\u90FD\u5E36\u6709\u9019\u516D\u500B\u6846\u67B6\u7684\u5C0D\u61C9\uff0C\u4E26\u7531 CI \u5F37\u5236\u3002",
     "integrate.label": "Integrate",
     "integrate.heading":
       "\u56DB\u689D\u8DEF\u5F91\u3002\u540C\u4E00\u500B\u7D42\u9EDE\u3002",

--- a/website/lib/spec-meta.ts
+++ b/website/lib/spec-meta.ts
@@ -4,14 +4,25 @@
 // number: once the standard ships in production and is cited by third parties,
 // a separate pre-1.0 spec-document number reads as half-baked. Status remains
 // "Working Draft" to register the governance transition (BDFL -> TSC) honestly.
-// Bump this when the package version bumps.
+// The version is read from the repo-root package.json at build time so it can
+// never drift from the published package again (it sat at a hardcoded 3.5.0
+// while npm shipped 3.5.6).
 
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { loadSiteStats } from "./stats";
 
-/** Public spec-document version, aligned to the npm package version (v3.5.0). */
-const SPEC_DOC_VERSION = "3.5.0";
+/** Public spec-document version, aligned to the npm package version. */
+const SPEC_DOC_VERSION = ((): string => {
+  try {
+    const pkg = JSON.parse(
+      readFileSync(join(process.cwd(), "..", "package.json"), "utf-8"),
+    ) as { version?: string };
+    return pkg.version ?? "unversioned";
+  } catch {
+    return "unversioned";
+  }
+})();
 
 interface StatsJsonShape {
   generatedAt?: string;

--- a/website/lib/stats.ts
+++ b/website/lib/stats.ts
@@ -1,6 +1,7 @@
 import { readFileSync, readdirSync, existsSync, statSync } from "node:fs";
 import { join } from "node:path";
 import { loadAllRules } from "./rules";
+import { loadAdopters, adopterLogoUrl, type Adopter, type AdopterTier } from "./adopters";
 
 const DATA_DIR = join(process.cwd(), "..", "data");
 const MEASUREMENTS_DIR = join(DATA_DIR, "measurements");
@@ -165,6 +166,8 @@ export interface EcosystemIntegration {
   detail: string;
   url?: string;
   logo?: string; // path to logo in public/ecosystem/ or external URL
+  /** ADOPTERS.md tier the entry came from (S/1/2/3/4). */
+  tier: AdopterTier;
 }
 
 /**
@@ -250,6 +253,34 @@ function isSafeUrl(url: string | undefined): boolean {
   }
 }
 
+/**
+ * Ecosystem integrations derived from ADOPTERS.md — the single source of
+ * truth for adoption (see lib/adopters.ts header). Tier order preserved
+ * (S -> 1 -> 2 -> 3 -> 4); "planning" entries are excluded because they
+ * carry no verifiable evidence yet. Status maps shipped -> "merged",
+ * in-review -> "open", matching the display vocabulary the pages use.
+ */
+function ecosystemFromAdopters(): EcosystemIntegration[] {
+  const adopters = loadAdopters();
+  const ordered: Adopter[] = [
+    ...adopters.tierS,
+    ...adopters.tier1,
+    ...adopters.tier2,
+    ...adopters.tier3,
+    ...adopters.tier4,
+  ];
+  return ordered
+    .filter((a) => a.status === "shipped" || a.status === "in-review")
+    .map((a) => ({
+      name: a.name,
+      type: a.status === "shipped" ? ("merged" as const) : ("open" as const),
+      detail: a.org,
+      url: isSafeUrl(a.evidence) ? a.evidence : undefined,
+      logo: adopterLogoUrl(a),
+      tier: a.tier,
+    }));
+}
+
 export function loadSiteStats(): SiteStats {
   const clawhub = readJson<ClawHubStats>(
     join(DATA_DIR, "clawhub-scan", "ecosystem-stats.json"),
@@ -270,6 +301,13 @@ export function loadSiteStats(): SiteStats {
   const statsJson = readJson<{ generatedAt?: string }>(
     join(DATA_DIR, "stats.json"),
   );
+  // Root stats.json is rewritten by CI on every rules-merge release, so its
+  // lastUpdated is the freshest honest "standard heartbeat". data/stats.json
+  // generatedAt only moves when the measurement pipeline reruns — keep it as
+  // the fallback.
+  const rootStatsJson = readJson<{ lastUpdated?: string }>(
+    join(process.cwd(), "..", "stats.json"),
+  );
 
   const rules = loadAllRules();
 
@@ -289,7 +327,8 @@ export function loadSiteStats(): SiteStats {
   return {
     ruleCount: rules.length,
     categoryCount: categories.size,
-    lastRegenerated: statsJson?.generatedAt?.slice(0, 10) ?? "",
+    lastRegenerated:
+      rootStatsJson?.lastUpdated ?? statsJson?.generatedAt?.slice(0, 10) ?? "",
 
     clawHubCrawled: clawhub?.totalCrawled ?? 36394,
     clawHubScanned: clawhub?.totalScanned ?? 9676,
@@ -337,201 +376,7 @@ export function loadSiteStats(): SiteStats {
 
     cveCount: cves.size || 16,
 
-    ecosystemIntegrations: [
-      // === Tier-1 standards bodies (merged by external maintainer) ===
-      {
-        name: "MISP Taxonomies",
-        type: "merged",
-        detail:
-          "PR #323 merged 2026-05-10 by adulau (MISP project lead). 10 ATR predicates + 330 rule IDs as MISP machine tags. CIRCL adoption.",
-        url: "https://github.com/MISP/misp-taxonomies/pull/323",
-        logo: "https://github.com/MISP.png?size=128",
-      },
-      {
-        name: "MISP Galaxy",
-        type: "merged",
-        detail:
-          "PR #1207 merged 2026-05-10 by adulau. 336 cluster values with kill-chain, severity, CVE / OWASP LLM / MITRE ATLAS cross-refs. 10,408 lines.",
-        url: "https://github.com/MISP/misp-galaxy/pull/1207",
-        logo: "https://github.com/MISP.png?size=128",
-      },
-      {
-        name: "Gen Digital Sage",
-        type: "merged",
-        detail:
-          "PR #33 merged 2026-05-11 by vaclavbelak (Norton / Avast / AVG parent security team). 7 privilege-escalation rules + ATR upstream bridge.",
-        url: "https://github.com/gendigitalinc/sage/pull/33",
-        logo: "https://github.com/gendigitalinc.png?size=128",
-      },
-      {
-        name: "Microsoft Agent Governance Toolkit",
-        type: "merged",
-        detail:
-          "PR #908 + #1277 merged. Weekly auto-sync workflow runs against ATR main. AGT #1981 (Copilot SWE Agent) generated regression fixtures presuming ATR coverage — closed loop 2026-05-11 in 2h 16m.",
-        url: "https://github.com/microsoft/agent-governance-toolkit/pull/1277",
-        logo: "https://github.com/microsoft.png?size=128",
-      },
-      {
-        name: "Cisco AI Defense",
-        type: "merged",
-        detail:
-          "PR #79 (34-rule PoC) + #99 merged. Full ATR rule pack (at time of PR #99) in skill-scanner production. Upstream maintained.",
-        url: "https://github.com/cisco-ai-defense/skill-scanner/pull/99",
-        logo: "https://github.com/cisco-ai-defense.png?size=128",
-      },
-      // === Curated awesome-list merges ===
-      {
-        name: "Awesome LM-SSP",
-        type: "merged",
-        detail: "PR #108 merged into LLM safety/security list.",
-        url: "https://github.com/ThuCCSLab/Awesome-LM-SSP/pull/108",
-        logo: "https://github.com/CryptoAILab.png?size=128",
-      },
-      {
-        name: "Agentic AI Top 10 Vulnerability",
-        type: "merged",
-        detail:
-          "PR #14 merged. ATR detection mapping for 12 vulnerability categories.",
-        url: "https://github.com/precize/Agentic-AI-Top10-Vulnerability/pull/14",
-        logo: "https://github.com/precize.png?size=128",
-      },
-      {
-        name: "Awesome LLM agent Security",
-        type: "merged",
-        detail: "PR #6 merged into LLM agent security tools list.",
-        url: "https://github.com/wearetyomsmnv/Awesome-LLM-agent-Security/pull/6",
-      },
-      {
-        name: "Awesome Agentic Patterns",
-        type: "merged",
-        detail:
-          "PR #58 merged. Deterministic Threat Rule Scanning pattern accepted.",
-        url: "https://github.com/nibzard/awesome-agentic-patterns/pull/58",
-      },
-      {
-        name: "Awesome AI Security",
-        type: "merged",
-        detail: "Merged into Agentic Systems section.",
-        url: "https://github.com/TalEliyahu/Awesome-AI-Security/pull/53",
-      },
-      // === Open PRs / draft conversations (standards + frameworks) ===
-      {
-        name: "FINOS Common Cloud Controls",
-        type: "open",
-        detail:
-          "PR #986 draft open. ATR guideline-mappings for CN01/CN02/CN04/CN06 + Gemara MappingReference. CI green, CLA signed. Linux Foundation project.",
-        url: "https://github.com/finos/common-cloud-controls/pull/986",
-        logo: "https://github.com/finos.png?size=128",
-      },
-      {
-        name: "NIST OSCAL",
-        type: "open",
-        detail:
-          "Submission in review; the OSCAL lead opened collaboration branch oscal-content#338 (rework of #333) and invited a community contribution. Not a NIST endorsement or adoption.",
-        url: "https://github.com/usnistgov/oscal-content/pull/338",
-        logo: "https://github.com/usnistgov.png?size=128",
-      },
-      {
-        name: "rulezet (CIRCL)",
-        type: "open",
-        detail:
-          "Issue #49 + PR #50 draft. atr_format.py converter mirroring sigma_format with 24 unit tests. CIRCL maintainer Théo GEFFE.",
-        url: "https://github.com/rulezet/rulezet-core/pull/50",
-      },
-      {
-        name: "OWASP LLM Top 10",
-        type: "open",
-        detail:
-          "PR #814 open. Detection mapping for ASI01-ASI10; engaged by reviewer desiorac with substantive feedback rounds.",
-        url: "https://github.com/OWASP/www-project-top-10-for-large-language-model-applications/pull/814",
-        logo: "https://github.com/OWASP.png?size=128",
-      },
-      {
-        name: "SAFE-MCP",
-        type: "open",
-        detail:
-          "Issue #207 open at safe-agentic-framework/safe-mcp. Structured proposal for a detections/ registry to support cross-project rule-ID linkage.",
-        url: "https://github.com/safe-agentic-framework/safe-mcp/issues/207",
-      },
-      // === Red team tooling (open) ===
-      {
-        name: "NVIDIA Garak",
-        type: "open",
-        detail:
-          "Integration PR #1676 open (not merged). ATR rules wrapped as garak detectors; under maintainer review.",
-        url: "https://github.com/NVIDIA/garak/pull/1676",
-        logo: "https://github.com/NVIDIA.png?size=128",
-      },
-      {
-        name: "Microsoft PyRIT",
-        type: "merged",
-        detail:
-          "PR #1715 merged. ATR adversarial-payload dataset loader for Microsoft's PyRIT red-team orchestration framework.",
-        url: "https://github.com/microsoft/PyRIT/pull/1715",
-        logo: "https://github.com/microsoft.png?size=128",
-      },
-      {
-        name: "NVIDIA NeMo Guardrails",
-        type: "open",
-        detail:
-          "PR #1869 open. ATR-inspired threat detection example library config; coderabbitai automated review clean.",
-        url: "https://github.com/NVIDIA-NeMo/Guardrails/pull/1869",
-        logo: "https://github.com/NVIDIA.png?size=128",
-      },
-      {
-        name: "Protect AI llm-guard",
-        type: "open",
-        detail:
-          "Issue #340. ATRScanner input/output scanner proposal following existing scanner pattern.",
-        url: "https://github.com/protectai/llm-guard/issues/340",
-      },
-      {
-        name: "PromptInject (NeurIPS 2022)",
-        type: "open",
-        detail:
-          "Issue #9. Attack-source integration — turn PromptInject's adversarial corpus into ATR detection coverage.",
-        url: "https://github.com/agencyenterprise/PromptInject/issues/9",
-      },
-      {
-        name: "Promptfoo",
-        type: "open",
-        detail:
-          "PR #8529 submitted. MCP red team example with ATR deterministic defense.",
-        url: "https://github.com/promptfoo/promptfoo/pull/8529",
-      },
-      {
-        name: "Damn Vulnerable MCP Server",
-        type: "open",
-        detail:
-          "PR #29 submitted. Blue team detection guide for all 10 challenges.",
-        url: "https://github.com/harishsg993010/damn-vulnerable-MCP-server/pull/29",
-      },
-      {
-        name: "Meta PurpleLlama",
-        type: "open",
-        detail:
-          "PR #206 open. RegexScanner expansion with 20 ATR-derived agent threat patterns. Multi-round maintainer follow-up; awaiting Meta internal CI gate.",
-        url: "https://github.com/meta-llama/PurpleLlama/pull/206",
-      },
-      {
-        name: "Awesome Cybersecurity Agentic AI",
-        type: "open",
-        detail: "PR #24 submitted to Tools section.",
-        url: "https://github.com/raphabot/awesome-cybersecurity-agentic-ai/pull/24",
-      },
-      {
-        name: "Awesome AI Agents Security",
-        type: "merged",
-        detail: "PR #17 merged into Static Analysis & Linters.",
-        url: "https://github.com/ProjectRecon/awesome-ai-agents-security/pull/17",
-      },
-      {
-        name: "Awesome AI Security (ottosulin)",
-        type: "merged",
-        detail: "PR #192 merged 2026-05-18 into MCP Security section.",
-        url: "https://github.com/ottosulin/awesome-ai-security/pull/192",
-      },
-    ],
+    ecosystemIntegrations: ecosystemFromAdopters(),
 
     owaspAgentic: "10/10",
     safeMcp: "78/85 (91.8%)",


### PR DESCRIPTION
Summary

Every ecosystem PR state was re-verified against GitHub today (gh pr view on 40+ PRs) and the website was refreshed to the live repo truth (683 rules, npm v3.5.6).

ADOPTERS.md (re-verified 2026-07-05)

- Add shipped: FINOS Common Cloud Controls #986 (merged 07-02, Tier S), rulezet/CIRCL #50, AMD GAIA #1809, ProjectRecon #17, raphabot #24
- Add in-review: NVIDIA NeMo Guardrails #1992, Cisco a2a-scanner #14
- Remove Google ADK #6130 (closed unmerged) to Removed entries

README

- Section 6 adoption table refreshed to 2026-07-05 (+6 merged rows: OWASP ASRH, PyRIT, SigmaHQ, rulezet, AMD GAIA, FINOS); under-review list rebuilt from verified-OPEN PRs only (drops closed IBM #4109 and CCCS-Yara #100)
- Section 7: OWASP Agentic mappings recounted from disk (1,179 mappings across all 683 tagged rules); category table re-summed to 683
- Wild-scan phrasing aligned to canonical 1,302 flagged / 552 confirmed after manual review

Website

- lib/stats.ts: hardcoded 195-line ecosystemIntegrations array (drifted; pointed at closed Guardrails #1869) replaced with a derivation from ADOPTERS.md - single source of truth, per lib/adopters.ts doctrine
- Home: mounts the previously-orphaned EcosystemWall logo wall (org logos for shipped tier S/1/2 adopters + under-review chips); production count and 19/33 ecosystem stat now derived
- /ecosystem: org logos on every adopter card (GitHub org avatar derived from evidence URL)
- lib/spec-meta.ts: spec version read from root package.json at build time (was hardcoded 3.5.0 while npm shipped 3.5.6)
- Stale current-state facts purged: 652-rule copy in i18n (EN+ZH), home npm pins, research 462-to-current delta, quality-standard install pins, about timeline reframed as dated history
- Standard heartbeat now prefers root stats.json lastUpdated (CI-refreshed every release)

Verification

- typecheck green, production build green (1445 static pages), EN/ZH
- Home wall and /ecosystem verified in a live browser: 9 logo cards render with correct evidence links; adopter total 33 (19 shipped) auto-updates from ADOPTERS.md (AG2 entry merged upstream mid-branch flowed through with zero code changes)