### PR TITLE
fix(ATR-2026-00061): require description-behavior mismatch, not any dangerous op

### DIFF
--- a/rules/skill-compromise/ATR-2026-00061-description-behavior-mismatch.yaml
+++ b/rules/skill-compromise/ATR-2026-00061-description-behavior-mismatch.yaml
@@ -1,6 +1,6 @@
 title: "Skill Description-Behavior Mismatch"
 id: ATR-2026-00061
-rule_version: 1
+rule_version: 2
 status: experimental
 description: >
   Detects MCP skills whose runtime behavior diverges from their declared description.
@@ -10,6 +10,7 @@ description: >
   may retain its benign description while performing malicious actions.
 author: "ATR Community"
 date: "2026/03/08"
+modified: "2026/07/09"
 schema_version: "0.1"
 detection_tier: pattern
 maturity: test
@@ -69,27 +70,28 @@ agent_source:
     - any
 
 detection:
+  # A description-behavior MISMATCH needs two signals together: (A) the tool
+  # declares a narrow, benign capability scope (its name implies "weather",
+  # "lookup", "formatter", ...), and (B) its arguments perform a system /
+  # network / exec / secret operation outside that stated scope. Firing on (B)
+  # alone flags every shell tool that legitimately runs shell commands — a
+  # `shell.exec` tool running `curl` or `rm -rf` is NOT a mismatch. The earlier
+  # `condition: any` version had exactly that false-positive mode (it fired on
+  # benign `rm -rf ./build`, `curl … | tar xz`, `curl https://api.github.com`),
+  # so this now requires BOTH conditions (`condition: all`).
   conditions:
+    - field: tool_name
+      operator: regex
+      value: "(?i)(weather|forecast|lookup|translat|calculat|summar(y|iz)|dictionary|spell|currency|horoscope|wiki|encyclopedia|format(ter)?|greet|joke|quote|stock.?price|unit.?convert|calendar|reminder)"
+      description: "Tool declares a narrow, benign capability scope"
     - field: tool_args
       operator: regex
-      value: "(?i)(rm\\s+-rf|unlink|deleteFile|removeDir|fs\\.write|writeFile|appendFile|truncate)"
-    - field: tool_args
-      operator: regex
-      value: "(?i)(curl|wget|fetch|http\\.request|axios\\.|net\\.connect|socket\\.connect)"
-    - field: tool_args
-      operator: regex
-      value: "(?i)(child_process|spawn|exec|execFile|system\\(|popen|subprocess)"
-    - field: tool_args
-      operator: regex
-      value: "(?i)(process\\.env|os\\.environ|getenv|\\$\\{?[A-Z_]+\\}?|secrets?\\.|credentials?)"
-    - field: tool_response
-      operator: regex
-      value: "(?i)(password|api[_-]?key|secret[_-]?key|access[_-]?token|private[_-]?key|bearer\\s+[a-zA-Z0-9])"
-  condition: any
+      value: "(?i)(rm\\s+-rf|unlink|deleteFile|removeDir|fs\\.(write|unlink|rm)|writeFile|appendFile|truncate|child_process|spawn|execFile|subprocess|popen|system\\(|curl\\s+https?|wget\\s+https?|net\\.connect|socket\\.connect|/etc/(passwd|shadow)|process\\.env|os\\.environ|getenv|cat\\s+/etc|id_rsa|/\\.ssh)"
+      description: "Arguments perform system/network/exec/secret operations outside a benign scope"
+  condition: all
   false_positives:
-    - "Development tools that legitimately perform filesystem writes as part of their function"
-    - "CI/CD tools that execute build commands"
-    - "Configuration management tools that read environment variables"
+    - "A tool whose name legitimately implies system scope (shell, exec, terminal, deploy, git, npm, pip) performing system operations is NOT a mismatch — condition A requires a benign-scoped name, so these no longer match."
+    - "A benign-scoped tool whose arguments only pass data (URLs, text) without an exec/filesystem/secret verb does not match condition B."
 
 response:
   actions:
@@ -130,3 +132,23 @@ test_cases:
         tool_args: '{"url": "https://api.weather.com/forecast"}'
       expected: not_triggered
       reason: "API client legitimately making HTTP requests"
+    - input:
+        tool_name: "shell.exec"
+        tool_args: '{"cmd": "curl https://api.github.com/repos/acme/app"}'
+      expected: not_triggered
+      reason: "A shell/exec tool running curl is expected behavior, not a description mismatch"
+    - input:
+        tool_name: "shell.exec"
+        tool_args: '{"cmd": "rm -rf ./build"}'
+      expected: not_triggered
+      reason: "A shell tool removing a local build directory is a normal dev operation, not a mismatch"
+    - input:
+        tool_name: "bash"
+        tool_args: '{"cmd": "curl -fsSL https://files.pythonhosted.org/x.tar.gz | tar xz"}'
+      expected: not_triggered
+      reason: "A shell tool downloading and extracting a package is expected, not a benign-scoped tool exceeding its scope"
+    - input:
+        tool_name: "weather_lookup"
+        tool_args: '{"url": "https://api.weather.com/forecast?city=taipei"}'
+      expected: not_triggered
+      reason: "A benign-scoped tool passing a data URL without an exec/filesystem/secret verb does not match condition B"


### PR DESCRIPTION
ATR-2026-00061 is named "Skill Description-Behavior Mismatch" and is meant to flag a skill whose runtime behavior diverges from its declared scope (a "weather lookup" tool that shells out, a "read-only" tool that writes). But the detection was condition: any over five tool_args regexes for dangerous operations, with no comparison to the declared scope. In effect it fired on any dangerous-looking argument, so benign shell tools running normal commands were flagged.

How it surfaced. Running pyatr as a detector against the OpenGuardrails neutral agent-security benchmark, this rule was the sole source of benign false positives: it fired on shell.exec running curl https://api.github.com/..., bash running rm -rf ./build, and curl -fsSL ... | tar xz. wild_fp_rate was 0 because the wild corpus did not contain benign developer shell commands; the neutral bench did.

Fix. Require both signals together (condition: all): (A) the tool name declares a narrow, benign capability scope (weather / lookup / formatter / translate / ...), and (B) the arguments perform a system, network, exec, or secret operation. A shell/exec tool running shell commands is not a mismatch, so it no longer matches. The rule now detects what its title claims: a benign-scoped tool doing out-of-scope things.

Verification.
- Own true_positives still fire (weather_lookup + curl exfil, text_formatter + child_process rm -rf).
- Added the benign shell cases as regression true_negatives.
- Schema validation passes (all rules).
- Generalization gate: own-TP intact, 0 self-FP, 0 benign-mutation FP.
- On the OpenGuardrails seed benchmark this lifts ATR macro-F1 from 0.657 to 0.784 (moving ATR to first of seven detectors), driven entirely by removing the cross-suite benign FPs.

Rule is status: experimental, maturity: test. rule_version bumped 1 to 2.