### PR TITLE
fix(ci): fn-mine pipefail masking + per-corpus fault tolerance

### DIFF
--- a/.github/workflows/fn-mine-scheduled.yml
+++ b/.github/workflows/fn-mine-scheduled.yml
@@ -85,7 +85,7 @@ jobs:
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         run: |
-          set -e
+          set -eo pipefail
           DRY_RUN_FLAG=""
           if [ "${{ inputs.dry_run }}" = "true" ]; then DRY_RUN_FLAG="--dry-run"; fi
           npx tsx scripts/fn-mine-llm.ts $DRY_RUN_FLAG --cap "${{ inputs.cap || '5' }}" | tee /tmp/fn-mine.out

--- a/scripts/fn-mine-llm.ts
+++ b/scripts/fn-mine-llm.ts
@@ -431,11 +431,27 @@ async function main(): Promise<void> {
   console.log(`[fn-mine] model=${model} cap=${cap} minRecovers=${minRecovers} dryRun=${isDryRun}`);
 
   console.log('[fn-mine] regenerating FN reports against the current rule set...');
+  // Per-corpus fault tolerance: an external dependency failing for ONE corpus
+  // (e.g. HackAPrompt's upstream HuggingFace dataset requiring auth) must not
+  // crash the whole run — the OTHER corpora should still get mined. A corpus
+  // that fails to regenerate is skipped for this run and logged loudly, not
+  // silently — this is exactly the kind of failure `set -o pipefail` in the
+  // calling workflow is there to make visible if left unhandled.
+  const availableCorpora: CorpusSpec[] = [];
   for (const spec of CORPORA) {
-    for (const cmd of spec.regenerate) {
-      console.log(`[fn-mine]   $ ${cmd}`);
-      execSync(cmd, { cwd: REPO_ROOT, stdio: 'inherit' });
+    try {
+      for (const cmd of spec.regenerate) {
+        console.log(`[fn-mine]   $ ${cmd}`);
+        execSync(cmd, { cwd: REPO_ROOT, stdio: 'inherit' });
+      }
+      availableCorpora.push(spec);
+    } catch (e) {
+      console.log(`[fn-mine] WARNING: ${spec.name} corpus regeneration failed — skipping this corpus for this run.`);
+      console.log(`[fn-mine]   ${e instanceof Error ? e.message : String(e)}`);
     }
+  }
+  if (availableCorpora.length === 0) {
+    throw new Error('Every corpus failed to regenerate — nothing to mine. See warnings above for per-corpus failure reasons.');
   }
 
   const benignTexts = loadBenignTexts();
@@ -445,7 +461,7 @@ async function main(): Promise<void> {
   console.log(`[fn-mine] existing rule regexes on disk (any status, incl. draft): ${existingRegexes.length}`);
 
   let allSurvivors: Array<GatedCandidate & { corpus: string }> = [];
-  for (const spec of CORPORA) {
+  for (const spec of availableCorpora) {
     const fnRaw = loadFnCorpus(spec);
     const fnFiltered = filterAlreadyCovered(fnRaw.texts, existingRegexes);
     const fn = { name: fnRaw.name, texts: fnFiltered };


### PR DESCRIPTION
Found by the first live dry-run test of #272 (workflow run 28940480872).

1. The "Run FN mining" step piped through `tee` without `pipefail`, so a FATAL script exit (code 1) was masked by tee's own exit 0 -- the whole workflow reported "success" despite the script having crashed. Added `set -eo pipefail`.

2. HackAPrompt's upstream dataset (hackaprompt/hackaprompt-dataset on HuggingFace) is now a GATED dataset requiring authentication. The corpus-regeneration step failed outright in a fresh CI runner with no HF_TOKEN -- which, via bug #1, silently killed PINT's mining too even though PINT has no such dependency. fn-mine-llm.ts now regenerates each corpus's FN report in its own try/catch: a corpus that fails to regenerate is skipped (loudly logged) for that run, but does not take down the others.

Net effect right now: HackAPrompt mining will keep failing until an HF_TOKEN secret is added (separate follow-up -- needs a human HuggingFace account + accepting the gated dataset's terms). PINT will run standalone in the meantime -- though PINT's current 164 measured FN are already 100% covered by yesterday's merged rules per the existing-regex filter, so expect null results (no PR opened) until either HackAPrompt access is restored or PINT's own corpus/rule-set state shifts. That is an honest, correct outcome of the design, not a bug.