### PR TITLE
docs: sync README/CITATION/package.json/crosswalk headers to 708 rules

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -3,7 +3,7 @@ message: "If you use ATR in academic work or security research, please cite it a
 title: "ATR: Agent Threat Rules — Open Detection Standard for AI Agent Threats"
 abstract: >
   ATR is an open-source detection rule set for AI agent threats, analogous to
-  Sigma for SIEM or YARA for malware. It provides 683 rules across 10 threat
+  Sigma for SIEM or YARA for malware. It provides 708 rules across 10 threat
   categories (prompt injection, tool poisoning, context exfiltration, skill
   compromise, model abuse, data poisoning, privilege escalation, excessive
   autonomy, model security), mapped to OWASP Agentic Top 10 (10/10), SAFE-MCP

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ AI Agent 威脅偵測規則的開放格式
 [![GitHub Marketplace](https://img.shields.io/badge/Marketplace-ATR%20Scan-2ea44f?style=flat-square&logo=github)](https://github.com/marketplace/actions/atr-scan)
 [![License: MIT](https://img.shields.io/badge/license-MIT-brightgreen?style=flat-square)](LICENSE)
 [![DOI](https://img.shields.io/badge/DOI-10.5281%2Fzenodo.19178002-blue?style=flat-square)](https://doi.org/10.5281/zenodo.19178002)
-[![Rules](https://img.shields.io/badge/rules-683-blue?style=flat-square)](#5-specification)
+[![Rules](https://img.shields.io/badge/rules-708-blue?style=flat-square)](#5-specification)
 [![Categories](https://img.shields.io/badge/categories-10-blue?style=flat-square)](#7-coverage)
 [![OWASP Agentic](https://img.shields.io/badge/OWASP_Agentic_Top_10-10%2F10-brightgreen?style=flat-square)](#7-coverage)
 [![SAFE-MCP](https://img.shields.io/badge/SAFE--MCP-91.8%25-brightgreen?style=flat-square)](#7-coverage)

--- a/docs/ETSI-TS-104223-MAPPING.md
+++ b/docs/ETSI-TS-104223-MAPPING.md
@@ -4,7 +4,7 @@ Version: 0.1.0 (INTERNAL DRAFT — not published)
 Status: Draft alignment mapping for ETSI TS 104 223 V1.1.1 and the UK NCSC/DSIT AI Cyber Security Code of Practice
 Date: 2026-06-12
 Editor: Adam Lin (林冠辛) <adam@agentthreatrule.org>
-Mapped corpus: Agent Threat Rules v3.5.2 (655 rules / 10 categories; disk == data/stats.json on 2026-06-29)
+Mapped corpus: Agent Threat Rules v3.5.2 (708 rules / 10 categories; disk == data/stats.json on 2026-06-29)
 Reference frameworks:
   - ETSI TS 104 223 V1.1.1 (2025-04) "Securing Artificial Intelligence (SAI); Baseline Cyber Security Requirements for AI Models and Systems"
   - UK AI Cyber Security Code of Practice (DSIT / NCSC), "Code of practice for the cyber security of AI"

--- a/docs/FINOS-AI-GOVERNANCE-MAPPING.md
+++ b/docs/FINOS-AI-GOVERNANCE-MAPPING.md
@@ -4,7 +4,7 @@ Version: 0.1.0 (INTERNAL DRAFT — not published, not submitted)
 Status: Draft for future FINOS AI Governance Framework Informative Reference / PR basis (human review gate before any upstream submission)
 Date: 2026-06-12
 Editor: Adam Lin (林冠辛) <adam@agentthreatrule.org>
-Mapped corpus: Agent Threat Rules v3.5.2 (655 rules / 10 categories, disk==stats.json verified 2026-06-29)
+Mapped corpus: Agent Threat Rules v3.5.2 (708 rules / 10 categories, disk==stats.json verified 2026-06-29)
 Reference framework: FINOS AI Governance Framework v2 (published 2025-10-20), Risk Catalogue
 Reference framework license: CC-BY-4.0 (finos/ai-governance-framework). Risk and
 mitigation text quoted below is reproduced under that license.

--- a/docs/FIVE-EYES-MAPPING.md
+++ b/docs/FIVE-EYES-MAPPING.md
@@ -1,6 +1,6 @@
 # ATR → Five Eyes "Careful Adoption of Agentic AI Services" Mapping
 
-- **ATR corpus version:** v3.5.2, 655 rules across 10 detection-rule categories
+- **ATR corpus version:** v3.5.2, 708 rules across 10 detection-rule categories
 - **Five Eyes guidance:** "Careful Adoption of Agentic AI Services", published 2026-04-30 on media.defense.gov, jointly authored by CISA (US) + NSA (US) + ASD-ACSC (Australia) + CCCS (Canada) + NCSC-UK + NCSC-NZ
 - **Document date:** 2026-06-05
 - **Maintainer:** Adam Lin (adam@agentthreatrule.org)

--- a/docs/MCP-38-MAPPING.md
+++ b/docs/MCP-38-MAPPING.md
@@ -1,7 +1,7 @@
 # ATR → MCP-38 Threat Taxonomy Mapping
 
 Last updated: 2026-06-20
-ATR corpus: v3.5.2, 655 rules (10 categories)
+ATR corpus: v3.5.2, 708 rules (10 categories)
 Source taxonomy: **MCP-38 — A Comprehensive Threat Taxonomy for Model Context
 Protocol Systems (v1.0)**, Shen, Toyoda & Leung, arXiv:2603.18063. 38 protocol-
 specific threat categories (MCP-01 … MCP-38) grouped into 5 tactic categories

--- a/docs/MITRE-ATLAS-MAPPING.md
+++ b/docs/MITRE-ATLAS-MAPPING.md
@@ -4,7 +4,7 @@ Version: 0.1.0 (INTERNAL DRAFT — not published)
 Status: Draft alignment mapping for MITRE ATLAS v5.6.0
 Date: 2026-06-14
 Editor: Adam Lin (林冠辛) <adam@agentthreatrule.org>
-Mapped corpus: Agent Threat Rules v3.5.2 (655 rules / 10 categories; disk == data/stats.json reconciled 2026-06-29)
+Mapped corpus: Agent Threat Rules v3.5.2 (708 rules / 10 categories; disk == data/stats.json reconciled 2026-06-29)
 Reference framework: MITRE ATLAS (Adversarial Threat Landscape for Artificial-Intelligence Systems), `dist/ATLAS.yaml` on mitre-atlas/atlas-data, v5.6.0 — 16 tactics, 101 top-level techniques (271 including sub-techniques), counted from the full machine-readable `dist/ATLAS.yaml`.
 
 ---

--- a/docs/NSA-MCP-MAPPING.md
+++ b/docs/NSA-MCP-MAPPING.md
@@ -1,6 +1,6 @@
 # ATR → NSA "Model Context Protocol (MCP): Security Design Considerations" Mapping
 
-- **ATR corpus version:** v3.5.2 HEAD, 655 rules across 10 detection-rule categories. Headline benchmarks below were measured at v3.5.0 (2026-06-16).
+- **ATR corpus version:** v3.5.2 HEAD, 708 rules across 10 detection-rule categories. Headline benchmarks below were measured at v3.5.0 (2026-06-16).
 - **NSA guidance:** *Model Context Protocol (MCP): Security Design Considerations for AI-Driven Automation*, Cybersecurity Information Sheet (CSI), **NSA Artificial Intelligence Security**, **May 2026 Ver. 1.0** (U/OO/6030316-26 | PP-26-1834), posted 2026-06-02 on media.defense.gov; developed with the Carnegie Mellon University Software Engineering Institute.
 - **Document date:** 2026-06-29 (ratings recalibrated after an adversarial second-reviewer pass — see Verification status)
 - **Maintainer:** Adam Lin (adam@agentthreatrule.org)

--- a/docs/OWASP-AGENTIC-MAPPING.md
+++ b/docs/OWASP-AGENTIC-MAPPING.md
@@ -1,7 +1,7 @@
 # ATR -> OWASP Agentic Top 10 (2026) Mapping
 
 Last updated: 2026-06-14
-ATR version: v3.5.2 (655 rules with OWASP Agentic tags)
+ATR version: v3.5.2 (708 rules with OWASP Agentic tags)
 OWASP framework: Agentic Top 10 v1.0 (December 2025)
 
 ## Summary

--- a/docs/OWASP-AGENTIC-MATURITY-MAPPING.md
+++ b/docs/OWASP-AGENTIC-MATURITY-MAPPING.md
@@ -4,7 +4,7 @@ Version: 0.1.0 (INTERNAL DRAFT — not published)
 Status: Draft alignment note for the OWASP Agentic adoption maturity model
 Date: 2026-06-14
 Editor: Adam Lin (林冠辛) <adam@agentthreatrule.org>
-Mapped corpus: Agent Threat Rules v3.5.2 (655 rules / 10 categories)
+Mapped corpus: Agent Threat Rules v3.5.2 (708 rules / 10 categories)
 Reference: "State of Agentic AI Security and Governance" (v2.01), OWASP GenAI Security Project, June 2026 — https://genai.owasp.org/resource/state-of-agentic-ai-security-and-governance/
 
 ---

--- a/docs/OWASP-AISVS-MAPPING.md
+++ b/docs/OWASP-AISVS-MAPPING.md
@@ -4,7 +4,7 @@ Version: 0.1.0 (INTERNAL DRAFT — not published, not submitted)
 Status: Draft for future OWASP AISVS Informative Reference / PR basis (human review gate before any upstream submission)
 Date: 2026-06-12
 Editor: Adam Lin (林冠辛) <adam@agentthreatrule.org>
-Mapped corpus: Agent Threat Rules v3.5.2 (655 rules / 10 categories, disk==stats.json verified 2026-06-29)
+Mapped corpus: Agent Threat Rules v3.5.2 (708 rules / 10 categories, disk==stats.json verified 2026-06-29)
 Reference framework: OWASP AI Security Verification Standard (AISVS) 1.0, chapters C9, C10, C13
 Reference framework license: CC BY-SA 4.0 (OWASP/AISVS README). Requirement text
 quoted below is reproduced under that license; this mapping is a derivative

--- a/docs/OWASP-AIVSS-MAPPING.md
+++ b/docs/OWASP-AIVSS-MAPPING.md
@@ -1,7 +1,7 @@
 # ATR -> OWASP AIVSS (AI Vulnerability Scoring System) Mapping
 
 Last updated: 2026-06-16
-ATR version: v3.5.2 (655 rules)
+ATR version: v3.5.2 (708 rules)
 OWASP framework: AIVSS v0.8 (March 2026) — OWASP Agentic AI Core Security Risks
 
 ## What this maps, and what it does not

--- a/docs/OWASP-AST10-MAPPING.md
+++ b/docs/OWASP-AST10-MAPPING.md
@@ -1,7 +1,7 @@
 # ATR → OWASP Agentic Skills Top 10 (AST10) Mapping
 
 Last updated: 2026-06-06 (header refreshed)
-ATR corpus: v3.5.2, 655 rules (10 categories, including skill-compromise)
+ATR corpus: v3.5.2, 708 rules (10 categories, including skill-compromise)
 OWASP framework: Agentic Skills Top 10 (AST10), March 2026
 
 > Coverage note: the per-category ATR rule citations below were last fully

--- a/docs/SAFE-MCP-MAPPING.md
+++ b/docs/SAFE-MCP-MAPPING.md
@@ -1,7 +1,7 @@
 # ATR → SAFE-MCP Technique Mapping
 
 Last updated: 2026-06-16 (header refreshed)
-ATR corpus: v3.5.2, 655 rules (10 categories)
+ATR corpus: v3.5.2, 708 rules (10 categories)
 SAFE-MCP version: latest (85 techniques, 47 mitigations)
 
 > Coverage note: the per-technique ATR rule citations in this document were last

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "3.5.6",
   "mcpName": "io.github.Agent-Threat-Rule/agent-threat-rules",
   "type": "module",
-  "description": "Open detection standard -- like Sigma, but for AI agents. 683 rules for prompt injection, tool poisoning, context exfiltration, and MCP attacks. Shipped in Cisco AI Defense. 97.2% recall on NVIDIA garak.",
+  "description": "Open detection standard -- like Sigma, but for AI agents. 708 rules for prompt injection, tool poisoning, context exfiltration, and MCP attacks. Shipped in Cisco AI Defense. 97.2% recall on NVIDIA garak.",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "bin": {


### PR DESCRIPTION
Manual npm run sync:stats pass. README's rule badge + CITATION.cff + package.json description + 12 crosswalk mapping doc headers were stale at 683 (before today's 3 FN-mining rule PRs). Reads the already-correct stats.json (708), rewrites only downstream doc surfaces. Version unchanged at 3.5.6 — no npm publish/version bump (that lane stays gated to TC-bot commits by design).