### PR TITLE
fix(ci): pass HF_TOKEN through to the FN-mine scheduled workflow

### DIFF
--- a/.github/workflows/fn-mine-scheduled.yml
+++ b/.github/workflows/fn-mine-scheduled.yml
@@ -84,6 +84,7 @@ jobs:
         id: mine
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: |
           set -eo pipefail
           DRY_RUN_FLAG=""


### PR DESCRIPTION
User added the HF_TOKEN repo secret (HuggingFace read token; account has accepted hackaprompt/hackaprompt-dataset's gated terms). Wires it into the "Run FN mining" step's env so scripts/hackaprompt-to-corpus.py's load_dataset() call -- which relies on huggingface_hub's standard HF_TOKEN env-var auto-detection, no code change needed there -- can actually authenticate.

Was previously falling back to the per-corpus fault-tolerance path added in #273 (hackaprompt skipped with a warning, PINT ran alone). Will verify via a dry-run dispatch once this merges.