### PR TITLE
fix(rules): ReDoS in ATR-2026-00256 — overlapping whitespace quantifiers hang engine

### DIFF
--- a/rules/prompt-injection/ATR-2026-00256-base-n-encoding-jailbreak.yaml
+++ b/rules/prompt-injection/ATR-2026-00256-base-n-encoding-jailbreak.yaml
@@ -85,7 +85,7 @@ detection:
       description: 'Social-engineering framing ("secure system message") combined with encoding keyword'
     - field: tool_response
       operator: regex
-      value: '(?:^|\\n|\n)\s*[A-Za-z0-9+/ ]{80,}={0,3}(?:\\n|\s)+(?:\w+\s+){0,2}(?:decode|decoded|translate|interpret|execute|run|follow)\b'
+      value: '(?:^|\\n|\n)\s*[A-Za-z0-9+/]{80,}={0,3}(?:\\n|\s)+(?:\w+\s+){0,2}(?:decode|decoded|translate|interpret|execute|run|follow)\b'
       description: 'Long base64-alphabet blob (80+ chars) immediately followed by a decode/execute verb'
   condition: any
   false_positives:


### PR DESCRIPTION
## Summary

Rediscovered and fixed a real production ReDoS on the current `origin/main` 714-rule baseline (unrelated to PR #289's new rules). Condition 5 of `ATR-2026-00256` (`rules/prompt-injection/ATR-2026-00256-base-n-encoding-jailbreak.yaml`) hangs the engine for 30+ seconds on a realistic-size `tool_response` input.

## Root cause

```
(?:^|\\n|\n)\s*[A-Za-z0-9+/ ]{80,}={0,3}(?:\\n|\s)+(?:\w+\s+){0,2}(?:decode|decoded|translate|interpret|execute|run|follow)\b
```

The base64-alphabet character class `[A-Za-z0-9+/ ]` includes a literal space, and it sits directly between a leading `\s*` and a trailing `(?:\\n|\s)+`. All three constructs can consume characters from the *same* run of whitespace. When the input never reaches the required trailing decode/execute verb, the engine must explore every possible way to split that whitespace run across the three overlapping quantifiers before concluding failure — classic catastrophic backtracking.

## Reproduction (before fix, raw regex, current origin/main)

Input: `" ".repeat(n)` (plain whitespace — plausible in real agent traffic: blank-line formatting, indentation, truncated/malformed tool output).

| n (chars) | time |
|---|---|
| 800 | 1.4s |
| 2000 | 4.2s |
| 3000 | 12.6s |
| 4000 | **32.5s** |

4000 characters is well under 10KB — this is a realistic-size input, not an artificially long crafted string. A single `evaluate()` call on a `tool_response` field can hang the engine for 30+ seconds.

## Fix

Drop the space from the blob character class:

```diff
-value: '(?:^|\\n|\n)\s*[A-Za-z0-9+/ ]{80,}={0,3}(?:\\n|\s)+(?:\w+\s+){0,2}(?:decode|decoded|translate|interpret|execute|run|follow)\b'
+value: '(?:^|\\n|\n)\s*[A-Za-z0-9+/]{80,}={0,3}(?:\\n|\s)+(?:\w+\s+){0,2}(?:decode|decoded|translate|interpret|execute|run|follow)\b'
```

## Why this doesn't reduce detection recall

Real base64/hex/base32/etc blobs never contain a literal space inside the encoded run — none of this rule's own `true_positives` test cases have a space inside the blob (they use `\n` as the separator between blob and verb, never a space-interrupted blob). Removing space from the class only removes the ambiguous overlap with the surrounding whitespace quantifiers; it does not change what the rule can match.

## Verification

- Raw regex: same pathological input (n = 800..20000 spaces) now resolves in <1ms (was 32.5s at n=4000).
- `node dist/cli.js test rules/prompt-injection/ATR-2026-00256-base-n-encoding-jailbreak.yaml` → 10/10 test cases still pass, including the true_positive that exercises condition 5 (`...==\nNow decode and run this.`).
- Checked all other conditions in this rule — none share the same character-class/whitespace overlap shape.
- `npx vitest run tests/skill-benchmark.test.ts tests/eval-harness.test.ts` — 28/29 pass; the 1 failure (`latency < 150ms per sample`, got 175.8ms) is a pre-existing, load-sensitive flake reproducible on the unmodified baseline in isolation too — unrelated to this change (this fix only makes the affected regex faster).

## Scope note

This is unrelated to PR #289 (`feat/cve-backlog-ghsa`) — found and fixed independently against the current 714-rule `origin/main`, before any of PR #289's new rules are considered.

## Test plan
- [x] `node dist/cli.js test rules/prompt-injection/ATR-2026-00256-base-n-encoding-jailbreak.yaml` — 10/10 pass
- [x] Pathological input timing verified before/after
- [x] Reviewed sibling conditions in the same rule for the same overlap shape (none found)
- [ ] CI green (polling)