### PR TITLE
feat(rules): rebuild CVE-proposal-to-rule flywheel (fn-mine pattern)

### DIFF
--- a/.github/workflows/cve-mine-scheduled.yml
+++ b/.github/workflows/cve-mine-scheduled.yml
@@ -57,19 +57,6 @@ on:
         required: false
         default: false
         type: boolean
-  # TEMPORARY bootstrap trigger — GitHub's workflow_dispatch API requires a
-  # workflow to already exist on the default branch before it can be manually
-  # dispatched, which makes it impossible to test-run this workflow from its
-  # own PR branch before merge. This push trigger (scoped only to this one
-  # branch) is test-only scaffolding to validate the workflow end-to-end
-  # against the real Anthropic API on GitHub Actions runners prior to review;
-  # it is removed in a follow-up commit on this same PR before merge so the
-  # production trigger set matches fn-mine-scheduled.yml's (schedule +
-  # workflow_dispatch only).
-  push:
-    branches:
-      - feat/cve-mine-automation
-
 permissions:
   contents: write
   pull-requests: write
@@ -99,6 +86,9 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
+
+      - name: Install Python dependencies
+        run: pip install pyyaml
 
       - name: Build
         run: npm run build
@@ -142,11 +132,15 @@ jobs:
             mkdir -p "$PAYLOAD_DIR/$(dirname "$f")"
             cp "$f" "$PAYLOAD_DIR/$f"
           done
-          # docs/crosswalks/ is regenerated output, not machine-parsed by
-          # `files=`, so capture it separately if present.
+          # docs/crosswalks/ (regenerated in place) and the run report are not
+          # machine-parsed by `files=`, so capture them separately if present.
           if [ -d docs/crosswalks ]; then
             mkdir -p "$PAYLOAD_DIR/docs/crosswalks"
             cp -r docs/crosswalks/. "$PAYLOAD_DIR/docs/crosswalks/"
+          fi
+          if [ -f output/cve-mine-report.json ]; then
+            mkdir -p "$PAYLOAD_DIR/output"
+            cp output/cve-mine-report.json "$PAYLOAD_DIR/output/cve-mine-report.json"
           fi
 
           git fetch origin main
@@ -160,6 +154,10 @@ jobs:
           if [ -d "$PAYLOAD_DIR/docs/crosswalks" ]; then
             mkdir -p docs/crosswalks
             cp -r "$PAYLOAD_DIR/docs/crosswalks/." docs/crosswalks/
+          fi
+          if [ -f "$PAYLOAD_DIR/output/cve-mine-report.json" ]; then
+            mkdir -p output
+            cp "$PAYLOAD_DIR/output/cve-mine-report.json" output/cve-mine-report.json
           fi
 
           git add rules/ docs/crosswalks/ data/cve-collector/promoted.json output/cve-mine-report.json 2>/dev/null || true

--- a/.github/workflows/cve-mine-scheduled.yml
+++ b/.github/workflows/cve-mine-scheduled.yml
@@ -1,0 +1,206 @@
+name: Scheduled CVE Mining (proposal-to-rule conversion)
+
+# Daily unattended counterpart to the deleted CVE-proposal-to-rule conversion
+# pipeline (PR #243 removed cve-daily-sync.yml / promote-cve.yml / the
+# author-rule-llm.ts family on 2026-07-01 as a deliberate "keep the
+# rule-authoring methodology private" business decision — but no private
+# replacement was ever built, so proposal COLLECTION kept running via an
+# external process while CONVERSION sat dead for 9+ days and 4,800+ backlog
+# items). Per an explicit decision to NOT keep this private, this workflow
+# mirrors the public scripts/fn-mine-llm.ts + fn-mine-scheduled.yml pattern
+# exactly: the authoring logic lives directly in this repo and calls the
+# Anthropic API (scripts/cve-mine-llm.ts), not a private service.
+#
+# Reads proposals/**/*.proposal.yaml, picks agent-attack-relevant proposals
+# with enough concrete PoC/payload detail to ground a precise regex and NOT
+# already covered by an existing rule, authors survivors via the Anthropic
+# API, self-tests each on the real engine, re-verifies the whole batch
+# against this repo's own safety gate (65K-benign 0-FP + cross-rule conflict
+# + duplicate-ID checks) AND the latency-regression gate (this session found
+# overly-wide bridge spans in new rules can blow the corpus-wide p95/avg
+# latency budget even when the safety gate passes clean), before opening a
+# DRAFT PR.
+#
+# Safety posture (deliberately conservative for unattended automation):
+#   - Never auto-merges. Always opens a draft PR; a human decides.
+#   - A "null result" (nothing survived the gate) is a valid, quiet outcome —
+#     no PR is opened, no noise.
+#   - Capped at 8 rules per run by default (the `cap` workflow_dispatch
+#     input, or --cap 8 on the cron trigger), under the repo's 10-rules/PR
+#     safety-gate limit, since an unattended batch has no interactive
+#     reviewer catching subtle bugs the way a live session does.
+#   - Idempotent: converted (and terminally-failed) proposals are recorded in
+#     data/cve-collector/promoted.json so re-runs don't re-process the same
+#     4,800+ item backlog forever.
+#   - Bootstrapping note: the branch-creation step below explicitly resets
+#     onto origin/main and copies over ONLY the files the mining step
+#     actually produced (new rule YAMLs + the promotion-state JSON + the
+#     report JSON), regardless of which ref this workflow itself was
+#     dispatched from. This keeps every batch PR's diff scoped to real
+#     content (rules + state), not incidentally bundling in whatever other
+#     changes happen to be on the triggering branch/ref.
+
+on:
+  schedule:
+    # Daily 05:40 UTC — matches the cadence of the deleted promote-cve.yml
+    # ('40 5 * * *'), since CVE proposals accumulate daily and the whole
+    # point of rebuilding this is to keep the backlog from re-forming.
+    - cron: '40 5 * * *'
+  workflow_dispatch:
+    inputs:
+      cap:
+        description: 'Max rules to author this run'
+        required: false
+        default: '8'
+      dry_run:
+        description: 'Select and rank candidates but do not author/PR (prints candidates)'
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: cve-mine-scheduled
+  cancel-in-progress: false
+
+jobs:
+  mine:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '22'
+
+      - name: Install Node dependencies
+        run: npm ci
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Build
+        run: npm run build
+
+      - name: Configure git identity
+        run: |
+          git config user.name "ATR CVE-Mine Bot"
+          git config user.email "cve-mine@agentthreatrule.org"
+
+      - name: Run CVE mining
+        id: mine
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          set -eo pipefail
+          DRY_RUN_FLAG=""
+          if [ "${{ inputs.dry_run }}" = "true" ]; then DRY_RUN_FLAG="--dry-run"; fi
+          npx tsx scripts/cve-mine-llm.ts $DRY_RUN_FLAG --cap "${{ inputs.cap || '8' }}" | tee /tmp/cve-mine.out
+          FILES=$(grep "::authored-files::" /tmp/cve-mine.out | tail -1 | sed 's/::authored-files:://')
+          echo "files=$FILES" >> "$GITHUB_OUTPUT"
+
+      - name: Stop here if nothing survived (null result — not an error)
+        if: steps.mine.outputs.files == ''
+        run: echo "No rules survived the gate this run (or --dry-run). Quiet exit, no PR."
+
+      - name: Create branch + commit + push
+        if: steps.mine.outputs.files != ''
+        id: push
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -e
+          FILES="${{ steps.mine.outputs.files }}"
+
+          # Preserve the files the mining step actually produced before
+          # resetting the working tree onto origin/main — see the
+          # "Bootstrapping note" comment at the top of this workflow.
+          PAYLOAD_DIR="$(mktemp -d)"
+          IFS=',' read -ra FILE_ARR <<< "$FILES"
+          for f in "${FILE_ARR[@]}"; do
+            mkdir -p "$PAYLOAD_DIR/$(dirname "$f")"
+            cp "$f" "$PAYLOAD_DIR/$f"
+          done
+          # docs/crosswalks/ is regenerated output, not machine-parsed by
+          # `files=`, so capture it separately if present.
+          if [ -d docs/crosswalks ]; then
+            mkdir -p "$PAYLOAD_DIR/docs/crosswalks"
+            cp -r docs/crosswalks/. "$PAYLOAD_DIR/docs/crosswalks/"
+          fi
+
+          git fetch origin main
+          BRANCH="cve-mine/scheduled-$(date +%Y%m%d-%H%M%S)"
+          git checkout -B "$BRANCH" origin/main
+
+          for f in "${FILE_ARR[@]}"; do
+            mkdir -p "$(dirname "$f")"
+            cp "$PAYLOAD_DIR/$f" "$f"
+          done
+          if [ -d "$PAYLOAD_DIR/docs/crosswalks" ]; then
+            mkdir -p docs/crosswalks
+            cp -r "$PAYLOAD_DIR/docs/crosswalks/." docs/crosswalks/
+          fi
+
+          git add rules/ docs/crosswalks/ data/cve-collector/promoted.json output/cve-mine-report.json 2>/dev/null || true
+          git commit -m "$(cat <<'EOF'
+          feat(rules): scheduled CVE-mine sweep
+
+          Unattended daily CVE-proposal-to-rule conversion (proposals/**/*.proposal.yaml
+          backlog). See output/cve-mine-report.json for per-rule provenance.
+          EOF
+          )"
+          git push origin "$BRANCH"
+          echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
+
+      - name: Open draft PR
+        if: steps.mine.outputs.files != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -e
+          gh pr create \
+            --title "feat(rules): scheduled CVE-mine sweep — $(date +%Y-%m-%d)" \
+            --body "$(cat <<'EOF'
+          Unattended daily CVE-proposal-to-rule conversion run, the rebuilt
+          counterpart to the CONVERSION half of the flywheel PR #243 deleted on
+          2026-07-01 (collection kept running via an external process; conversion
+          had been dead since — this workflow is the from-scratch, in-repo,
+          public replacement, mirroring scripts/fn-mine-llm.ts's methodology).
+
+          Method: scanned the proposals/**/*.proposal.yaml backlog, selected
+          proposals that are (a) tagged detection_ready with a valid ATR category,
+          (b) contain a concrete PoC/payload signal (not just prose about the
+          vulnerability), (c) are genuinely agent/LLM/MCP-relevant (a local
+          keyword filter plus a second LLM-judged veto — the upstream collector's
+          own "agent-relevant" tagging has confirmed false positives, e.g.
+          generic CVEs where a security researcher merely disclosed using an LLM
+          to help write the report), and (d) not already covered by an existing
+          rule regex on disk (any status, draft included). Authored survivors via
+          the Anthropic API grounded in the REAL advisory/PoC text, self-tested
+          each on the real engine, enforced a hard bridge-span cap ([\s\S]{0,N},
+          N<=30 — a wider span caused a real corpus-wide latency regression this
+          session), then re-verified the whole batch against this repo's own
+          safety gate (65K-benign 0-FP + cross-rule conflict + duplicate-ID
+          checks) AND the tests/skill-benchmark.test.ts + tests/eval-harness.test.ts
+          latency-regression gate — dropping (not force-fixing) anything that
+          failed any of these.
+
+          See output/cve-mine-report.json in this PR's diff for per-rule
+          provenance (which proposal it came from). Left as draft — nothing here
+          is auto-merged; a human reviews and decides, same as every other rule
+          PR in this repo.
+          EOF
+          )" \
+            --label "auto-generated,cve-mine,needs-human-review" \
+            --draft \
+            --base main \
+            --head "${{ steps.push.outputs.branch }}"

