### PR TITLE
chore(maturity): promote 0 rule(s) — 2026-07-09

### DIFF
--- a/data/maturity-promote/last-run.json
+++ b/data/maturity-promote/last-run.json
@@ -1,300 +1,59 @@
 {
-  "run_date": "2026-07-05",
+  "run_date": "2026-07-09",
   "mode": "write",
-  "promotions": [
-    {
-      "ruleId": "ATR-2026-00032",
-      "file": "rules/agent-manipulation/ATR-2026-00032-goal-hijacking.yaml",
-      "from": "experimental",
-      "to": "test",
-      "daysInCurrentTier": 90,
-      "reason": "≥30 days in experimental (90d) + 0 open FP reports"
-    },
-    {
-      "ruleId": "ATR-2026-00201",
-      "file": "rules/context-exfiltration/ATR-2026-00201-credential-pipe-exfiltration.yaml",
-      "from": "test",
-      "to": "stable",
-      "daysInCurrentTier": 77,
-      "reason": "≥60 days in test (77d) + 0 FP reports + 2 wild-looking TP(s)"
-    },
-    {
-      "ruleId": "ATR-2026-00524",
-      "file": "rules/context-exfiltration/ATR-2026-00524-claude-code-anthropic-base-url-credential-exfil.yaml",
-      "from": "experimental",
-      "to": "test",
-      "daysInCurrentTier": 53,
-      "reason": "≥30 days in experimental (53d) + 0 open FP reports"
-    },
-    {
-      "ruleId": "ATR-2026-00566",
-      "file": "rules/context-exfiltration/ATR-2026-00566-librechat-is-a-chatgpt-clone-with-additi.yaml",
-      "from": "experimental",
-      "to": "test",
-      "daysInCurrentTier": 33,
-      "reason": "≥30 days in experimental (33d) + 0 open FP reports"
-    },
-    {
-      "ruleId": "ATR-2026-00569",
-      "file": "rules/context-exfiltration/ATR-2026-00569-agent-mcp-path-traversal-arbitrary-file-access.yaml",
-      "from": "experimental",
-      "to": "test",
-      "daysInCurrentTier": 33,
-      "reason": "≥30 days in experimental (33d) + 0 open FP reports"
-    },
-    {
-      "ruleId": "ATR-2026-00571",
-      "file": "rules/context-exfiltration/ATR-2026-00571-xss-in-agent-mcp-rendered-output.yaml",
-      "from": "experimental",
-      "to": "test",
-      "daysInCurrentTier": 33,
-      "reason": "≥30 days in experimental (33d) + 0 open FP reports"
-    },
-    {
-      "ruleId": "ATR-2026-00574",
-      "file": "rules/context-exfiltration/ATR-2026-00574-semantic-paraphrased-context-extraction.yaml",
-      "from": "experimental",
-      "to": "test",
-      "daysInCurrentTier": 32,
-      "reason": "≥30 days in experimental (32d) + 0 open FP reports"
-    },
-    {
-      "ruleId": "ATR-2026-00570",
-      "file": "rules/data-poisoning/ATR-2026-00570-sql-injection-in-agent-tool-query.yaml",
-      "from": "experimental",
-      "to": "test",
-      "daysInCurrentTier": 33,
-      "reason": "≥30 days in experimental (33d) + 0 open FP reports"
-    },
-    {
-      "ruleId": "ATR-2026-00051",
-      "file": "rules/excessive-autonomy/ATR-2026-00051-resource-exhaustion.yaml",
-      "from": "experimental",
-      "to": "test",
-      "daysInCurrentTier": 90,
-      "reason": "≥30 days in experimental (90d) + 0 open FP reports"
-    },
-    {
-      "ruleId": "ATR-2026-00204",
-      "file": "rules/privilege-escalation/ATR-2026-00204-stealth-execution-persistence.yaml",
-      "from": "test",
-      "to": "stable",
-      "daysInCurrentTier": 77,
-      "reason": "≥60 days in test (77d) + 0 FP reports + 2 wild-looking TP(s)"
-    },
-    {
-      "ruleId": "ATR-2026-00539",
-      "file": "rules/privilege-escalation/ATR-2026-00539-crewai-codeinterpreter-sandbox-escape-rce.yaml",
-      "from": "experimental",
-      "to": "test",
-      "daysInCurrentTier": 32,
-      "reason": "≥30 days in experimental (32d) + 0 open FP reports"
-    },
-    {
-      "ruleId": "ATR-2026-00546",
-      "file": "rules/privilege-escalation/ATR-2026-00546-crewai-json-loader-local-file-read.yaml",
-      "from": "experimental",
-      "to": "test",
-      "daysInCurrentTier": 32,
-      "reason": "≥30 days in experimental (32d) + 0 open FP reports"
-    },
-    {
-      "ruleId": "ATR-2026-00547",
-      "file": "rules/privilege-escalation/ATR-2026-00547-crewai-rag-url-ssrf-bypass.yaml",
-      "from": "experimental",
-      "to": "test",
-      "daysInCurrentTier": 32,
-      "reason": "≥30 days in experimental (32d) + 0 open FP reports"
-    },
-    {
-      "ruleId": "ATR-2026-00003",
-      "file": "rules/prompt-injection/ATR-2026-00003-jailbreak-attempt.yaml",
-      "from": "experimental",
-      "to": "test",
-      "daysInCurrentTier": 90,
-      "reason": "≥30 days in experimental (90d) + 0 open FP reports"
-    },
-    {
-      "ruleId": "ATR-2026-00005",
-      "file": "rules/prompt-injection/ATR-2026-00005-multi-turn-injection.yaml",
-      "from": "experimental",
-      "to": "test",
-      "daysInCurrentTier": 90,
-      "reason": "≥30 days in experimental (90d) + 0 open FP reports"
-    },
-    {
-      "ruleId": "ATR-2026-00203",
-      "file": "rules/prompt-injection/ATR-2026-00203-context-pollution-skill-description.yaml",
-      "from": "test",
-      "to": "stable",
-      "daysInCurrentTier": 77,
-      "reason": "≥60 days in test (77d) + 0 FP reports + 2 wild-looking TP(s)"
-    },
-    {
-      "ruleId": "ATR-2026-00535",
-      "file": "rules/prompt-injection/ATR-2026-00535-windsurf-ide-zero-click-prompt-injection.yaml",
-      "from": "experimental",
-      "to": "test",
-      "daysInCurrentTier": 39,
-      "reason": "≥30 days in experimental (39d) + 0 open FP reports"
-    },
-    {
-      "ruleId": "ATR-2026-00554",
-      "file": "rules/prompt-injection/ATR-2026-00554-langchain-vulnerable-to-template-injecti.yaml",
-      "from": "experimental",
-      "to": "test",
-      "daysInCurrentTier": 33,
-      "reason": "≥30 days in experimental (33d) + 0 open FP reports"
-    },
-    {
-      "ruleId": "ATR-2026-00565",
-      "file": "rules/prompt-injection/ATR-2026-00565-the-llm-cli-tool-thru-0-27-1-contains-a-.yaml",
-      "from": "experimental",
-      "to": "test",
-      "daysInCurrentTier": 33,
-      "reason": "≥30 days in experimental (33d) + 0 open FP reports"
-    },
-    {
-      "ruleId": "ATR-2026-00573",
-      "file": "rules/prompt-injection/ATR-2026-00573-semantic-paraphrased-injection.yaml",
-      "from": "experimental",
-      "to": "test",
-      "daysInCurrentTier": 32,
-      "reason": "≥30 days in experimental (32d) + 0 open FP reports"
-    },
-    {
-      "ruleId": "ATR-2026-00523",
-      "file": "rules/skill-compromise/ATR-2026-00523-claude-code-hooks-session-start-pre-trust-rce.yaml",
-      "from": "experimental",
-      "to": "test",
-      "daysInCurrentTier": 53,
-      "reason": "≥30 days in experimental (53d) + 0 open FP reports"
-    },
-    {
-      "ruleId": "ATR-2026-00531",
-      "file": "rules/tool-poisoning/ATR-2026-00531-praisonai-unauthenticated-agent-api.yaml",
-      "from": "experimental",
-      "to": "test",
-      "daysInCurrentTier": 39,
-      "reason": "≥30 days in experimental (39d) + 0 open FP reports"
-    },
-    {
-      "ruleId": "ATR-2026-00532",
-      "file": "rules/tool-poisoning/ATR-2026-00532-apache-doris-mcp-sql-injection.yaml",
-      "from": "experimental",
-      "to": "test",
-      "daysInCurrentTier": 39,
-      "reason": "≥30 days in experimental (39d) + 0 open FP reports"
-    },
-    {
-      "ruleId": "ATR-2026-00533",
-      "file": "rules/tool-poisoning/ATR-2026-00533-apache-pinot-mcp-unauthenticated-takeover.yaml",
-      "from": "experimental",
-      "to": "test",
-      "daysInCurrentTier": 39,
-      "reason": "≥30 days in experimental (39d) + 0 open FP reports"
-    },
-    {
-      "ruleId": "ATR-2026-00534",
-      "file": "rules/tool-poisoning/ATR-2026-00534-alibaba-rds-mcp-unauthenticated-metadata-exfil.yaml",
-      "from": "experimental",
-      "to": "test",
-      "daysInCurrentTier": 39,
-      "reason": "≥30 days in experimental (39d) + 0 open FP reports"
-    },
-    {
-      "ruleId": "ATR-2026-00536",
-      "file": "rules/tool-poisoning/ATR-2026-00536-nginx-ui-mcp-unauthenticated-command-execution.yaml",
-      "from": "experimental",
-      "to": "test",
-      "daysInCurrentTier": 39,
-      "reason": "≥30 days in experimental (39d) + 0 open FP reports"
-    },
-    {
-      "ruleId": "ATR-2026-00561",
-      "file": "rules/tool-poisoning/ATR-2026-00561-fastmcp-vulnerable-to-windows-command-in.yaml",
-      "from": "experimental",
-      "to": "test",
-      "daysInCurrentTier": 33,
-      "reason": "≥30 days in experimental (33d) + 0 open FP reports"
-    },
-    {
-      "ruleId": "ATR-2026-00567",
-      "file": "rules/tool-poisoning/ATR-2026-00567-mcp-stdio-config-command-injection.yaml",
-      "from": "experimental",
-      "to": "test",
-      "daysInCurrentTier": 33,
-      "reason": "≥30 days in experimental (33d) + 0 open FP reports"
-    },
-    {
-      "ruleId": "ATR-2026-00568",
-      "file": "rules/tool-poisoning/ATR-2026-00568-agent-ssrf-cloud-metadata-file-inclusion.yaml",
-      "from": "experimental",
-      "to": "test",
-      "daysInCurrentTier": 33,
-      "reason": "≥30 days in experimental (33d) + 0 open FP reports"
-    },
-    {
-      "ruleId": "ATR-2026-00572",
-      "file": "rules/tool-poisoning/ATR-2026-00572-symjack-symlink-config-redirection.yaml",
-      "from": "experimental",
-      "to": "test",
-      "daysInCurrentTier": 32,
-      "reason": "≥30 days in experimental (32d) + 0 open FP reports"
-    }
-  ],
+  "promotions": [],
   "blocked": [
     {
       "ruleId": "ATR-2026-00081",
-      "reason": "blocked: ≥60 days in test (90d) but no wild-looking true_positive (≥1 required for stable)"
+      "reason": "blocked: ≥60 days in test (94d) but no wild-looking true_positive (≥1 required for stable)"
     },
     {
       "ruleId": "ATR-2026-00082",
-      "reason": "blocked: ≥60 days in test (90d) but no wild-looking true_positive (≥1 required for stable)"
+      "reason": "blocked: ≥60 days in test (94d) but no wild-looking true_positive (≥1 required for stable)"
     },
     {
       "ruleId": "ATR-2026-00085",
-      "reason": "blocked: ≥60 days in test (90d) but no wild-looking true_positive (≥1 required for stable)"
+      "reason": "blocked: ≥60 days in test (94d) but no wild-looking true_positive (≥1 required for stable)"
     },
     {
       "ruleId": "ATR-2026-00086",
-      "reason": "blocked: ≥60 days in test (90d) but no wild-looking true_positive (≥1 required for stable)"
+      "reason": "blocked: ≥60 days in test (94d) but no wild-looking true_positive (≥1 required for stable)"
     },
     {
       "ruleId": "ATR-2026-00087",
-      "reason": "blocked: ≥60 days in test (90d) but no wild-looking true_positive (≥1 required for stable)"
+      "reason": "blocked: ≥60 days in test (94d) but no wild-looking true_positive (≥1 required for stable)"
     },
     {
       "ruleId": "ATR-2026-00088",
-      "reason": "blocked: ≥60 days in test (90d) but no wild-looking true_positive (≥1 required for stable)"
+      "reason": "blocked: ≥60 days in test (94d) but no wild-looking true_positive (≥1 required for stable)"
     },
     {
       "ruleId": "ATR-2026-00090",
-      "reason": "blocked: ≥60 days in test (90d) but no wild-looking true_positive (≥1 required for stable)"
+      "reason": "blocked: ≥60 days in test (94d) but no wild-looking true_positive (≥1 required for stable)"
     },
     {
       "ruleId": "ATR-2026-00092",
-      "reason": "blocked: ≥60 days in test (90d) but no wild-looking true_positive (≥1 required for stable)"
+      "reason": "blocked: ≥60 days in test (94d) but no wild-looking true_positive (≥1 required for stable)"
     },
     {
       "ruleId": "ATR-2026-00093",
-      "reason": "blocked: ≥60 days in test (90d) but no wild-looking true_positive (≥1 required for stable)"
+      "reason": "blocked: ≥60 days in test (94d) but no wild-looking true_positive (≥1 required for stable)"
     },
     {
       "ruleId": "ATR-2026-00094",
-      "reason": "blocked: ≥60 days in test (90d) but no wild-looking true_positive (≥1 required for stable)"
+      "reason": "blocked: ≥60 days in test (94d) but no wild-looking true_positive (≥1 required for stable)"
     },
     {
       "ruleId": "ATR-2026-00202",
-      "reason": "blocked: ≥60 days in test (77d) but no wild-looking true_positive (≥1 required for stable)"
+      "reason": "blocked: ≥60 days in test (81d) but no wild-looking true_positive (≥1 required for stable)"
     },
     {
       "ruleId": "ATR-2026-00200",
-      "reason": "blocked: ≥60 days in test (77d) but no wild-looking true_positive (≥1 required for stable)"
+      "reason": "blocked: ≥60 days in test (81d) but no wild-looking true_positive (≥1 required for stable)"
     },
     {
       "ruleId": "ATR-2026-00013",
-      "reason": "blocked: ≥60 days in test (90d) but no wild-looking true_positive (≥1 required for stable)"
+      "reason": "blocked: ≥60 days in test (94d) but no wild-looking true_positive (≥1 required for stable)"
     }
   ],
   "fp_reports_open": []


### PR DESCRIPTION
Daily maturity promotion run for 2026-07-09.

## Promotions

| Rule | From | To | Days in tier | Why |
|---|---|---|---|---|

## Policy

- experimental -> test: >=30 days in main + 0 open FP reports
- test -> stable: >=60 days in test + 0 FP reports + >=1 wild-looking true_positive

Opened by the PanGuard rule-production flywheel. Safe to squash-merge if the table looks right; CI gates (validate + rule-quality) run on this PR.