### PR TITLE
perf(safety-gate): scope corpus-FP checks to new rules only (~100x faster)

### DIFF
--- a/scripts/check-rules-safety.ts
+++ b/scripts/check-rules-safety.ts
@@ -31,8 +31,17 @@
  */
 
 import { execFileSync } from "node:child_process";
-import { readFileSync, readdirSync, existsSync, statSync } from "node:fs";
-import { join, resolve, dirname } from "node:path";
+import {
+  readFileSync,
+  readdirSync,
+  existsSync,
+  statSync,
+  mkdtempSync,
+  copyFileSync,
+  rmSync,
+} from "node:fs";
+import { join, resolve, dirname, basename } from "node:path";
+import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
 import { load as yamlLoad } from "js-yaml";
 import { ATREngine } from "../src/engine.js";
@@ -614,6 +623,31 @@ async function main(): Promise<void> {
       }
     };
 
+    // Perf: the corpus-FP checks (Checks 3/3b/3c/4) only ask whether a NEW
+    // rule matches a benign sample. Running the full ~690-rule engine over
+    // thousands of samples spends ~99% of its time evaluating rules whose
+    // result is discarded. Per-event preprocessing (base64/unicode folding,
+    // skill parsing) is content-driven, not rule-set-driven, so a scoped
+    // engine holding ONLY the new rules yields the identical new-rule match
+    // set at ~100x less work. Verified empirically: scoped+promoted
+    // reproduces the full-engine FP set exactly (same rules, same counts).
+    // The full engine is still used for own-TP (Check 2) and cross-rule
+    // conflict (Check 5, which must see every existing rule's true_negatives).
+    const scopedDir = mkdtempSync(join(tmpdir(), "atr-safety-newrules-"));
+    for (const f of newFiles) {
+      copyFileSync(join(REPO_ROOT, f), join(scopedDir, basename(f)));
+    }
+    const scopedEngine = new ATREngine({ rulesDir: scopedDir });
+    await scopedEngine.loadRules();
+    for (const id of newRuleIds) {
+      const rule = scopedEngine.getRuleById(id) as
+        | Record<string, unknown>
+        | undefined;
+      if (rule && (rule['status'] === 'draft' || rule['status'] === 'test')) {
+        rule['status'] = 'active';
+      }
+    }
+
     // Check 2 — own TPs must actually match.
     const tpMisses = await checkOwnTruePositivesMatch(engine, ruleEntries);
     for (const [id, reasons] of tpMisses) {
@@ -627,7 +661,7 @@ async function main(): Promise<void> {
     }
 
     // Check 3 — benign skill corpus FP (432 SKILL.md samples).
-    const benignFps = await checkBenignCorpusFP(engine, newRuleIds);
+    const benignFps = await checkBenignCorpusFP(scopedEngine, newRuleIds);
     for (const [id, samples] of benignFps) {
       failures.push({
         file: fileToId.get(id) ?? id,
@@ -636,7 +670,7 @@ async function main(): Promise<void> {
     }
 
     // Check 3b — extended benign corpus FP (arxiv + npm + pypi).
-    const extendedFps = await checkExtendedBenignFP(engine, newRuleIds);
+    const extendedFps = await checkExtendedBenignFP(scopedEngine, newRuleIds);
     for (const [id, samples] of extendedFps) {
       failures.push({
         file: fileToId.get(id) ?? id,
@@ -646,7 +680,7 @@ async function main(): Promise<void> {
 
     // Check 3c — benign-CODE corpus FP (imports + normal library usage).
     // Hard gate against the import-FP class that slipped through before.
-    const codeFps = await checkBenignCodeFP(engine, newRuleIds);
+    const codeFps = await checkBenignCodeFP(scopedEngine, newRuleIds);
     for (const [id, samples] of codeFps) {
       failures.push({
         file: fileToId.get(id) ?? id,
@@ -655,7 +689,7 @@ async function main(): Promise<void> {
     }
 
     // Check 4 — research-mention corpus FP.
-    const mentionFps = await checkResearchMentionFP(engine, newRuleIds);
+    const mentionFps = await checkResearchMentionFP(scopedEngine, newRuleIds);
     for (const [id, samples] of mentionFps) {
       failures.push({
         file: fileToId.get(id) ?? id,
@@ -678,6 +712,7 @@ async function main(): Promise<void> {
 
     // Restore original statuses now that all FP checks are complete
     restoreStatuses();
+    rmSync(scopedDir, { recursive: true, force: true });
   }
 
   if (failures.length === 0) {


### PR DESCRIPTION
## Problem

The rule safety gate's benign-FP checks (Checks 3/3b/3c/4) evaluate the **full ~690-rule engine** against every sample in the benign corpora (basic 431 + extended 4,817 + code + research-mention). But those checks only ask one question: *does a NEW rule match this benign sample?* ~99% of the per-sample work evaluates rules whose result is discarded.

This was invisible until #256 fixed a crash that had been aborting the gate before it ran to completion. Once it actually ran, a 10-rule PR's gate took **43 minutes**.

## Fix

Build a **scoped engine holding only the new rules** (promoted to active) and run the four corpus-FP checks against that instead of the full engine. Per-event preprocessing (base64/unicode folding, skill parsing) is content-driven, not rule-set-driven, so the scoped engine returns the identical new-rule match set at a fraction of the work.

The full engine is still used where it must be:
- own-TP coverage (Check 2)
- cross-rule conflict (Check 5 — must see every existing rule's `true_negatives`)

## Soundness (verified empirically, not just argued)

Ran the optimized gate against two known rule sets:

| Input | Full gate (before) | Scoped gate (this PR) | Match? |
|---|---|---|---|
| 5 FP-prone rules | 01990:14+41, 01991:1, 01995:1, 01997:3, 01998:2 | **identical** — same rules, same sample counts, same named samples | ✓ |
| 5 clean rules | PASS | PASS | ✓ |

Same failures, same sample attribution — the scoped engine reproduces the full-engine FP set exactly.

## Speed

End-to-end `check-rules-safety.ts` on a 5-rule diff: **~90s** (was ~43 min). The corpus-FP scan itself is ~100x fewer rule evaluations; the residual 90s is npm/tsx startup + own-TP + cross-rule + rule loading.

No behaviour change to what the gate accepts or rejects — only how fast it decides.