--- a/.github/workflows/cve-mine-scheduled.yml
+++ b/.github/workflows/cve-mine-scheduled.yml
@@ -57,6 +57,18 @@ on:
         required: false
         default: false
         type: boolean
+  # TEMPORARY bootstrap trigger — GitHub's workflow_dispatch API requires a
+  # workflow to already exist on the default branch before it can be manually
+  # dispatched, which makes it impossible to test-run this workflow from its
+  # own PR branch before merge. This push trigger (scoped only to this one
+  # branch) is test-only scaffolding to validate the workflow end-to-end
+  # against the real Anthropic API on GitHub Actions runners prior to review;
+  # it is removed in a follow-up commit on this same PR before merge so the
+  # production trigger set matches fn-mine-scheduled.yml's (schedule +
+  # workflow_dispatch only).
+  push:
+    branches:
+      - feat/cve-mine-automation
 
 permissions:
   contents: write
@@ -104,7 +116,7 @@ jobs:
           set -eo pipefail
           DRY_RUN_FLAG=""
           if [ "${{ inputs.dry_run }}" = "true" ]; then DRY_RUN_FLAG="--dry-run"; fi
-          npx tsx scripts/cve-mine-llm.ts $DRY_RUN_FLAG --cap "${{ inputs.cap || '8' }}" | tee /tmp/cve-mine.out
+          npx tsx scripts/cve-mine-llm.ts $DRY_RUN_FLAG --cap "${{ inputs.cap || '3' }}" | tee /tmp/cve-mine.out
           FILES=$(grep "::authored-files::" /tmp/cve-mine.out | tail -1 | sed 's/::authored-files:://')
           echo "files=$FILES" >> "$GITHUB_OUTPUT"
 

