### PR TITLE
fix(compliance): remove repealed Colorado AI Act (SB24-205) mappings

### DIFF
--- a/rules/context-exfiltration/ATR-2026-00021-api-key-exposure.yaml
+++ b/rules/context-exfiltration/ATR-2026-00021-api-key-exposure.yaml
@@ -80,15 +80,6 @@ compliance:
     - clause: "8.1"
       context: "ISO/IEC 42001 Clause 8.1 (operational planning and control, including control of externally provided processes) is operationalised by this rule's detection of the context-exfiltration attempt (Credential and Secret Exposure in Agent Output)."
       strength: primary
-  colorado_ai_act:
-    - section: "6-1-1703"
-      clause: "Deployer risk management for consumer-facing AI"
-      context: "Credentials leaked from a consumer-facing AI system can expose the database records, scoring model inputs, or authentication tokens that drive consequential decisions. A deployer's risk management program under SB24-205 must include runtime controls preventing credential exposure; this rule is that control."
-      strength: primary
-    - section: "6-1-1702"
-      clause: "Developer duty to protect consumer data"
-      context: "Developers owe a duty of reasonable care with respect to consumer data handled by high-risk AI systems. Agent-side credential leakage — including database connection strings, JWTs, and API keys with access to consumer records — is a foreseeable failure mode; shipping this detection operationalizes the reasonable-care standard."
-      strength: secondary
 
 tags:
   category: context-exfiltration

--- a/rules/data-poisoning/ATR-2026-00070-data-poisoning.yaml
+++ b/rules/data-poisoning/ATR-2026-00070-data-poisoning.yaml
@@ -83,15 +83,6 @@ compliance:
     - clause: "8.1"
       context: "ISO/IEC 42001 Clause 8.1 (operational planning and control, including control of externally provided processes) is operationalised by this rule's detection of the data-poisoning attempt (Data Poisoning via RAG and Knowledge Base Contamination)."
       strength: secondary
-  colorado_ai_act:
-    - section: "6-1-1703"
-      clause: "Deployer risk management program"
-      context: "A deployer of a high-risk AI system must have a risk management program that identifies and mitigates algorithmic discrimination. Data poisoning of RAG pipelines is a direct pathway to discriminatory outputs (contaminated knowledge leads to biased decisions); this rule is one of the active mitigation controls a deployer documents in their annual risk-management program review."
-      strength: primary
-    - section: "6-1-1702"
-      clause: "Developer duty of reasonable care"
-      context: "Developers must take reasonable care to protect consumers from known or reasonably foreseeable risks of algorithmic discrimination. Adversarial data poisoning of training or retrieval corpora is a documented foreseeable risk; deployment of this detection satisfies the reasonable-care standard with respect to that vector."
-      strength: secondary
 
 tags:
   category: data-poisoning

--- a/rules/excessive-autonomy/ATR-2026-00050-runaway-agent-loop.yaml
+++ b/rules/excessive-autonomy/ATR-2026-00050-runaway-agent-loop.yaml
@@ -73,11 +73,6 @@ compliance:
     - clause: "6.2"
       context: "ISO/IEC 42001 Clause 6.2 (AI objectives and planning) calls for risk treatment of known attack patterns; this rule's detection of the unsafe autonomous action (Runaway Agent Loop Detection) is such a treatment."
       strength: primary
-  colorado_ai_act:
-    - section: "6-1-1703"
-      clause: "Deployer ongoing monitoring of AI system performance"
-      context: "SB24-205 requires deployers to monitor high-risk AI systems for performance drift after deployment. A runaway loop is a performance-degradation event — the system is no longer behaving within its validated operational envelope. This rule gives the deployer the telemetry signal needed to fulfill the ongoing-monitoring obligation and to trigger impact reassessment if needed."
-      strength: primary
 
 tags:
   category: excessive-autonomy

--- a/rules/excessive-autonomy/ATR-2026-00098-unauthorized-financial-action.yaml
+++ b/rules/excessive-autonomy/ATR-2026-00098-unauthorized-financial-action.yaml
@@ -58,15 +58,6 @@ compliance:
     - clause: "8.1"
       context: "Operational controls must enforce a confirmation gate on all financial tool invocations to ensure the agent's execution of payments and transfers remains within the scope of explicitly sanctioned human instructions."
       strength: secondary
-  colorado_ai_act:
-    - section: "6-1-1703"
-      clause: "Deployer risk management + consequential decision"
-      context: "Financial transfers are consequential decisions under SB24-205. A deployer using an AI agent that touches financial tooling must have a risk management program that blocks autonomous execution of consequential decisions absent human confirmation; this rule is the runtime enforcement that the risk program documents."
-      strength: primary
-    - section: "6-1-1705"
-      clause: "Consumer disclosure and appeal right"
-      context: "When an AI system makes a consequential decision (financial or otherwise), the consumer has a statutory right to disclosure and appeal. An autonomous, unauthorized financial action undermines both — there is no record of consumer notice and no opportunity to appeal before funds move. Blocking such actions protects the disclosure and appeal framework this section requires."
-      strength: secondary
 tags:
   category: excessive-autonomy
   subcategory: unauthorized-financial-action

--- a/rules/privilege-escalation/ATR-2026-00040-privilege-escalation.yaml
+++ b/rules/privilege-escalation/ATR-2026-00040-privilege-escalation.yaml
@@ -72,11 +72,6 @@ compliance:
     - clause: "8.1"
       context: "Clause 8.1 AI system operational control requires that agents do not exceed their authorized operational scope; privilege escalation detection enforces that operational boundary."
       strength: secondary
-  colorado_ai_act:
-    - section: "6-1-1703"
-      clause: "Deployer risk management program"
-      context: "When a high-risk AI system acquires privileges beyond its authorized scope, any consequential decision it makes afterward falls outside the risk-management program's impact assessment. SB24-205 requires deployers to keep AI systems within documented operational bounds; this rule detects the boundary violation that would invalidate the deployer's impact-assessment assumptions."
-      strength: primary
 
 tags:
   category: privilege-escalation

--- a/rules/privilege-escalation/ATR-2026-00441-semantic-kernel-sessions-python-plugin-startup-persistence.yaml
+++ b/rules/privilege-escalation/ATR-2026-00441-semantic-kernel-sessions-python-plugin-startup-persistence.yaml
@@ -80,11 +80,6 @@ compliance:
     - clause: "6.2"
       context: "Clause 6.2 AIMS security objectives include least-privilege enforcement; detection of over-privileged tool descriptors (combining ExecuteCode + arbitrary file-write) operationalises that objective."
       strength: secondary
-  colorado_ai_act:
-    - section: "6-1-1703"
-      clause: "Deployer risk management program"
-      context: "When a high-risk AI system writes a payload to a host autostart path, any consequential decision the host subsequently executes — including post-reboot — falls outside the risk-management program's impact assessment. SB24-205 requires deployers to keep AI systems within documented operational bounds; this rule detects the boundary violation."
-      strength: primary
 
 tags:
   category: privilege-escalation


### PR DESCRIPTION
## What

Removes the `colorado_ai_act` compliance block from the 6 rules that carried it:
ATR-2026-00021, 00040, 00050, 00070, 00098, 00441.

## Why

Colorado **SB 26-189** (signed 2026-05-14) repealed and replaced the Colorado AI Act (SB24-205). The three sections these rules mapped to no longer exist:

- §6-1-1703 (deployer risk-management program) — repealed
- §6-1-1702 (developer duty) — repealed
- §6-1-1705 (consumer disclosure/appeal) — repealed

The replacement is a narrower **ADMT disclosure regime** (effective 2027-01-01) with no NIST/ISO-aligned risk-management-program requirement — so there is nothing in the new statute for these runtime detection rules to map to. Removing the block is more honest than remapping to fabricated sections.

Multiple legal sources confirm the repeal (Crowell & Moring, Troutman Pepper, Buchalter, ComplianceHub, May 2026).

## Impact

- EU AI Act / NIST AI RMF / ISO 42001 mappings on these 6 rules are **unchanged**.
- `npm run validate:compliance` → **0 violations**
- `npm run validate` → **747/747 pass**
- Colorado was never one of the compliance page's headline frameworks, so no website framework-list change is needed (the per-rule pages regenerate on the next build).