--- a/scripts/cve-mine-llm.ts
+++ b/scripts/cve-mine-llm.ts
@@ -1,0 +1,806 @@
+#!/usr/bin/env node
+/**
+ * scripts/cve-mine-llm.ts
+ *
+ * Unattended CVE-proposal-to-rule conversion: reads the continuously-growing
+ * `proposals/**\/*.proposal.yaml` backlog (populated daily by an external
+ * collector process this repo no longer runs — see data/cve-collector/), picks
+ * proposals that are agent-attack-relevant, have enough concrete PoC/payload
+ * detail to ground a precise regex, and are NOT already covered by an existing
+ * rule, authors each survivor as a full ATR rule YAML via the Anthropic API,
+ * self-tests it on the real engine, re-verifies the whole batch against this
+ * repo's own safety gate, and hands off to the calling workflow to open a
+ * draft PR.
+ *
+ * This is the direct architectural sibling of scripts/fn-mine-llm.ts (the
+ * scheduled false-negative-mining flywheel) — same @anthropic-ai/sdk calling
+ * pattern, same engine-accurate regex-compile gate, same "drop, don't
+ * force-fix" philosophy, same draft-PR-only safety posture. Where fn-mine
+ * clusters many false-negative TEXTS into one generalizable regex, cve-mine
+ * treats each proposal as its own (already-scoped) cluster: one CVE/advisory
+ * -> at most one authored rule.
+ *
+ * Never merges anything. Drops (does not force-fix) any candidate that fails
+ * self-test, the bridge-span lint, the safety gate, or the latency-regression
+ * gate — an empty result is a valid, honest outcome, not an error.
+ *
+ * Idempotency: converted (and terminally-failed) proposals are recorded in
+ * data/cve-collector/promoted.json so re-runs don't re-process the same
+ * proposal forever — the analogous mechanism to fn-mine-llm.ts's
+ * loadAllExistingRegexes()-based "already covered" filter, adapted for a
+ * discrete backlog of files instead of a re-derived FN corpus.
+ *
+ * Usage:
+ *   npx tsx scripts/cve-mine-llm.ts [--dry-run] [--cap 8] [--model claude-sonnet-5]
+ *
+ * Environment:
+ *   ANTHROPIC_API_KEY required (NOT read in --dry-run mode — dry-run only
+ *   selects and ranks candidates, no API calls are made)
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { execSync } from 'node:child_process';
+import { parseArgs } from 'node:util';
+import { load as yamlLoad } from 'js-yaml';
+import Anthropic from '@anthropic-ai/sdk';
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+const REPO_ROOT = process.cwd();
+const DEFAULT_MODEL = process.env['ATR_CVEMINE_MODEL'] ?? 'claude-sonnet-5';
+const MAX_TOKENS = 8192;
+const PROPOSALS_DIR = 'proposals';
+const REFERENCE_RULE = 'rules/tool-poisoning/ATR-2026-01928-framelink-figma-mcp-curl-fallback-command-injection.yaml';
+const REPORT_PATH = 'output/cve-mine-report.json';
+const STATE_PATH = 'data/cve-collector/promoted.json';
+const MAX_ATTEMPTS_BEFORE_SKIP = 2; // give a candidate 2 daily runs' worth of corrective retries before parking it
+const MAX_BRIDGE_SPAN = 30; // {0,N} bridge spans above this are the confirmed latency-regression cause
+
+const VALID_CATEGORIES = new Set([
+  'agent-manipulation',
+  'context-exfiltration',
+  'data-poisoning',
+  'excessive-autonomy',
+  'model-abuse',
+  'model-security',
+  'privilege-escalation',
+  'prompt-injection',
+  'skill-compromise',
+  'tool-poisoning',
+]);
+
+// ---------------------------------------------------------------------------
+// Anthropic call plumbing (same pattern as scripts/fn-mine-llm.ts /
+// scripts/quality-upgrade.ts) — client is constructed lazily inside
+// callClaude() so that --dry-run (selection only) never touches
+// ANTHROPIC_API_KEY or requires it to be set.
+// ---------------------------------------------------------------------------
+
+async function callClaude(systemPrompt: string, userPrompt: string, model: string): Promise<string> {
+  const client = new Anthropic({ apiKey: process.env['ANTHROPIC_API_KEY'] });
+  const response = await client.messages.create({
+    model,
+    max_tokens: MAX_TOKENS,
+    system: systemPrompt,
+    messages: [{ role: 'user', content: userPrompt }],
+  });
+  const textBlock = response.content.find((b) => b.type === 'text');
+  if (!textBlock || textBlock.type !== 'text') throw new Error('No text block in LLM response');
+  return textBlock.text;
+}
+
+// ---------------------------------------------------------------------------
+// Engine-accurate regex gate (mirrors src/engine.ts's normalizeRegex + the
+// auto 'iu' flag rule EXACTLY — see compilePatterns() in src/engine.ts and
+// the identical helper in scripts/fn-mine-llm.ts).
+// ---------------------------------------------------------------------------
+
+function normalizeRegex(pattern: string): string {
+  return pattern.replace(/^\(\?[imsx]+\)/, '');
+}
+
+function compileEngineAccurate(value: string): RegExp | null {
+  const pattern = normalizeRegex(value);
+  const flags = pattern.includes('\\u{') || pattern.includes('\\p{') ? 'iu' : 'i';
+  try {
+    return new RegExp(pattern, flags);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Load every regex condition from every rule currently on disk, REGARDLESS of
+ * maturity/status (draft included — a rule authored by a prior cve-mine run
+ * for the same CVE still exists on disk even if never promoted past draft;
+ * mining that CVE again tomorrow would just produce a near-duplicate PR).
+ *
+ * NOTE: scripts/fn-mine-llm.ts's loadAllExistingRegexes() extracts `value:`
+ * lines via a raw-text regex (to avoid a full YAML parse per rule) and only
+ * unescapes quote characters before compiling. That is WRONG for any pattern
+ * containing a YAML-double-quoted backslash escape (\\s, \\b, \\u0400, ...):
+ * the raw file bytes for `"[\\u0400-\\u04FF]"` contain a literal two-character
+ * `\\` followed by `u0400`, and constructing `new RegExp()` directly from
+ * that raw text (without YAML-unescaping `\\` -> `\`) turns the intended
+ * codepoint-range escape into a bare `\` character inside a `[...]` class —
+ * which then forms an accidental range like `0-\` (0x30-0x5C) that matches
+ * huge swaths of ordinary ASCII text. Verified empirically: this corrupted-
+ * regex bug made `[\\u0400-\\u04FF][a-zA-Z]|...` match plain English prose
+ * like "xyzzy nonsense unrelated text", which silently made EVERY CVE-mine
+ * candidate here look "already covered". Parsing each rule file with the
+ * real YAML loader (same as check-rules-safety.ts / lint-rule-patterns.ts)
+ * avoids the bug entirely, at a real but small cost (~700 rule files).
+ */
+function loadAllExistingRegexes(): RegExp[] {
+  const out: RegExp[] = [];
+  const walk = (dir: string): void => {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const p = path.join(dir, entry.name);
+      if (entry.isDirectory()) { walk(p); continue; }
+      if (!entry.name.endsWith('.yaml')) continue;
+      let doc: Record<string, unknown>;
+      try {
+        doc = yamlLoad(fs.readFileSync(p, 'utf8')) as Record<string, unknown>;
+      } catch {
+        continue;
+      }
+      if (!doc || typeof doc !== 'object') continue;
+      const det = (doc.detection ?? {}) as Record<string, unknown>;
+      const conds = (det.conditions ?? []) as Array<Record<string, unknown>>;
+      for (const c of conds) {
+        if (c && c.operator === 'regex' && typeof c.value === 'string') {
+          const re = compileEngineAccurate(c.value);
+          if (re) out.push(re);
+        }
+      }
+    }
+  };
+  walk(path.join(REPO_ROOT, 'rules'));
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Promotion state (idempotency) — data/cve-collector/promoted.json
+// ---------------------------------------------------------------------------
+
+interface PromotionState {
+  promoted: Record<string, { ruleId: string; file: string; promotedAt: string }>;
+  skipped: Record<string, { reason: string; attempts: number; lastAttempt: string }>;
+}
+
+function loadState(): PromotionState {
+  const abs = path.join(REPO_ROOT, STATE_PATH);
+  if (!fs.existsSync(abs)) return { promoted: {}, skipped: {} };
+  try {
+    const parsed = JSON.parse(fs.readFileSync(abs, 'utf8'));
+    return { promoted: parsed.promoted ?? {}, skipped: parsed.skipped ?? {} };
+  } catch {
+    return { promoted: {}, skipped: {} };
+  }
+}
+
+function saveState(state: PromotionState): void {
+  const abs = path.join(REPO_ROOT, STATE_PATH);
+  fs.mkdirSync(path.dirname(abs), { recursive: true });
+  fs.writeFileSync(abs, JSON.stringify(state, null, 2) + '\n');
+}
+
+// ---------------------------------------------------------------------------
+// Proposal loading + candidate selection
+// ---------------------------------------------------------------------------
+
+function walkProposalFiles(dir: string): string[] {
+  const out: string[] = [];
+  const walk = (d: string): void => {
+    for (const entry of fs.readdirSync(d, { withFileTypes: true })) {
+      const p = path.join(d, entry.name);
+      if (entry.isDirectory()) { walk(p); continue; }
+      if (entry.name.endsWith('.proposal.yaml')) out.push(p);
+    }
+  };
+  if (fs.existsSync(dir)) walk(dir);
+  return out;
+}
+
+interface ProposalCandidate {
+  relPath: string;
+  doc: Record<string, unknown>;
+  title: string;
+  category: string;
+  payloadText: string;
+  testPositives: string[];
+  score: number;
+}
+
+/**
+ * Pull every string worth showing to the LLM out of a proposal doc: the
+ * description, any already-populated test_cases.true_positives (benchmark
+ * imports ship the real attack string here), and every `_*_sync` provenance
+ * block's advisory_body / poc_body fields (GHSA/Huntr/vulnerablemcp/etc. sync
+ * scripts attach the real advisory or PoC text there as plain YAML strings,
+ * not comments — see e.g. proposals/huntr/*.proposal.yaml).
+ */
+function extractProvenanceText(doc: Record<string, unknown>): { text: string; tps: string[] } {
+  const parts: string[] = [];
+  if (typeof doc.description === 'string') parts.push(doc.description);
+
+  const tps: string[] = [];
+  const testCases = doc.test_cases as { true_positives?: Array<{ input?: string } | string> } | undefined;
+  for (const tp of testCases?.true_positives ?? []) {
+    const input = typeof tp === 'string' ? tp : tp?.input;
+    if (typeof input === 'string' && input.trim()) {
+      tps.push(input);
+      parts.push(input);
+    }
+  }
+
+  for (const [key, value] of Object.entries(doc)) {
+    if (!key.startsWith('_')) continue;
+    if (!value || typeof value !== 'object') continue;
+    for (const [subKey, subValue] of Object.entries(value as Record<string, unknown>)) {
+      if (typeof subValue !== 'string') continue;
+      if (/advisory_body|poc_body|advisory_summary/i.test(subKey)) parts.push(subValue);
+    }
+  }
+
+  return { text: parts.join('\n'), tps };
+}
+
+/**
+ * Coarse local heuristic for "this proposal has a concrete, groundable
+ * PoC/payload" — deliberately cheap (no LLM call) so we don't burn API
+ * tokens ranking ~4,800 mostly-prose proposals. False positives here just
+ * cost one wasted authoring call (caught downstream by self-test/gate);
+ * false negatives just mean a good candidate waits for the heuristic to be
+ * refined later — neither is a safety problem, unlike the reverse.
+ */
+const PAYLOAD_SIGNAL_RE =
+  /```|method:\s*(get|post|put|delete)|(?:^|\s)(?:curl|wget)\s|\.\.\/\.\.\/|\$\([^)]*\)|`[^`\n]{2,80}`|<script|\$\{[a-z_]+\}|\beval\(|\bexec\(|os\.system\(|subprocess\.|require\(unsafe|base64|%60|%2e%2e|ifs[-_]?d|payload:|ignore (?:all |previous |the )?instructions|jailbreak|shell metacharacter|command injection|sql injection|deserializ|path traversal|prompt injection payload|malicious (?:tool|skill|package|payload)/i;
+
+function hasConcretePayloadSignal(text: string): boolean {
+  return PAYLOAD_SIGNAL_RE.test(text);
+}
+
+/**
+ * Agent/AI-relevance filter. `proposals/` is populated by an upstream
+ * collector that already applies its own "is this agent-relevant" filter per
+ * source (see data/cve-collector/last-run.json's per-source
+ * `filtered_not_agent` counts) — but that upstream filter is demonstrably
+ * noisy: e.g. plain historical web-app CVEs (a 2015 PHP SQLi, phpMyFAQ,
+ * pam_usb) slipped through because their advisory text happens to contain the
+ * substring "agent" in an unrelated sense (a POST parameter literally named
+ * `agent[]`, a `User-Agent` HTTP header, a Linux daemon named `*-agent`).
+ * Every proposals/owasp-asi/* file is *also* contaminated for this purpose:
+ * its collector-generated description boilerplate always starts with
+ * "OWASP Agentic AI Security Incident INC-NNNNN." regardless of whether the
+ * underlying incident has anything to do with AI agents (a security
+ * researcher's report merely disclosing "I used an LLM to help review this
+ * code" is enough to taint a totally unrelated Caddy/rustls-webpki CVE).
+ * stripCollectorBoilerplate() removes that specific known contamination
+ * before testing; AGENT_CONTEXT_WORD_RE additionally requires bare "agent"
+ * mentions to co-occur with actual agent/tooling vocabulary rather than
+ * matching on the word alone.
+ */
+const AGENT_STRONG_RE =
+  /\bmcp\b|model context protocol|\bllm\b|langchain|langgraph|autogen|crewai|semantic kernel|praisonai|huggingface|hugging face|litellm|vllm|sglang|ollama|\bgpt-?\d|\bclaude\b|anthropic|openai|copilot|chatbot|prompt injection|jailbreak|vector (?:store|database|db)|embedding model|rag pipeline|inference (?:server|endpoint)|model serving|sagemaker|bedrock|vertex ai|\bskill\.?md\b|tool[- ]poisoning|tool[- ]invocation|generative ai|\bgenai\b|\bagentic\b|multi-agent|ai agent|llm agent|autonomous agent|agent framework|agent runtime|agent sdk|agent-to-agent|agent orchestrat/i;
+const AGENT_CONTEXT_WORD_RE = /\btool\b|\bframework\b|\bruntime\b|\bsdk\b|orchestrat|\bworkflow\b|callable|autonom/i;
+
+function stripCollectorBoilerplate(text: string): string {
+  return text
+    .replace(/^OWASP Agentic AI Security Incidents?.*$/gim, '')
+    .replace(/^OWASP ASI:.*$/gim, '')
+    .replace(/^#* ?AI Disclosure.*$/gim, '');
+}
+
+function isAgentRelevant(rawText: string): boolean {
+  const text = stripCollectorBoilerplate(rawText);
+  if (AGENT_STRONG_RE.test(text)) return true;
+  return /\bagents?\b/i.test(text) && AGENT_CONTEXT_WORD_RE.test(text);
+}
+
+/**
+ * Extract a SHORT window around the actual payload signal for the
+ * "already covered by an existing rule" probe. Using the full multi-hundred/
+ * multi-thousand-char advisory prose blob as the probe is too aggressive —
+ * dense security-advisory text naturally contains many generic
+ * security-relevant tokens (exec, delete, admin, token, session, curl, ...)
+ * that coincidentally trip SOME existing rule's regex out of 2000+ patterns
+ * on any long-enough passage, producing near-100% false "already covered"
+ * exclusion. A tight window around the concrete payload marker is a much
+ * fairer analogue of fn-mine-llm.ts's per-attack-text probe.
+ */
+function extractPayloadSnippet(text: string): string {
+  const m = PAYLOAD_SIGNAL_RE.exec(text);
+  if (!m || m.index === undefined) return text.slice(0, 200);
+  const start = Math.max(0, m.index - 80);
+  return text.slice(start, start + 320);
+}
+
+/**
+ * Ranking score: EPSS exploit-probability (real-world exploitation pressure,
+ * additive prioritisation signal used by the collector's own PoC comments)
+ * dominates; a labelled benchmark true_positive and higher severity are
+ * secondary boosts.
+ */
+function scoreCandidate(doc: Record<string, unknown>, hasTps: boolean): number {
+  let score = 0;
+  const epss = doc._epss as { score?: number } | undefined;
+  if (typeof epss?.score === 'number') score += epss.score * 100;
+  if (hasTps) score += 5;
+  const severity = String((doc as { severity?: string }).severity ?? '').toLowerCase();
+  score += { critical: 4, high: 3, medium: 2, low: 1 }[severity] ?? 0;
+  return score;
+}
+
+function selectCandidates(
+  state: PromotionState,
+  existingRegexes: readonly RegExp[],
+  gatherLimit: number,
+): ProposalCandidate[] {
+  const files = walkProposalFiles(path.join(REPO_ROOT, PROPOSALS_DIR));
+  const out: ProposalCandidate[] = [];
+
+  for (const abs of files) {
+    const relPath = path.relative(REPO_ROOT, abs);
+    if (state.promoted[relPath]) continue;
+    const skip = state.skipped[relPath];
+    if (skip && skip.attempts >= MAX_ATTEMPTS_BEFORE_SKIP) continue;
+
+    let doc: Record<string, unknown>;
+    try {
+      doc = yamlLoad(fs.readFileSync(abs, 'utf8')) as Record<string, unknown>;
+    } catch {
+      continue;
+    }
+    if (!doc || typeof doc !== 'object') continue;
+
+    const tags = doc.tags as { category?: string } | undefined;
+    const category = tags?.category ?? '';
+    if (!VALID_CATEGORIES.has(category)) continue;
+
+    const triage = doc._triage as { detection_ready?: boolean } | undefined;
+    if (triage?.detection_ready !== true) continue;
+
+    const { text, tps } = extractProvenanceText(doc);
+    if (!hasConcretePayloadSignal(text)) continue;
+    if (!isAgentRelevant(text)) continue;
+
+    // "Already covered" — same semantics as fn-mine-llm.ts's
+    // filterAlreadyCovered(), applied to a short window around this
+    // proposal's own payload text instead of a mined FN corpus text.
+    const probe = tps[0] ? tps[0].slice(0, 320) : extractPayloadSnippet(text);
+    if (existingRegexes.some((re) => re.test(probe))) continue;
+
+    const title = typeof doc.title === 'string' ? doc.title : relPath;
+    out.push({
+      relPath,
+      doc,
+      title,
+      category,
+      payloadText: text.slice(0, 4000),
+      testPositives: tps,
+      score: scoreCandidate(doc, tps.length > 0),
+    });
+  }
+
+  out.sort((a, b) => b.score - a.score);
+  return out.slice(0, gatherLimit);
+}
+
+// ---------------------------------------------------------------------------
+// Authoring (Claude writes the full ATR rule YAML for one candidate)
+// ---------------------------------------------------------------------------
+
+const COMPLIANCE_CHEAT_SHEET = `Valid compliance/reference identifiers (use ONLY these — anything else fails CI's allowlist validation):
+owasp_agentic (references.owasp_agentic + compliance.owasp_agentic, id format "ASIxx:2026 - <name>"):
+  ASI01:2026 Agent Goal Hijack | ASI02:2026 Tool Misuse & Exploitation | ASI03:2026 Identity & Privilege Abuse
+  ASI04:2026 Agentic Supply Chain | ASI05:2026 Unexpected Code Execution (RCE) | ASI06:2026 Memory & Context Poisoning
+  ASI07:2026 Insecure Inter-Agent Communication | ASI08:2026 Cascading Failures | ASI09:2026 Human-Agent Trust Exploitation
+  ASI10:2026 Rogue Agents
+owasp_llm (references.owasp_llm + compliance.owasp_llm, id format "LLMxx:2025 - <name>"):
+  LLM01:2025 Prompt Injection | LLM02:2025 Sensitive Information Disclosure | LLM03:2025 Supply Chain
+  LLM04:2025 Data and Model Poisoning | LLM05:2025 Improper Output Handling | LLM06:2025 Excessive Agency
+  LLM07:2025 System Prompt Leakage | LLM08:2025 Vector and Embedding Weaknesses | LLM09:2025 Misinformation
+  LLM10:2025 Unbounded Consumption
+mitre_atlas (references.mitre_atlas only, no allowlist but must be a REAL technique — never fabricate):
+  AML.T0051 LLM Prompt Injection | AML.T0051.001 Indirect | AML.T0053 AI Agent Tool Invocation | AML.T0054 LLM Jailbreak
+compliance.eu_ai_act (article field — pick 2, primary+secondary): article 15 (accuracy/robustness/cybersecurity, use as primary for anything technique-specific) + article 9 (risk management system, secondary)
+compliance.nist_ai_rmf (subcategory field — pick 2, primary+secondary): MG.2.3 (procedures respond to previously unknown identified risks, primary) + MS.2.7 (security and resilience evaluated and documented, secondary) — OR for supply-chain/dependency techniques use MG.3.2 (pre-trained/third-party components monitored, primary) + MP.5.1 (impact likelihood/magnitude identified, secondary)
+compliance.iso_42001 (clause field — pick 2, primary+secondary): clause 8.1 (operational planning and control, primary) + clause 8.3 (AI risk treatment, secondary)`;
+
+const NOT_AGENT_RELEVANT_SENTINEL = 'NOT_AGENT_RELEVANT';
+
+function buildAuthorSystemPrompt(referenceYaml: string): string {
+  return `You are authoring ONE payload-grounded ATR detection rule YAML file from a real CVE/advisory proposal. NEVER mention PanGuard anywhere in the output — ATR is a fully independent open standard.
+
+FIRST — relevance check: ATR only detects attacks specific to AI agents / LLM applications / MCP servers / agent tooling. A local keyword filter selected this proposal, but that filter has known false positives — e.g. a security researcher's report merely disclosing "I used an LLM to help review this code" (Caddy, rustls-webpki), or an advisory field literally named "agent[]" / a "User-Agent" HTTP header / a Linux daemon named "*-agent" — none of which make the underlying vulnerability agent-relevant. If, after reading the actual source material below, the vulnerability is a generic infrastructure/web/library bug with NO real connection to an AI agent, LLM application, MCP server, or agent tool/framework, respond with EXACTLY the single line \`${NOT_AGENT_RELEVANT_SENTINEL}\` (nothing else) instead of a YAML rule. Do not force a rule onto an irrelevant CVE just because you were asked to author one.
+
+If it IS genuinely agent-relevant, copy this reference rule's structure EXACTLY (field order; references block with owasp_llm/owasp_agentic/mitre_atlas/cve/cwe; compliance block with ALL of owasp_agentic/owasp_llm/eu_ai_act/nist_ai_rmf/iso_42001; metadata_provenance; tags; agent_source; detection; response; confidence; wild_fp_rate; test_cases; _llm_authored):
+
+--- REFERENCE RULE ---
+${referenceYaml}
+--- END REFERENCE ---
+
+${COMPLIANCE_CHEAT_SHEET}
+
+Requirements:
+- Ground detection.conditions in the REAL CVE/advisory/PoC text you are given — never invent an attack mechanism not present in the source material.
+- The regex must anchor on the SPECIFIC vulnerable construct (product/component name + the exploited mechanism — command, path, deserialization gadget, injection sink), not a bare generic keyword. Generic terms alone (curl, exec, eval, request) cause false positives on install docs and normal code; the specific product/CVE context must co-occur with the mechanism, matching how the reference rule requires BOTH the "framelink/figma" anchor AND the exec/curl-fallback sink.
+- Bridge spans [\\s\\S]{0,N} between anchor and sink: keep N <= 30 unless the two tokens genuinely cannot appear closer in any real payload — wide bridges ({0,150}+) caused a real CI latency regression in this repo. Prefer several tight, specific conditions over one wide loose one.
+- Use (?i) as a leading inline flag for case-insensitivity (the engine strips this prefix and reapplies it as a real regex flag).
+- NEVER an unbounded .* — use bounded [\\s\\S]{0,N} spans instead (N <= 30).
+- Add \\b word boundaries around bare keyword tokens (nc, sh, id, host, exec, eval, curl, wget, etc. are the confirmed FP-prone class — see this repo's lint).
+- test_cases.true_positives: 2-4 realistic attack strings GROUNDED in the actual CVE/PoC/advisory text you were given (paraphrase/adapt the real payload into a plausible in-context event string; do not fabricate an unrelated attack).
+- test_cases.true_negatives: 4-6 benign texts you write that do NOT match your regex — include generic versions of the vulnerable product's normal (non-exploit) usage, and any CVE-patch-discussion / research-abstract sentence that merely NAMES the CVE without a live payload (must not fire).
+- status: draft, maturity: test, author: "ATR Community", severity: match the proposal's severity (critical/high/medium/low).
+- wild_fp_rate: 0.
+
+OUTPUT FORMAT: pure YAML, no markdown fences, no prose before or after. The output must be a single complete, valid YAML document.`;
+}
+
+function buildAuthorUserPrompt(id: string, c: ProposalCandidate): string {
+  const refs = (c.doc.references ?? {}) as Record<string, unknown>;
+  const cveIds = (refs.cve as string[] | undefined) ?? [];
+  const cwe = (refs.cwe as string[] | undefined) ?? [];
+  const external = (refs.external as string[] | undefined) ?? [];
+  return `id: ${id}
+category: ${c.category}
+title: ${c.title}
+CVE(s): ${cveIds.join(', ') || '(none — non-CVE source, e.g. benchmark or standards-body incident)'}
+CWE(s): ${cwe.join(', ') || '(none)'}
+external references: ${external.slice(0, 3).join(' | ')}
+severity: ${String((c.doc as { severity?: string }).severity ?? 'medium')}
+labelled true_positive payload(s) from source (use as grounding, adapt into test_cases): ${c.testPositives.length ? JSON.stringify(c.testPositives.slice(0, 3)) : '(none pre-labelled — extract from the advisory/PoC text below)'}
+
+REAL ADVISORY / PoC / DESCRIPTION TEXT (this is the ONLY source material — ground the regex and test cases in this, do not invent details):
+${c.payloadText}`;
+}
+
+async function authorRule(
+  id: string,
+  c: ProposalCandidate,
+  referenceYaml: string,
+  model: string,
+  correctionNote?: string,
+): Promise<string> {
+  const system = buildAuthorSystemPrompt(referenceYaml);
+  const user =
+    buildAuthorUserPrompt(id, c) +
+    (correctionNote ? `\n\nPREVIOUS ATTEMPT FAILED: ${correctionNote}\nFix this specific issue and output the complete corrected YAML.` : '');
+  const raw = await callClaude(system, user, model);
+  return raw.trim().replace(/^```(?:yaml)?\s*\n?/i, '').replace(/\n?```\s*$/i, '');
+}
+
+function slugify(s: string): string {
+  return s.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '').slice(0, 60);
+}
+
+/** Runs `node dist/cli.js test <file>`; returns null on success, failure text otherwise. */
+function selfTest(filePath: string): string | null {
+  try {
+    const out = execSync(`node dist/cli.js test ${JSON.stringify(filePath)}`, { cwd: REPO_ROOT, encoding: 'utf8' });
+    if (/All tests passed/.test(out)) return null;
+    return out.slice(-1500);
+  } catch (e) {
+    const out = e instanceof Error && 'stdout' in e ? String((e as { stdout?: unknown }).stdout ?? '') : '';
+    return (out || String(e)).slice(-1500);
+  }
+}
+
+/** Max {0,N} bridge span across every regex condition in a rule YAML's text. */
+function maxBridgeSpan(yamlText: string): number {
+  let max = 0;
+  for (const m of yamlText.matchAll(/\{0,(\d+)\}/g)) {
+    const n = Number(m[1]);
+    if (n > max) max = n;
+  }
+  return max;
+}
+
+// ---------------------------------------------------------------------------
+// Safety-gate integration (repo's own 65K-benign / cross-rule-conflict gate)
+// — identical to scripts/fn-mine-llm.ts's runSafetyGate().
+// ---------------------------------------------------------------------------
+
+interface SafetyGateResult {
+  pass: boolean;
+  failedFiles: string[];
+  raw: string;
+}
+
+function runSafetyGate(): SafetyGateResult {
+  let raw = '';
+  let pass = false;
+  try {
+    raw = execSync('npx tsx scripts/check-rules-safety.ts --base origin/main', { cwd: REPO_ROOT, encoding: 'utf8' });
+    pass = /PASS —/.test(raw);
+  } catch (e) {
+    raw = e instanceof Error && 'stdout' in e ? String((e as { stdout?: unknown }).stdout ?? '') : String(e);
+    pass = false;
+  }
+  const failedFiles: string[] = [];
+  const re = /✗\s+(rules\/\S+\.yaml)/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(raw)) !== null) failedFiles.push(m[1]);
+  return { pass, failedFiles, raw };
+}
+
+/**
+ * Latency-regression gate: this repo's real p95/avg-latency vitest assertions
+ * (tests/skill-benchmark.test.ts, tests/eval-harness.test.ts) run over the
+ * FULL live rule corpus. A prior session found overly-wide [\s\S]{0,N} bridge
+ * spans in new rules blow this budget even when the safety gate (which never
+ * measures latency) passes clean. Run these two files specifically rather
+ * than the whole suite to keep the check fast and attributable.
+ */
+function runLatencyGate(): { pass: boolean; raw: string } {
+  let raw = '';
+  let pass = false;
+  try {
+    raw = execSync('npx vitest run tests/skill-benchmark.test.ts tests/eval-harness.test.ts', {
+      cwd: REPO_ROOT,
+      encoding: 'utf8',
+    });
+    pass = true;
+  } catch (e) {
+    raw = e instanceof Error && 'stdout' in e ? String((e as { stdout?: unknown }).stdout ?? '') : String(e);
+    pass = false;
+  }
+  return { pass, raw };
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+interface AuthoredRule {
+  id: string;
+  file: string;
+  relPath: string;
+  title: string;
+}
+
+async function main(): Promise<void> {
+  const { values } = parseArgs({
+    options: {
+      'dry-run': { type: 'boolean', default: false },
+      cap: { type: 'string', default: '8' },
+      model: { type: 'string', default: DEFAULT_MODEL },
+    },
+  });
+  const cap = parseInt(values.cap as string, 10);
+  const model = values.model as string;
+  const isDryRun = values['dry-run'] as boolean;
+
+  console.log(`[cve-mine] model=${model} cap=${cap} dryRun=${isDryRun}`);
+
+  const state = loadState();
+  console.log(
+    `[cve-mine] state: ${Object.keys(state.promoted).length} previously promoted, ${Object.keys(state.skipped).length} parked/skipped`,
+  );
+
+  const existingRegexes = loadAllExistingRegexes();
+  console.log(`[cve-mine] existing rule regexes on disk (any status, incl. draft): ${existingRegexes.length}`);
+
+  const gatherLimit = Math.max(cap * 4, cap + 20);
+  const candidates = selectCandidates(state, existingRegexes, gatherLimit);
+  console.log(`[cve-mine] ${candidates.length} candidate proposal(s) selected (of a much larger backlog) after filtering:`);
+  console.log('[cve-mine]   detection_ready=true + valid ATR category + concrete-payload heuristic + not already covered + not previously promoted/parked');
+  for (const c of candidates.slice(0, 15)) {
+    console.log(`[cve-mine]   score=${c.score.toFixed(2)} ${c.relPath} — ${c.title}`);
+  }
+
+  if (candidates.length === 0) {
+    console.log('[cve-mine] NULL RESULT — no eligible candidates this run. Not an error.');
+    fs.mkdirSync(path.join(REPO_ROOT, path.dirname(REPORT_PATH)), { recursive: true });
+    fs.writeFileSync(path.join(REPO_ROOT, REPORT_PATH), JSON.stringify({ authored: [], note: 'null result — no eligible candidates' }, null, 2));
+    console.log('::authored-files::');
+    return;
+  }
+
+  if (isDryRun) {
+    console.log('[cve-mine] --dry-run: stopping before authoring. Top candidates:');
+    console.log(JSON.stringify(candidates.slice(0, cap).map((c) => ({ relPath: c.relPath, title: c.title, category: c.category, score: c.score })), null, 2));
+    return;
+  }
+
+  // Allocate IDs collision-safely against the CURRENT origin/main tip (+ open
+  // PRs) via the repo's own helper — never a local/stale generator.
+  const idsNeeded = Math.min(candidates.length, cap + 10);
+  const idsRaw = execSync(`npx tsx scripts/next-rule-id.ts ${idsNeeded} --include-open-prs --json`, {
+    cwd: REPO_ROOT,
+    encoding: 'utf8',
+  });
+  const ids: string[] = JSON.parse(idsRaw).ids;
+  let idIdx = 0;
+
+  const referenceYaml = fs.readFileSync(path.join(REPO_ROOT, REFERENCE_RULE), 'utf8');
+  const authored: AuthoredRule[] = [];
+  const attemptedThisRun = new Set<string>();
+
+  for (const c of candidates) {
+    if (authored.length >= cap) break;
+    if (idIdx >= ids.length) break;
+    const id = ids[idIdx++];
+    attemptedThisRun.add(c.relPath);
+
+    const slug = slugify(c.title);
+    const file = `rules/${c.category}/${id}-${slug}.yaml`;
+    const fullPath = path.join(REPO_ROOT, file);
+    fs.mkdirSync(path.dirname(fullPath), { recursive: true });
+
+    console.log(`[cve-mine] authoring ${id} (${c.relPath} — ${c.title})...`);
+    let yaml: string;
+    try {
+      yaml = await authorRule(id, c, referenceYaml, model);
+    } catch (e) {
+      console.log(`[cve-mine]   authoring call failed: ${e instanceof Error ? e.message : String(e)} — dropping.`);
+      state.skipped[c.relPath] = bumpSkip(state.skipped[c.relPath], 'authoring API call failed');
+      continue;
+    }
+    if (yaml.trim() === NOT_AGENT_RELEVANT_SENTINEL) {
+      console.log(`[cve-mine]   ${id} — author judged this NOT agent-relevant despite passing the local keyword filter. Dropping, not counted against the retry budget.`);
+      fs.rmSync(fullPath, { force: true });
+      // Park permanently (not a transient failure) so this proposal never re-surfaces.
+      state.skipped[c.relPath] = { reason: 'author judged not agent-relevant', attempts: MAX_ATTEMPTS_BEFORE_SKIP, lastAttempt: new Date().toISOString() };
+      idIdx--; // return the unused id to the pool for the next candidate
+      continue;
+    }
+    fs.writeFileSync(fullPath, yaml.endsWith('\n') ? yaml : yaml + '\n');
+
+    // Bridge-span lint (hard local gate — stricter than the repo's own
+    // advisory-only lint threshold, per this session's latency-regression
+    // lesson): one corrective retry, then drop.
+    let span = maxBridgeSpan(yaml);
+    if (span > MAX_BRIDGE_SPAN) {
+      console.log(`[cve-mine]   bridge span ${span} exceeds ${MAX_BRIDGE_SPAN} — one corrective retry for ${id}...`);
+      try {
+        yaml = await authorRule(id, c, referenceYaml, model, `Bridge span {0,${span}} exceeds the maximum allowed {0,${MAX_BRIDGE_SPAN}} — tighten every [\\s\\S]{0,N} span to N<=${MAX_BRIDGE_SPAN}, adding more specific anchor conditions if needed instead of widening spans.`);
+      } catch (e) {
+        console.log(`[cve-mine]   retry authoring call failed: ${e instanceof Error ? e.message : String(e)} — dropping.`);
+        fs.rmSync(fullPath, { force: true });
+        state.skipped[c.relPath] = bumpSkip(state.skipped[c.relPath], 'authoring retry API call failed');
+        continue;
+      }
+      fs.writeFileSync(fullPath, yaml.endsWith('\n') ? yaml : yaml + '\n');
+      span = maxBridgeSpan(yaml);
+    }
+    if (span > MAX_BRIDGE_SPAN) {
+      console.log(`[cve-mine]   DROPPING ${id} — bridge span still ${span} after retry.`);
+      fs.rmSync(fullPath, { force: true });
+      state.skipped[c.relPath] = bumpSkip(state.skipped[c.relPath], `bridge span ${span} still exceeds ${MAX_BRIDGE_SPAN} after retry`);
+      continue;
+    }
+
+    let failure = selfTest(file);
+    if (failure) {
+      console.log(`[cve-mine]   self-test failed, one corrective retry for ${id}...`);
+      try {
+        yaml = await authorRule(id, c, referenceYaml, model, failure);
+      } catch (e) {
+        console.log(`[cve-mine]   retry authoring call failed: ${e instanceof Error ? e.message : String(e)} — dropping.`);
+        fs.rmSync(fullPath, { force: true });
+        state.skipped[c.relPath] = bumpSkip(state.skipped[c.relPath], 'self-test retry API call failed');
+        continue;
+      }
+      fs.writeFileSync(fullPath, yaml.endsWith('\n') ? yaml : yaml + '\n');
+      failure = selfTest(file);
+    }
+    if (failure) {
+      console.log(`[cve-mine]   DROPPING ${id} — self-test still failing after retry:\n${failure}`);
+      fs.rmSync(fullPath, { force: true });
+      state.skipped[c.relPath] = bumpSkip(state.skipped[c.relPath], `self-test failed after retry: ${failure.slice(0, 300)}`);
+      continue;
+    }
+
+    authored.push({ id, file, relPath: c.relPath, title: c.title });
+  }
+
+  if (authored.length === 0) {
+    console.log('[cve-mine] NULL RESULT — every candidate failed self-test/bridge-span even after retry. Not an error.');
+    saveState(state);
+    console.log('::authored-files::');
+    return;
+  }
+
+  // Repo-standard gates: build, regenerate crosswalk docs (always stale after
+  // a rule change), then the safety gate. Drop (not force-fix) anything the
+  // gate rejects and re-run once on the remainder.
+  execSync('npm run build', { cwd: REPO_ROOT, stdio: 'inherit' });
+  execSync('python3 scripts/generate-attack-crosswalk.py', { cwd: REPO_ROOT, stdio: 'inherit' });
+  execSync('python3 scripts/generate-ast-crosswalk.py', { cwd: REPO_ROOT, stdio: 'inherit' });
+
+  for (let attempt = 0; attempt < 2 && authored.length > 0; attempt++) {
+    const gate = runSafetyGate();
+    if (gate.pass) break;
+    const dropIds = new Set(gate.failedFiles);
+    const before = authored.length;
+    for (let i = authored.length - 1; i >= 0; i--) {
+      if (dropIds.has(authored[i].file)) {
+        const reason = gate.raw.match(new RegExp(`✗\\s+${authored[i].file.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}.*`))?.[0] ?? 'safety gate rejected';
+        console.log(`[cve-mine]   safety-gate rejected ${authored[i].id} — dropping: ${reason}`);
+        fs.rmSync(path.join(REPO_ROOT, authored[i].file), { force: true });
+        state.skipped[authored[i].relPath] = bumpSkip(state.skipped[authored[i].relPath], `safety gate: ${reason.slice(0, 300)}`);
+        authored.splice(i, 1);
+      }
+    }
+    if (authored.length === before) {
+      console.log('[cve-mine] safety gate failed without attributable per-file rejections — dropping entire batch to be safe.');
+      for (const a of authored) {
+        fs.rmSync(path.join(REPO_ROOT, a.file), { force: true });
+        state.skipped[a.relPath] = bumpSkip(state.skipped[a.relPath], 'safety gate failed batch-wide, unattributable');
+      }
+      authored.length = 0;
+    }
+  }
+
+  if (authored.length > 0) {
+    execSync('python3 scripts/generate-attack-crosswalk.py', { cwd: REPO_ROOT, stdio: 'inherit' });
+    execSync('python3 scripts/generate-ast-crosswalk.py', { cwd: REPO_ROOT, stdio: 'inherit' });
+  }
+
+  if (authored.length === 0) {
+    console.log('[cve-mine] NULL RESULT after safety-gate — nothing survived. Not an error.');
+    saveState(state);
+    console.log('::authored-files::');
+    return;
+  }
+
+  // Latency-regression gate (this session's real lesson: safety gate alone
+  // does not catch wide-bridge-span latency regressions). Bail the WHOLE
+  // batch if it fails — attributing a p95 regression to one specific rule
+  // among several requires per-rule profiling this script does not do, and
+  // "drop, don't force-fix" means the safe default is to hold the batch back
+  // for human triage rather than guess which rule to cut.
+  console.log('[cve-mine] running latency-regression gate (tests/skill-benchmark.test.ts + tests/eval-harness.test.ts)...');
+  const latency = runLatencyGate();
+  if (!latency.pass) {
+    console.log('[cve-mine] LATENCY GATE FAILED — dropping entire batch (bridge-span discipline was insufficient to prevent a corpus-wide regression):');
+    console.log(latency.raw.slice(-2000));
+    for (const a of authored) {
+      fs.rmSync(path.join(REPO_ROOT, a.file), { force: true });
+      state.skipped[a.relPath] = bumpSkip(state.skipped[a.relPath], 'latency-regression gate failed batch-wide');
+    }
+    authored.length = 0;
+    execSync('python3 scripts/generate-attack-crosswalk.py', { cwd: REPO_ROOT, stdio: 'inherit' });
+    execSync('python3 scripts/generate-ast-crosswalk.py', { cwd: REPO_ROOT, stdio: 'inherit' });
+    saveState(state);
+    console.log('::authored-files::');
+    return;
+  }
+  console.log('[cve-mine] latency gate PASS.');
+
+  // Mark every attempted proposal (success or otherwise) so re-runs don't
+  // re-select it. Successes go to `promoted`; anything left in `skipped` from
+  // the loop above already recorded its failure reason with an attempt count.
+  const now = new Date().toISOString();
+  for (const a of authored) {
+    state.promoted[a.relPath] = { ruleId: a.id, file: a.file, promotedAt: now };
+    delete state.skipped[a.relPath]; // no longer needed once promoted
+  }
+  saveState(state);
+
+  fs.mkdirSync(path.join(REPO_ROOT, path.dirname(REPORT_PATH)), { recursive: true });
+  fs.writeFileSync(
+    path.join(REPO_ROOT, REPORT_PATH),
+    JSON.stringify({ authored, attemptedThisRun: [...attemptedThisRun], backlogRemainingEstimateNote: 'see proposals/ minus data/cve-collector/promoted.json' }, null, 2),
+  );
+  console.log(`[cve-mine] DONE — ${authored.length} rule(s) authored and gate-clean: ${authored.map((a) => a.id).join(', ')}`);
+  console.log(`::authored-files::${authored.map((a) => a.file).join(',')},${STATE_PATH}`);
+  console.log(`::report-file::${REPORT_PATH}`);
+}
+
+function bumpSkip(
+  prior: { reason: string; attempts: number; lastAttempt: string } | undefined,
+  reason: string,
+): { reason: string; attempts: number; lastAttempt: string } {
+  return { reason, attempts: (prior?.attempts ?? 0) + 1, lastAttempt: new Date().toISOString() };
+}
+
+main().catch((e) => {
+  console.error('[cve-mine] FATAL:', e);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

PR #243 (2026-07-01, "chore(moat): un-publish the entire rule-production
flywheel") deleted the entire CVE-proposal-to-rule CONVERSION pipeline
(cve-daily-sync.yml, promote-cve.yml, red-team-probe-to-pr.yml,
author-rule-llm.ts, generate-detection-from-poc.ts, and related scripts) as a
deliberate "keep the rule-authoring methodology private" decision. No private
replacement was ever built. Proposal COLLECTION kept running via an external
process regardless (`proposals/` has grown to ~4,900 files since, +150-300/day),
while CONVERSION sat completely dead for 9+ days.

Per an explicit decision to NOT keep this private, this PR mirrors the
existing public red-team FN-mining flywheel exactly — same
`scripts/fn-mine-llm.ts` + `.github/workflows/fn-mine-scheduled.yml` pattern,
same `@anthropic-ai/sdk` direct-call approach, same draft-PR-only safety
posture — rebuilt from scratch for CVE proposals rather than resurrecting the
deleted (and previously flagged as FP-prone, see PR #232) heuristic extractor.

## What's added

- `scripts/cve-mine-llm.ts` — reads `proposals/**/*.proposal.yaml`, selects
  candidates that are `detection_ready`, carry a concrete PoC/payload signal
  (not just prose about a CVE), are genuinely agent/LLM/MCP-relevant (a local
  heuristic filter, PLUS a second LLM-judged veto during authoring — the
  upstream collector's own "agent-relevant" tagging has confirmed false
  positives, e.g. a security researcher's report merely disclosing "I used an
  LLM to help review this code" tainting an unrelated Caddy/rustls-webpki
  CVE), and are not already covered by an existing rule. Authors survivors via
  the Anthropic API grounded in the real advisory/PoC text, self-tests each on
  the real engine (one corrective retry), enforces a hard `<=30`-char bridge-
  span cap, then re-verifies the whole batch against `check-rules-safety.ts`
  AND the `tests/skill-benchmark.test.ts` + `tests/eval-harness.test.ts`
  latency-regression gate. Idempotent via `data/cve-collector/promoted.json`.
- `.github/workflows/cve-mine-scheduled.yml` — daily cron (05:40 UTC, matching
  the deleted `promote-cve.yml`'s cadence) + `workflow_dispatch` with
  `cap`/`dry_run` inputs. Never auto-merges; opens a draft PR only when the
  mining step actually produced files.

## Notable finds along the way

- The existing `fn-mine-llm.ts`'s `loadAllExistingRegexes()` extracts
  `value:` lines via a raw-text regex and only unescapes quote characters.
  That silently corrupts any pattern with a YAML-double-escaped backslash
  (`\\u0400`, `\\s`, ...) into a bogus wide character-class range that matches
  ordinary prose — verified empirically it made `[\\u0400-\\u04FF][a-zA-Z]|...`
  match plain English text. This script's version YAML-parses each rule file
  properly to avoid the same bug (not fixed in `fn-mine-llm.ts` itself here —
  flagged separately, out of scope for this PR).
- The upstream CVE-proposal collector's own "agent-relevant" filtering is
  noisier than expected: plain historical CVEs (old PHP SQLi, phpMyFAQ,
  pam_usb) and even generic infra CVEs (Caddy, rustls-webpki) slip through
  because of incidental keyword coincidences. Handled with a combination of
  a stricter local relevance heuristic and an explicit LLM veto path in the
  authoring prompt.

## Test plan

- [x] `npx tsc --noEmit` passes with the new file
- [x] `--dry-run` selection verified against the real current `proposals/`
      backlog (see PR discussion / session log — 40 genuinely agent/MCP-
      relevant candidates found this way, e.g. Langflow, PraisonAI, LangChain,
      Meta Ads MCP, 9router)
- [ ] Live `workflow_dispatch` run on GitHub Actions (has `ANTHROPIC_API_KEY`
      access this local checkout does not) to verify end-to-end authoring +
      safety-gate + latency-gate + draft-PR creation
- [ ] First real (non-dry-run) batch run reviewed as its own draft PR

Left as draft per this repo's PR pipeline convention — a human reviews before
merge, same as every other rule/infra PR.