### PR TITLE
docs(compliance): CSA MAESTRO crosswalk + refresh all crosswalk corpus stamps to v3.5.8/747

### DIFF
--- a/docs/CSA-MAESTRO-MAPPING.md
+++ b/docs/CSA-MAESTRO-MAPPING.md
@@ -1,0 +1,97 @@
+# ATR → CSA MAESTRO Layer Mapping
+
+Last updated: 2026-07-12
+ATR corpus: v3.5.8, 747 rules (10 categories)
+Source framework: **MAESTRO — Multi-Agent Environment, Security, Threat, Risk & Outcome**,
+Cloud Security Alliance (2025). A layered threat-modeling framework for agentic AI that
+decomposes an agent system into seven architectural layers, each with its own threat
+surface. Reference: https://cloudsecurityalliance.org/blog/2025/02/06/agentic-ai-threat-modeling-framework-maestro
+
+> **What this mapping is.** MAESTRO is an *architectural* threat-modeling framework, not a
+> numbered attack taxonomy (unlike MITRE ATLAS or MCP-38). It asks "which layer of the agent
+> stack does a threat live in, and how do threats cross layers?" This crosswalk therefore maps
+> at the **ATR-category → MAESTRO-layer** granularity: for each of MAESTRO's seven layers, it
+> lists the ATR detection categories that produce runtime evidence for threats at that layer.
+> A single ATR category can serve more than one layer (e.g. prompt-injection is a Foundation-
+> Model threat when direct, a Data-Operations threat when indirect via retrieved content, and
+> an Agent-Frameworks threat when injected through tool output). Rule counts are the size of
+> each contributing category, not a claim that every rule in it is layer-exclusive.
+
+> **Relationship.** MAESTRO is a *modeling* framework; ATR is the *detection* layer beneath it.
+> MAESTRO Layer 5 (Evaluation & Observability) and the cross-cutting Layer 6 (Security &
+> Compliance) explicitly call for runtime controls and continuous evidence — ATR rules are
+> that evidence, mapped to EU AI Act / NIST AI RMF / ISO 42001 in each rule's `compliance:`
+> block. CSA's 2026 guidance frames the threat model as a continuous property regenerated on
+> every commit; ATR is detection-as-code that runs in that same pipeline.
+
+## Coverage summary
+
+| MAESTRO layer | Threat surface | Primary ATR categories | Rules |
+|---|---|---|---|
+| **L1 Foundation Models** | The LLM itself: jailbreak, model manipulation, behavior extraction | model-abuse, model-security, prompt-injection (direct) | 41 + PI |
+| **L2 Data Operations** | RAG, memory, embeddings, training/ingested data | data-poisoning, context-exfiltration, prompt-injection (indirect) | 126 + PI |
+| **L3 Agent Frameworks** | Tool-calling, planning, skill/plugin runtime | tool-poisoning, excessive-autonomy, skill-compromise | 175 |
+| **L4 Deployment & Infrastructure** | Hosting, sandboxing, host privileges, persistence | privilege-escalation | 51 |
+| **L5 Evaluation & Observability** | Detection, monitoring, runtime evidence | *(ATR is this layer)* — all 747 | 747 |
+| **L6 Security & Compliance** *(cross-cutting)* | Regulatory obligation + control evidence across all layers | *(ATR compliance block)* — all 747 | 747 |
+| **L7 Agent Ecosystem** | Multi-agent interaction, inter-agent trust, marketplace/supply chain | agent-manipulation, skill-compromise (supply chain) | 153 |
+
+Every ATR rule maps to at least one horizontal layer (L1–L4, L7) **and** contributes to the two
+cross-cutting layers (L5 detection, L6 compliance), which is MAESTRO's intended shape: the
+security/observability layers are vertical concerns that intersect every functional layer.
+
+---
+
+## Detailed mapping
+
+### L1 — Foundation Models
+The model's own attack surface: adversarial prompts that alter model behavior, jailbreaks that
+defeat safety training, and extraction of model behavior or system configuration.
+- **model-abuse** (38) — jailbreak, safety-bypass, adversarial output shaping
+- **model-security** (3) — model tampering / deserialization / weight-level threats
+- **prompt-injection** (direct subset of 246) — instruction-override delivered straight to the model input
+
+### L2 — Data Operations
+Threats in the data plane the agent reads and writes: RAG corpora, long-term memory, embeddings,
+and any ingested content the model treats as trusted context.
+- **data-poisoning** (7) — RAG / knowledge-base / memory contamination
+- **context-exfiltration** (119) — credential/secret/PII leaving through the agent's context
+- **prompt-injection** (indirect subset) — payloads embedded in retrieved documents, tool output, or memory
+
+### L3 — Agent Frameworks
+The agent runtime itself: tool/function calling, planning loops, and the skill/plugin extension
+surface where MCP tools and skills execute.
+- **tool-poisoning** (97) — malicious tool descriptions, MCP tool-response manipulation, command injection via tool args
+- **excessive-autonomy** (33) — runaway loops, unauthorized high-blast-radius actions, missing human-in-the-loop
+- **skill-compromise** (45) — MCP skill impersonation, hidden capability, description-behavior mismatch
+
+### L4 — Deployment & Infrastructure
+The host the agent runs on: sandbox escape, privilege boundaries, and startup/persistence.
+- **privilege-escalation** (51) — scope escalation, sandbox escape, autostart/persistence, host-level RCE
+
+### L5 — Evaluation & Observability *(cross-cutting)*
+MAESTRO's detection and monitoring layer. **ATR is a realization of this layer**: 747 deterministic
+rules that run over SKILL.md files, MCP tool descriptions, tool arguments, agent I/O, and behavioral
+traces, emitting rule-ID-tagged findings suitable for SIEM ingestion (MISP taxonomy, Sigma).
+
+### L6 — Security & Compliance *(cross-cutting)*
+MAESTRO's vertical security/governance concern. Every ATR rule carries a `compliance:` block mapping
+its detection to **EU AI Act** (Articles 9/10/12/13/14/15), **NIST AI RMF** (GV/MP/MS/MG), and
+**ISO 42001** (clauses 6.2, 8.1–8.4, 9.1) — turning a MAESTRO-layer threat into auditor-readable
+evidence. Coverage is CI-enforced at 100% with 0 fabricated identifiers.
+
+### L7 — Agent Ecosystem
+The multi-agent / ecosystem layer: inter-agent communication, delegation-chain trust, human-agent
+trust, and the skill/tool marketplace supply chain.
+- **agent-manipulation** (108) — cross-agent attacks, goal hijacking, inter-agent comms abuse, human-agent trust exploitation, Sybil/consensus attacks
+- **skill-compromise** (supply-chain subset of 45) — marketplace poisoning, compromised tool distribution, malicious skill updates
+
+---
+
+## Notes & caveats
+- This is a first-pass architectural mapping produced against ATR v3.5.8 (747 rules). MAESTRO layer
+  names follow the CSA 2025 framework; MAESTRO V2 (expected 2026) may refine per-layer threat detail,
+  at which point this crosswalk should be re-validated.
+- "Rules" counts are the size of each contributing ATR category, not a per-rule layer-exclusivity claim.
+  Prompt-injection (246 rules) deliberately spans L1/L2/L3 because injection is a cross-layer attack class.
+- This crosswalk is a community-authored alignment, not a CSA endorsement or a MAESTRO adoption of ATR.

--- a/docs/ETSI-TS-104223-MAPPING.md
+++ b/docs/ETSI-TS-104223-MAPPING.md
@@ -4,7 +4,7 @@ Version: 0.1.0 (INTERNAL DRAFT — not published)
 Status: Draft alignment mapping for ETSI TS 104 223 V1.1.1 and the UK NCSC/DSIT AI Cyber Security Code of Practice
 Date: 2026-06-12
 Editor: Adam Lin (林冠辛) <adam@agentthreatrule.org>
-Mapped corpus: Agent Threat Rules v3.5.2 (708 rules / 10 categories; disk == data/stats.json on 2026-06-29)
+Mapped corpus: Agent Threat Rules v3.5.8 (747 rules / 10 categories; disk == data/stats.json on 2026-07-12)
 Reference frameworks:
   - ETSI TS 104 223 V1.1.1 (2025-04) "Securing Artificial Intelligence (SAI); Baseline Cyber Security Requirements for AI Models and Systems"
   - UK AI Cyber Security Code of Practice (DSIT / NCSC), "Code of practice for the cyber security of AI"

--- a/docs/FINOS-AI-GOVERNANCE-MAPPING.md
+++ b/docs/FINOS-AI-GOVERNANCE-MAPPING.md
@@ -4,7 +4,7 @@ Version: 0.1.0 (INTERNAL DRAFT — not published, not submitted)
 Status: Draft for future FINOS AI Governance Framework Informative Reference / PR basis (human review gate before any upstream submission)
 Date: 2026-06-12
 Editor: Adam Lin (林冠辛) <adam@agentthreatrule.org>
-Mapped corpus: Agent Threat Rules v3.5.2 (708 rules / 10 categories, disk==stats.json verified 2026-06-29)
+Mapped corpus: Agent Threat Rules v3.5.8 (747 rules / 10 categories, disk==stats.json verified 2026-07-12)
 Reference framework: FINOS AI Governance Framework v2 (published 2025-10-20), Risk Catalogue
 Reference framework license: CC-BY-4.0 (finos/ai-governance-framework). Risk and
 mitigation text quoted below is reproduced under that license.

--- a/docs/FIVE-EYES-MAPPING.md
+++ b/docs/FIVE-EYES-MAPPING.md
@@ -1,6 +1,6 @@
 # ATR → Five Eyes "Careful Adoption of Agentic AI Services" Mapping
 
-- **ATR corpus version:** v3.5.2, 708 rules across 10 detection-rule categories
+- **ATR corpus version:** v3.5.8, 747 rules across 10 detection-rule categories
 - **Five Eyes guidance:** "Careful Adoption of Agentic AI Services", published 2026-04-30 on media.defense.gov, jointly authored by CISA (US) + NSA (US) + ASD-ACSC (Australia) + CCCS (Canada) + NCSC-UK + NCSC-NZ
 - **Document date:** 2026-06-05
 - **Maintainer:** Adam Lin (adam@agentthreatrule.org)

--- a/docs/MCP-38-MAPPING.md
+++ b/docs/MCP-38-MAPPING.md
@@ -1,9 +1,9 @@
 # ATR → MCP-38 Threat Taxonomy Mapping
 
-Last updated: 2026-07-08 (version stamp refreshed to v3.5.6; cited rule IDs
+Last updated: 2026-07-12 (corpus re-stamp to v3.5.8; cited rule IDs
 spot-checked as still resolving; the 7-gap authoring roadmap is carried forward
 and re-validated as those dedicated rules are written)
-ATR corpus: v3.5.6, 708 rules (10 categories)
+ATR corpus: v3.5.8, 747 rules (10 categories)
 Source taxonomy: **MCP-38 — A Comprehensive Threat Taxonomy for Model Context
 Protocol Systems (v1.0)**, Shen, Toyoda & Leung, arXiv:2603.18063. 38 protocol-
 specific threat categories (MCP-01 … MCP-38) grouped into 5 tactic categories

--- a/docs/MITRE-ATLAS-MAPPING.md
+++ b/docs/MITRE-ATLAS-MAPPING.md
@@ -4,7 +4,7 @@ Version: 0.1.0 (INTERNAL DRAFT — not published)
 Status: Draft alignment mapping for MITRE ATLAS v5.6.0
 Date: 2026-06-14
 Editor: Adam Lin (林冠辛) <adam@agentthreatrule.org>
-Mapped corpus: Agent Threat Rules v3.5.2 (708 rules / 10 categories; disk == data/stats.json reconciled 2026-06-29)
+Mapped corpus: Agent Threat Rules v3.5.8 (747 rules / 10 categories; disk == data/stats.json reconciled 2026-07-12)
 Reference framework: MITRE ATLAS (Adversarial Threat Landscape for Artificial-Intelligence Systems), `dist/ATLAS.yaml` on mitre-atlas/atlas-data, v5.6.0 — 16 tactics, 101 top-level techniques (271 including sub-techniques), counted from the full machine-readable `dist/ATLAS.yaml`.
 
 ---

--- a/docs/NSA-MCP-MAPPING.md
+++ b/docs/NSA-MCP-MAPPING.md
@@ -1,6 +1,6 @@
 # ATR → NSA "Model Context Protocol (MCP): Security Design Considerations" Mapping
 
-- **ATR corpus version:** v3.5.2 HEAD, 708 rules across 10 detection-rule categories. Headline benchmarks below were measured at v3.5.0 (2026-06-16).
+- **ATR corpus version:** v3.5.8 HEAD, 747 rules across 10 detection-rule categories. Headline benchmarks below were measured at v3.5.0 (2026-06-16).
 - **NSA guidance:** *Model Context Protocol (MCP): Security Design Considerations for AI-Driven Automation*, Cybersecurity Information Sheet (CSI), **NSA Artificial Intelligence Security**, **May 2026 Ver. 1.0** (U/OO/6030316-26 | PP-26-1834), posted 2026-06-02 on media.defense.gov; developed with the Carnegie Mellon University Software Engineering Institute.
 - **Document date:** 2026-06-29 (ratings recalibrated after an adversarial second-reviewer pass — see Verification status)
 - **Maintainer:** Adam Lin (adam@agentthreatrule.org)

--- a/docs/OWASP-AGENTIC-MAPPING.md
+++ b/docs/OWASP-AGENTIC-MAPPING.md
@@ -1,15 +1,15 @@
 # ATR -> OWASP Agentic Top 10 (2026) Mapping
 
-Last updated: 2026-06-14
-ATR version: v3.5.2 (708 rules with OWASP Agentic tags)
+Last updated: 2026-07-12
+ATR version: v3.5.8 (747 rules with OWASP Agentic tags)
 OWASP framework: Agentic Top 10 v1.0 (December 2025)
 
 ## Summary
 
 - Categories covered: **10/10**
-- Total rule -> category mappings: **866**
-- Tagged ATR rules: **652** of 652 total rules in repo
-- ATR version: `v3.5.0` -- OWASP Agentic Top 10: `v1.0 (December 2025)`
+- Total rule -> category mappings: **976**
+- Tagged ATR rules: **747** of 747 total rules in repo
+- ATR version: `v3.5.8` -- OWASP Agentic Top 10: `v1.0 (December 2025)`
 
 Strength tiers: **STRONG** >= 8 rules · **MODERATE** 4-7 rules · **LIMITED** 1-3 rules.
 
@@ -17,22 +17,22 @@ Strength tiers: **STRONG** >= 8 rules · **MODERATE** 4-7 rules · **LIMITED** 1
 
 | ASI | Title | Rule count | Strength | Reference attack |
 |---|---|---|---|---|
-| ASI01 | Agent Goal Hijack | 445 | STRONG | EchoLeak |
-| ASI02 | Tool Misuse and Exploitation | 32 | STRONG | Amazon Q |
-| ASI03 | Identity and Privilege Abuse | 107 | STRONG | n/a |
-| ASI04 | Agentic Supply Chain Vulnerabilities | 71 | STRONG | GitHub MCP exploit |
-| ASI05 | Unexpected Code Execution (RCE) | 65 | STRONG | AutoGPT RCE |
-| ASI06 | Memory & Context Poisoning | 54 | STRONG | Gemini Memory Attack |
+| ASI01 | Agent Goal Hijack | 480 | STRONG | EchoLeak |
+| ASI02 | Tool Misuse and Exploitation | 48 | STRONG | Amazon Q |
+| ASI03 | Identity and Privilege Abuse | 115 | STRONG | n/a |
+| ASI04 | Agentic Supply Chain Vulnerabilities | 75 | STRONG | GitHub MCP exploit |
+| ASI05 | Unexpected Code Execution (RCE) | 76 | STRONG | AutoGPT RCE |
+| ASI06 | Memory & Context Poisoning | 87 | STRONG | Gemini Memory Attack |
 | ASI07 | Insecure Inter-Agent Communication | 21 | STRONG | n/a |
 | ASI08 | Cascading Failures | 48 | STRONG | n/a |
-| ASI09 | Human-Agent Trust Exploitation | 16 | STRONG | n/a |
-| ASI10 | Rogue Agents | 7 | MODERATE | Replit meltdown |
+| ASI09 | Human-Agent Trust Exploitation | 18 | STRONG | n/a |
+| ASI10 | Rogue Agents | 8 | STRONG | Replit meltdown |
 
 ---
 
 ## Per-category detail
 
-### ASI01: Agent Goal Hijack (445 rules) -- STRONG
+### ASI01: Agent Goal Hijack (480 rules) -- STRONG
 
 **OWASP description.** Attackers manipulate the agent's decision pathways or objectives so it pursues an adversary-controlled goal instead of its assigned task. Canonical instance: EchoLeak.
 
@@ -50,9 +50,9 @@ Top rules by severity:
 | ATR-2026-00091 | Advanced Structured Data Injection with Nested Payloads | critical | Detects advanced structured data injection where malicious prompts are deeply nested with… |
 | ATR-2026-00092 | Multi-Agent Consensus Poisoning and Sybil Attack | critical | Detects attacks targeting multi-agent consensus systems through coordinated fake proposal… |
 
-Plus 440 additional rules tagged ASI01 -- see `docs/owasp-agentic-mapping.json` for the complete list.
+Plus 475 additional rules tagged ASI01 -- see `docs/owasp-agentic-mapping.json` for the complete list.
 
-### ASI02: Tool Misuse and Exploitation (32 rules) -- STRONG
+### ASI02: Tool Misuse and Exploitation (48 rules) -- STRONG
 
 **OWASP description.** Legitimate tools are used unsafely because the agent acts on ambiguous instructions or has over-privileged access. Canonical instance: Amazon Q assistant tool-misuse incident.
 
@@ -65,14 +65,14 @@ Top rules by severity:
 | Rule ID | Title | Severity | Description |
 |---|---|---|---|
 | ATR-2026-00010 | Malicious Content in MCP Tool Response | critical | Detects malicious content embedded in MCP (Model Context Protocol) tool responses. Attack… |
-| ATR-2026-00013 | SSRF via Agent Tool Calls | critical | Detects Server-Side Request Forgery (SSRF) attempts through agent tool calls. Attackers m… |
+| ATR-2026-00013 | SSRF via Agent Tool Calls | critical | Detects high-confidence Server-Side Request Forgery (SSRF) that targets cloud CREDENTIAL… |
 | ATR-2026-00062 | Hidden Capability in MCP Skill | critical | Detects MCP skills that expose hidden or undocumented capabilities beyond their declared… |
 | ATR-2026-00063 | Multi-Skill Chain Attack | critical | Detects attack sequences where multiple MCP skills are chained together to achieve a mali… |
 | ATR-2026-00066 | Parameter Injection via Tool Arguments | critical | Detects injection attacks delivered through MCP tool arguments. An attacker crafts tool a… |
 
-Plus 27 additional rules tagged ASI02 -- see `docs/owasp-agentic-mapping.json` for the complete list.
+Plus 43 additional rules tagged ASI02 -- see `docs/owasp-agentic-mapping.json` for the complete list.
 
-### ASI03: Identity and Privilege Abuse (107 rules) -- STRONG
+### ASI03: Identity and Privilege Abuse (115 rules) -- STRONG
 
 **OWASP description.** Agents operate in an attribution gap; leaked credentials or escalated privileges let them act beyond intended scope.
 
@@ -88,9 +88,9 @@ Top rules by severity:
 | ATR-2026-00113 | Credential File Theft from Agent Environment | critical | Detects tools or agent instructions that access well-known credential files from the host… |
 | ATR-2026-00115 | Bulk Environment Variable Harvesting and Exfiltration | critical | Detects tools or agent instructions that perform bulk extraction of environment variables… |
 
-Plus 102 additional rules tagged ASI03 -- see `docs/owasp-agentic-mapping.json` for the complete list.
+Plus 110 additional rules tagged ASI03 -- see `docs/owasp-agentic-mapping.json` for the complete list.
 
-### ASI04: Agentic Supply Chain Vulnerabilities (71 rules) -- STRONG
+### ASI04: Agentic Supply Chain Vulnerabilities (75 rules) -- STRONG
 
 **OWASP description.** Runtime composition of third-party capabilities (MCP servers, plugins, skills, A2A endpoints) lets adversaries poison the call graph after deployment. Canonical instance: GitHub MCP exploit.
 
@@ -108,9 +108,9 @@ Top rules by severity:
 | ATR-2026-00149 | Skill Data Exfiltration via Compound Patterns | critical | Detects compound exfiltration patterns in SKILL.md files where sensitive data (credential… |
 | ATR-2026-00200 | Agent Memory and Configuration File Tampering | critical | Detects attempts to write, append, or modify agent memory files (MEMORY.md, SOUL.md, CLAU… |
 
-Plus 66 additional rules tagged ASI04 -- see `docs/owasp-agentic-mapping.json` for the complete list.
+Plus 70 additional rules tagged ASI04 -- see `docs/owasp-agentic-mapping.json` for the complete list.
 
-### ASI05: Unexpected Code Execution (RCE) (65 rules) -- STRONG
+### ASI05: Unexpected Code Execution (RCE) (76 rules) -- STRONG
 
 **OWASP description.** Agents generate and execute code ("vibe coding"), opening RCE paths through natural-language instructions. Canonical instance: AutoGPT RCE.
 
@@ -128,9 +128,9 @@ Top rules by severity:
 | ATR-2026-00096 | Skill Registry Poisoning and Compromised Tool Distribution | critical | Detects supply chain attacks that target skill/tool registries and distribution channels.… |
 | ATR-2026-00110 | Remote Code Execution via eval() and Dynamic Code Injection | critical | Detects tools or agent instructions that invoke eval(), Function(), vm.runInNewContext(),… |
 
-Plus 60 additional rules tagged ASI05 -- see `docs/owasp-agentic-mapping.json` for the complete list.
+Plus 71 additional rules tagged ASI05 -- see `docs/owasp-agentic-mapping.json` for the complete list.
 
-### ASI06: Memory & Context Poisoning (54 rules) -- STRONG
+### ASI06: Memory & Context Poisoning (87 rules) -- STRONG
 
 **OWASP description.** Long-term memory, RAG stores, or shared context are corrupted so the agent's future behavior is shaped by attacker payloads. Canonical instance: Gemini Memory Attack.
 
@@ -148,7 +148,7 @@ Top rules by severity:
 | ATR-2026-00201 | Credential Exfiltration via Shell Pipe | critical | Detects credential theft patterns where environment variables containing API keys, secret… |
 | ATR-2026-00212 | mcp-atlassian Credential Leak via Hint Parameter Injection (CVE-2026-27825/27826) | critical | Detects the mcp-atlassian credential-leak attack pattern (CVE-2026-27825 and CVE-2026-278… |
 
-Plus 49 additional rules tagged ASI06 -- see `docs/owasp-agentic-mapping.json` for the complete list.
+Plus 82 additional rules tagged ASI06 -- see `docs/owasp-agentic-mapping.json` for the complete list.
 
 ### ASI07: Insecure Inter-Agent Communication (21 rules) -- STRONG
 
@@ -186,7 +186,7 @@ Top rules by severity:
 
 Plus 43 additional rules tagged ASI08 -- see `docs/owasp-agentic-mapping.json` for the complete list.
 
-### ASI09: Human-Agent Trust Exploitation (16 rules) -- STRONG
+### ASI09: Human-Agent Trust Exploitation (18 rules) -- STRONG
 
 **OWASP description.** Adversaries exploit anthropomorphism and authority bias so humans approve harmful agent actions they would otherwise reject.
 
@@ -202,9 +202,9 @@ Top rules by severity:
 | ATR-2026-00524 | Claude Code ANTHROPIC_BASE_URL Credential Exfiltration (CVE-2026-21852) | critical | Detects exploitation of CVE-2026-21852 (Moderate, CVSS 5.3), credential exfiltration in C… |
 | ATR-2026-00858 | Indirect PI — Data Exfiltration with Evidence Destruction (Exfil-and-Delete) | critical | Detects indirect prompt injection payloads instructing an agent to exfiltrate sensitive d… |
 
-Plus 11 additional rules tagged ASI09 -- see `docs/owasp-agentic-mapping.json` for the complete list.
+Plus 13 additional rules tagged ASI09 -- see `docs/owasp-agentic-mapping.json` for the complete list.
 
-### ASI10: Rogue Agents (7 rules) -- MODERATE
+### ASI10: Rogue Agents (8 rules) -- STRONG
 
 **OWASP description.** Agents deviate from their intended function, optionally collude with other agents, and operate as autonomous threats. Canonical instance: Replit meltdown.
 
@@ -222,7 +222,7 @@ Top rules by severity:
 | ATR-2026-00108 | Multi-Agent Consensus Sybil Attack | critical | Detects attempts to manipulate multi-agent consensus or voting systems through Sybil-styl… |
 | ATR-2026-00117 | Agent Identity Spoofing and Authority Impersonation | critical | Detects agents or messages that impersonate other agents, system components, or superviso… |
 
-Plus 2 additional rules tagged ASI10 -- see `docs/owasp-agentic-mapping.json` for the complete list.
+Plus 3 additional rules tagged ASI10 -- see `docs/owasp-agentic-mapping.json` for the complete list.
 
 ---
 

--- a/docs/OWASP-AGENTIC-MATURITY-MAPPING.md
+++ b/docs/OWASP-AGENTIC-MATURITY-MAPPING.md
@@ -4,7 +4,7 @@ Version: 0.1.0 (INTERNAL DRAFT — not published)
 Status: Draft alignment note for the OWASP Agentic adoption maturity model
 Date: 2026-06-14
 Editor: Adam Lin (林冠辛) <adam@agentthreatrule.org>
-Mapped corpus: Agent Threat Rules v3.5.2 (708 rules / 10 categories)
+Mapped corpus: Agent Threat Rules v3.5.8 (747 rules / 10 categories)
 Reference: "State of Agentic AI Security and Governance" (v2.01), OWASP GenAI Security Project, June 2026 — https://genai.owasp.org/resource/state-of-agentic-ai-security-and-governance/
 
 ---

--- a/docs/OWASP-AISVS-MAPPING.md
+++ b/docs/OWASP-AISVS-MAPPING.md
@@ -4,7 +4,7 @@ Version: 0.1.0 (INTERNAL DRAFT — not published, not submitted)
 Status: Draft for future OWASP AISVS Informative Reference / PR basis (human review gate before any upstream submission)
 Date: 2026-06-12
 Editor: Adam Lin (林冠辛) <adam@agentthreatrule.org>
-Mapped corpus: Agent Threat Rules v3.5.2 (708 rules / 10 categories, disk==stats.json verified 2026-06-29)
+Mapped corpus: Agent Threat Rules v3.5.8 (747 rules / 10 categories, disk==stats.json verified 2026-07-12)
 Reference framework: OWASP AI Security Verification Standard (AISVS) 1.0, chapters C9, C10, C13
 Reference framework license: CC BY-SA 4.0 (OWASP/AISVS README). Requirement text
 quoted below is reproduced under that license; this mapping is a derivative

--- a/docs/OWASP-AIVSS-MAPPING.md
+++ b/docs/OWASP-AIVSS-MAPPING.md
@@ -1,7 +1,7 @@
 # ATR -> OWASP AIVSS (AI Vulnerability Scoring System) Mapping
 
-Last updated: 2026-06-16
-ATR version: v3.5.2 (708 rules)
+Last updated: 2026-07-12
+ATR version: v3.5.8 (747 rules)
 OWASP framework: AIVSS v0.8 (March 2026) — OWASP Agentic AI Core Security Risks
 
 ## What this maps, and what it does not

--- a/docs/OWASP-AST10-MAPPING.md
+++ b/docs/OWASP-AST10-MAPPING.md
@@ -1,7 +1,7 @@
 # ATR → OWASP Agentic Skills Top 10 (AST10) Mapping
 
-Last updated: 2026-06-06 (header refreshed)
-ATR corpus: v3.5.2, 708 rules (10 categories, including skill-compromise)
+Last updated: 2026-07-12 (corpus re-stamp v3.5.2->v3.5.8)
+ATR corpus: v3.5.8, 747 rules (10 categories, including skill-compromise)
 OWASP framework: Agentic Skills Top 10 (AST10), March 2026
 
 > Coverage note: the per-category ATR rule citations below were last fully

--- a/docs/SAFE-MCP-MAPPING.md
+++ b/docs/SAFE-MCP-MAPPING.md
@@ -1,7 +1,7 @@
 # ATR → SAFE-MCP Technique Mapping
 
-Last updated: 2026-06-16 (header refreshed)
-ATR corpus: v3.5.2, 708 rules (10 categories)
+Last updated: 2026-07-12 (corpus re-stamp v3.5.2->v3.5.8)
+ATR corpus: v3.5.8, 747 rules (10 categories)
 SAFE-MCP version: latest (85 techniques, 47 mitigations)
 
 > Coverage note: the per-technique ATR rule citations in this document were last

--- a/docs/owasp-agentic-mapping.json
+++ b/docs/owasp-agentic-mapping.json
@@ -1,10 +1,10 @@
 {
-  "generated_at": "2026-06-14",
-  "atr_version": "v3.5.0",
+  "generated_at": "2026-07-12",
+  "atr_version": "v3.5.8",
   "owasp_agentic_version": "v1.0 (December 2025)",
-  "total_rules_in_repo": 652,
-  "total_tagged_rules": 652,
-  "total_mappings": 866,
+  "total_rules_in_repo": 747,
+  "total_tagged_rules": 747,
+  "total_mappings": 976,
   "categories": [
     {
       "key": "ASI01",
@@ -13,7 +13,7 @@
       "official_description": "Attackers manipulate the agent's decision pathways or objectives so it pursues an adversary-controlled goal instead of its assigned task. Canonical instance: EchoLeak.",
       "reference_attack": "EchoLeak",
       "coverage_note": "Direct + indirect prompt injection, persona hijack, encoding evasion, jailbreak chains, multi-turn assembly, multilingual paraphrase.",
-      "rule_count": 445,
+      "rule_count": 480,
       "strength": "STRONG",
       "rules": [
         {
@@ -834,6 +834,20 @@
           "severity": "critical",
           "category": "privilege-escalation",
           "file": "rules/privilege-escalation/ATR-2026-01899-remote-access-backdoor.yaml"
+        },
+        {
+          "id": "ATR-2026-01988",
+          "title": "Local Sensitive-File Read Chained to Outbound Exfiltration",
+          "severity": "critical",
+          "category": "context-exfiltration",
+          "file": "rules/context-exfiltration/ATR-2026-01988-t1005-agent-local-data-staging-exfil.yaml"
+        },
+        {
+          "id": "ATR-2026-02211",
+          "title": "Named Dangerous-Substance Synthesis or Delivery Instruction Request (Non-Step-By-Step Phrasing)",
+          "severity": "critical",
+          "category": "model-abuse",
+          "file": "rules/model-abuse/ATR-2026-02211-named-substance-synthesis-request-non-stepword.yaml"
         },
         {
           "id": "ATR-2026-00001",
@@ -2642,6 +2656,216 @@
           "file": "rules/prompt-injection/ATR-2026-01926-cross-lingual-authorization-laundering.yaml"
         },
         {
+          "id": "ATR-2026-01993",
+          "title": "Agent Disabling of Host Security Controls",
+          "severity": "high",
+          "category": "excessive-autonomy",
+          "file": "rules/excessive-autonomy/ATR-2026-01993-t1562-agent-impair-defenses.yaml"
+        },
+        {
+          "id": "ATR-2026-01994",
+          "title": "Agent Establishing an Encrypted Reverse Channel or Tunnel",
+          "severity": "high",
+          "category": "excessive-autonomy",
+          "file": "rules/excessive-autonomy/ATR-2026-01994-t1573-agent-encrypted-c2-channel.yaml"
+        },
+        {
+          "id": "ATR-2026-02001",
+          "title": "Ignore-Below-Instructions Injection (Downstream Override)",
+          "severity": "high",
+          "category": "prompt-injection",
+          "file": "rules/prompt-injection/ATR-2026-02001-ignore-below-instructions-mirror-of-ignore-previ.yaml"
+        },
+        {
+          "id": "ATR-2026-02002",
+          "title": "Instruction-Set Probe or Supplant",
+          "severity": "high",
+          "category": "prompt-injection",
+          "file": "rules/prompt-injection/ATR-2026-02002-instruction-set-probe-or-supplant-direct-meta-qu.yaml"
+        },
+        {
+          "id": "ATR-2026-02003",
+          "title": "Task-Pivot Override: Cover-Task Abandonment",
+          "severity": "high",
+          "category": "prompt-injection",
+          "file": "rules/prompt-injection/ATR-2026-02003-task-pivot-override-abandon-the-cover-task-trans.yaml"
+        },
+        {
+          "id": "ATR-2026-02004",
+          "title": "Regional-Indicator Flag-Emoji Alphabet Letter-Spelling Smuggling",
+          "severity": "high",
+          "category": "prompt-injection",
+          "file": "rules/prompt-injection/ATR-2026-02004-regional-indicator-flag-emoji-alphabet-letter-sp.yaml"
+        },
+        {
+          "id": "ATR-2026-02005",
+          "title": "Actor Never-Breaks-Character Roleplay (DAN-Style Film Framing)",
+          "severity": "high",
+          "category": "prompt-injection",
+          "file": "rules/prompt-injection/ATR-2026-02005-actor-never-breaks-character-roleplay-dan-style-.yaml"
+        },
+        {
+          "id": "ATR-2026-02006",
+          "title": "Fuzzy Cross-Lingual 'I Have Been PWNED' Near-Miss Obfuscation",
+          "severity": "high",
+          "category": "prompt-injection",
+          "file": "rules/prompt-injection/ATR-2026-02006-fuzzy-cross-lingual-i-have-been-pwned-near-miss-.yaml"
+        },
+        {
+          "id": "ATR-2026-02007",
+          "title": "Bare Key Elicitation Token Detection",
+          "severity": "high",
+          "category": "prompt-injection",
+          "file": "rules/prompt-injection/ATR-2026-02007-bare-key-elicitation-token.yaml"
+        },
+        {
+          "id": "ATR-2026-02008",
+          "title": "Translation-Chain Output Laundering (Forced Phrase via Foreign-Language Auxiliary)",
+          "severity": "high",
+          "category": "prompt-injection",
+          "file": "rules/prompt-injection/ATR-2026-02008-translation-chain-output-laundering-state-secret.yaml"
+        },
+        {
+          "id": "ATR-2026-02010",
+          "title": "Emoji-Only Payload Injection",
+          "severity": "high",
+          "category": "prompt-injection",
+          "file": "rules/prompt-injection/ATR-2026-02010-emoji-only-payload.yaml"
+        },
+        {
+          "id": "ATR-2026-02011",
+          "title": "Malformed-Grammar PWNED Success-Claim Detection",
+          "severity": "high",
+          "category": "prompt-injection",
+          "file": "rules/prompt-injection/ATR-2026-02011-malformed-grammar-pwned-success-claim.yaml"
+        },
+        {
+          "id": "ATR-2026-02012",
+          "title": "Movie Title Generator Instruction Wrapper for PWNED Payload",
+          "severity": "high",
+          "category": "prompt-injection",
+          "file": "rules/prompt-injection/ATR-2026-02012-movie-title-generator-instruction-wrapper-for-pw.yaml"
+        },
+        {
+          "id": "ATR-2026-02013",
+          "title": "Delimiter-Fence Ignore-Instructions Override",
+          "severity": "high",
+          "category": "prompt-injection",
+          "file": "rules/prompt-injection/ATR-2026-02013-delimiter-fence-ignore-instructions-override.yaml"
+        },
+        {
+          "id": "ATR-2026-02014",
+          "title": "Spliced Target-String Canary Token Evasion",
+          "severity": "high",
+          "category": "prompt-injection",
+          "file": "rules/prompt-injection/ATR-2026-02014-spliced-target-string-letters-of-a-filtered-cana.yaml"
+        },
+        {
+          "id": "ATR-2026-02015",
+          "title": "Dense Emoji-Only Payload Flood",
+          "severity": "high",
+          "category": "prompt-injection",
+          "file": "rules/prompt-injection/ATR-2026-02015-dense-emoji-only-payload-flood.yaml"
+        },
+        {
+          "id": "ATR-2026-02016",
+          "title": "Reversed Payload String (HackAPrompt Canary)",
+          "severity": "high",
+          "category": "prompt-injection",
+          "file": "rules/prompt-injection/ATR-2026-02016-reversed-payload-string.yaml"
+        },
+        {
+          "id": "ATR-2026-02017",
+          "title": "Secret Key Exfiltration Request",
+          "severity": "high",
+          "category": "context-exfiltration",
+          "file": "rules/context-exfiltration/ATR-2026-02017-secret-key-exfiltration-request.yaml"
+        },
+        {
+          "id": "ATR-2026-02018",
+          "title": "Regional-Indicator Flag-Emoji Letter Spelling",
+          "severity": "high",
+          "category": "prompt-injection",
+          "file": "rules/prompt-injection/ATR-2026-02018-regional-indicator-flag-emoji-letter-spelling-sp.yaml"
+        },
+        {
+          "id": "ATR-2026-02019",
+          "title": "Python Interpreter Role-Assignment Exec Framing",
+          "severity": "high",
+          "category": "prompt-injection",
+          "file": "rules/prompt-injection/ATR-2026-02019-python-interpreter-role-assignment-exec-framing.yaml"
+        },
+        {
+          "id": "ATR-2026-02020",
+          "title": "Obfuscated Token Reconstruction via Character Substitution",
+          "severity": "high",
+          "category": "prompt-injection",
+          "file": "rules/prompt-injection/ATR-2026-02020-obfuscated-token-reconstruction-via-character-su.yaml"
+        },
+        {
+          "id": "ATR-2026-02022",
+          "title": "CurXecute — Cursor .cursor/mcp.json Injected-Server Auto-Exec RCE (CVE-2025-54135)",
+          "severity": "high",
+          "category": "tool-poisoning",
+          "file": "rules/tool-poisoning/ATR-2026-02022-curxecute-cursor-mcp-json-injected-server-rce.yaml"
+        },
+        {
+          "id": "ATR-2026-02025",
+          "title": "MCP Full Schema Poisoning — Injected Directive in Non-Description inputSchema Field (MCP-11)",
+          "severity": "high",
+          "category": "tool-poisoning",
+          "file": "rules/tool-poisoning/ATR-2026-02025-mcp-full-schema-poisoning-nondescription-field.yaml"
+        },
+        {
+          "id": "ATR-2026-02026",
+          "title": "System Prompt Extraction - Oblique Referent + Transform",
+          "severity": "high",
+          "category": "context-exfiltration",
+          "file": "rules/context-exfiltration/ATR-2026-02026-oblique-sysprompt-extraction-transform.yaml"
+        },
+        {
+          "id": "ATR-2026-02120",
+          "title": "AgentDojo 'Important Message' Identity-Spoof Before-You-Solve Pretext (Generalized)",
+          "severity": "high",
+          "category": "prompt-injection",
+          "file": "rules/prompt-injection/ATR-2026-02120-agentdojo-important-message-identity-spoof-pretext.yaml"
+        },
+        {
+          "id": "ATR-2026-02121",
+          "title": "MCP/API Tool Argument LFI via Mixed-Encoding Path Separator or file:// URI Scheme Escape",
+          "severity": "high",
+          "category": "context-exfiltration",
+          "file": "rules/context-exfiltration/ATR-2026-02121-mixed-encoding-lfi-file-scheme-tool-argument.yaml"
+        },
+        {
+          "id": "ATR-2026-02122",
+          "title": "Single-Level Directory Traversal to a Named Sensitive Config/Secret File",
+          "severity": "high",
+          "category": "context-exfiltration",
+          "file": "rules/context-exfiltration/ATR-2026-02122-single-level-traversal-sensitive-config-file.yaml"
+        },
+        {
+          "id": "ATR-2026-02144",
+          "title": "Stored External Data Reframes Itself as an Administrative Request to Hijack System Prompt",
+          "severity": "high",
+          "category": "data-poisoning",
+          "file": "rules/data-poisoning/ATR-2026-02144-stored-data-administrative-request-role-elevation.yaml"
+        },
+        {
+          "id": "ATR-2026-02210",
+          "title": "Negated-Topic Two-Script Evil-Persona Jailbreak",
+          "severity": "high",
+          "category": "prompt-injection",
+          "file": "rules/prompt-injection/ATR-2026-02210-negation-topic-evil-persona-two-script-jailbreak.yaml"
+        },
+        {
+          "id": "ATR-2026-02250",
+          "title": "Attachment/Upload Tool Argument Reads Sensitive System File or Traverses Outside Workspace",
+          "severity": "high",
+          "category": "context-exfiltration",
+          "file": "rules/context-exfiltration/ATR-2026-02250-attachment-upload-tool-arbitrary-file-read.yaml"
+        },
+        {
           "id": "ATR-2026-00005",
           "title": "Multi-Turn Prompt Injection",
           "severity": "medium",
@@ -3118,6 +3342,27 @@
           "file": "rules/prompt-injection/ATR-2026-01906-content-manipulation.yaml"
         },
         {
+          "id": "ATR-2026-02230",
+          "title": "Conditional Keyword-Triggered Response Override",
+          "severity": "medium",
+          "category": "prompt-injection",
+          "file": "rules/prompt-injection/ATR-2026-02230-conditional-keyword-trigger-override.yaml"
+        },
+        {
+          "id": "ATR-2026-02231",
+          "title": "Second-Person Direct Existential Threat Coercion",
+          "severity": "medium",
+          "category": "agent-manipulation",
+          "file": "rules/agent-manipulation/ATR-2026-02231-second-person-death-threat-coercion.yaml"
+        },
+        {
+          "id": "ATR-2026-02232",
+          "title": "Bare Brand/Entity Persona Assignment for Off-Label Opinion Elicitation",
+          "severity": "medium",
+          "category": "prompt-injection",
+          "file": "rules/prompt-injection/ATR-2026-02232-brand-persona-opinion-hijack.yaml"
+        },
+        {
           "id": "ATR-2026-00455",
           "title": "No-Period Output Override Instruction",
           "severity": "low",
@@ -3140,7 +3385,7 @@
       "official_description": "Legitimate tools are used unsafely because the agent acts on ambiguous instructions or has over-privileged access. Canonical instance: Amazon Q assistant tool-misuse incident.",
       "reference_attack": "Amazon Q",
       "coverage_note": "Unauthorized tool calls, SSRF via tool, MCP malicious response, schema-description contradiction, consent bypass.",
-      "rule_count": 32,
+      "rule_count": 48,
       "strength": "STRONG",
       "rules": [
         {
@@ -3226,6 +3471,55 @@
           "severity": "critical",
           "category": "excessive-autonomy",
           "file": "rules/excessive-autonomy/ATR-2026-01806-asb-clinical-patient-harm.yaml"
+        },
+        {
+          "id": "ATR-2026-02021",
+          "title": "MCP Inspector Unauthenticated Proxy stdio Command Execution (CVE-2025-49596)",
+          "severity": "critical",
+          "category": "tool-poisoning",
+          "file": "rules/tool-poisoning/ATR-2026-02021-mcp-inspector-unauthenticated-proxy-rce.yaml"
+        },
+        {
+          "id": "ATR-2026-02040",
+          "title": "Arbitrary Write to SSH Authorized Keys or Shell Startup File via Unvalidated File-Edit Tool",
+          "severity": "critical",
+          "category": "privilege-escalation",
+          "file": "rules/privilege-escalation/ATR-2026-02040-file-edit-tool-persistence-write.yaml"
+        },
+        {
+          "id": "ATR-2026-02041",
+          "title": "Shell Command Injection via Echo-Marker Proof-of-Concept in Tool Argument",
+          "severity": "critical",
+          "category": "tool-poisoning",
+          "file": "rules/tool-poisoning/ATR-2026-02041-shell-injection-echo-marker-poc.yaml"
+        },
+        {
+          "id": "ATR-2026-02100",
+          "title": "LLM-Generated Cypher Query Injection with Destructive or Administrative Operations",
+          "severity": "critical",
+          "category": "privilege-escalation",
+          "file": "rules/privilege-escalation/ATR-2026-02100-cypher-destructive-admin-query-injection.yaml"
+        },
+        {
+          "id": "ATR-2026-02141",
+          "title": "Unsandboxed Command Execution via Dynamic MCP Server Config (command/args Injection)",
+          "severity": "critical",
+          "category": "tool-poisoning",
+          "file": "rules/tool-poisoning/ATR-2026-02141-mcp-server-config-command-execution.yaml"
+        },
+        {
+          "id": "ATR-2026-02146",
+          "title": "Export/Extract Tool Directory Parameter Redirected to a Credential Directory",
+          "severity": "critical",
+          "category": "privilege-escalation",
+          "file": "rules/privilege-escalation/ATR-2026-02146-export-tool-dest-dir-credential-directory-redirect.yaml"
+        },
+        {
+          "id": "ATR-2026-02194",
+          "title": "Malicious Go init() Function Spawning a Process via a Code-Generation Tool",
+          "severity": "critical",
+          "category": "tool-poisoning",
+          "file": "rules/tool-poisoning/ATR-2026-02194-go-init-func-process-exec-codegen-rce.yaml"
         },
         {
           "id": "ATR-2026-00011",
@@ -3361,6 +3655,69 @@
           "file": "rules/tool-poisoning/ATR-2026-01928-framelink-figma-mcp-curl-fallback-command-injection.yaml"
         },
         {
+          "id": "ATR-2026-02023",
+          "title": "EscapeRoute — Filesystem MCP Server Directory Prefix-Bypass (CVE-2025-53110)",
+          "severity": "high",
+          "category": "tool-poisoning",
+          "file": "rules/tool-poisoning/ATR-2026-02023-escaperoute-filesystem-mcp-prefix-bypass.yaml"
+        },
+        {
+          "id": "ATR-2026-02024",
+          "title": "EscapeRoute — Filesystem MCP Symlink Escape to LaunchAgent Persistence (CVE-2025-53109)",
+          "severity": "high",
+          "category": "tool-poisoning",
+          "file": "rules/tool-poisoning/ATR-2026-02024-escaperoute-filesystem-mcp-symlink-launchagent.yaml"
+        },
+        {
+          "id": "ATR-2026-02102",
+          "title": "HTML/Script Injection in Tool Call Argument Targeting a Human-Approval Dashboard",
+          "severity": "high",
+          "category": "tool-poisoning",
+          "file": "rules/tool-poisoning/ATR-2026-02102-html-injection-tool-arg-approval-ui-xss.yaml"
+        },
+        {
+          "id": "ATR-2026-02123",
+          "title": "Authentication Bypass via Bare Query-String Path-Confusion Suffix",
+          "severity": "high",
+          "category": "privilege-escalation",
+          "file": "rules/privilege-escalation/ATR-2026-02123-bare-query-path-confusion-auth-bypass.yaml"
+        },
+        {
+          "id": "ATR-2026-02140",
+          "title": "SSRF to Cloud Metadata Endpoint via IPv6 Transition-Address Hex Encoding",
+          "severity": "high",
+          "category": "context-exfiltration",
+          "file": "rules/context-exfiltration/ATR-2026-02140-ssrf-ipv6-hex-encoded-cloud-metadata-bypass.yaml"
+        },
+        {
+          "id": "ATR-2026-02142",
+          "title": "Download/Attachment Tool Directed to Write Outside Its Sandbox via Absolute-Path Filename",
+          "severity": "high",
+          "category": "privilege-escalation",
+          "file": "rules/privilege-escalation/ATR-2026-02142-download-tool-absolute-path-sandbox-escape.yaml"
+        },
+        {
+          "id": "ATR-2026-02143",
+          "title": "Cypher/Graph-Query Injection via Unsanitized node_labels or group_ids Field",
+          "severity": "high",
+          "category": "data-poisoning",
+          "file": "rules/data-poisoning/ATR-2026-02143-graph-query-injection-node-labels-group-ids.yaml"
+        },
+        {
+          "id": "ATR-2026-02233",
+          "title": "Unscoped Destructive or Mass-Disclosure Database Operation Request via Natural Language",
+          "severity": "high",
+          "category": "tool-poisoning",
+          "file": "rules/tool-poisoning/ATR-2026-02233-unscoped-destructive-db-request-nl.yaml"
+        },
+        {
+          "id": "ATR-2026-02251",
+          "title": "Multi-Tenant Identifier Field (sender_id/owner_id/tenant_id) Carries Path Traversal Into a Storage Write",
+          "severity": "high",
+          "category": "privilege-escalation",
+          "file": "rules/privilege-escalation/ATR-2026-02251-identifier-field-path-traversal-storage-write.yaml"
+        },
+        {
           "id": "ATR-2026-00127",
           "title": "Subcommand Overflow Bypass",
           "severity": "medium",
@@ -3376,7 +3733,7 @@
       "official_description": "Agents operate in an attribution gap; leaked credentials or escalated privileges let them act beyond intended scope.",
       "reference_attack": null,
       "coverage_note": "API key exposure, OAuth token abuse, env var harvesting, scope creep, credential file theft, privilege escalation.",
-      "rule_count": 107,
+      "rule_count": 115,
       "strength": "STRONG",
       "rules": [
         {
@@ -3521,7 +3878,7 @@
         },
         {
           "id": "ATR-2026-00451",
-          "title": "LiteLLM Proxy Admin Endpoint SQL Injection — CISA KEV (CVE-2026-42208)",
+          "title": "LiteLLM Proxy Authorization-Header SQL Injection — CISA KEV (CVE-2026-42208)",
           "severity": "critical",
           "category": "privilege-escalation",
           "file": "rules/privilege-escalation/ATR-2026-00451-litellm-admin-sqli-cisa-kev.yaml"
@@ -3798,6 +4155,41 @@
           "severity": "critical",
           "category": "excessive-autonomy",
           "file": "rules/excessive-autonomy/ATR-2026-01806-asb-clinical-patient-harm.yaml"
+        },
+        {
+          "id": "ATR-2026-01933",
+          "title": "LiteLLM User-Role Privilege Escalation (CVE-2026-47102)",
+          "severity": "critical",
+          "category": "privilege-escalation",
+          "file": "rules/privilege-escalation/ATR-2026-01933-litellm-user-role-privilege-escalation-cve-2026-47102.yaml"
+        },
+        {
+          "id": "ATR-2026-01934",
+          "title": "LiteLLM allowed_routes Authorization Bypass (CVE-2026-47101)",
+          "severity": "critical",
+          "category": "privilege-escalation",
+          "file": "rules/privilege-escalation/ATR-2026-01934-litellm-allowed-routes-authz-bypass-cve-2026-47101.yaml"
+        },
+        {
+          "id": "ATR-2026-01986",
+          "title": "Windows-MCP Unauthenticated HTTP PowerShell via Wildcard CORS (CVE-2026-48989)",
+          "severity": "critical",
+          "category": "privilege-escalation",
+          "file": "rules/privilege-escalation/ATR-2026-01986-windows-mcp-unauth-http-powershell-cors.yaml"
+        },
+        {
+          "id": "ATR-2026-01992",
+          "title": "Agent Weakening of Host Authentication Configuration",
+          "severity": "critical",
+          "category": "privilege-escalation",
+          "file": "rules/privilege-escalation/ATR-2026-01992-t1556-agent-auth-process-tamper.yaml"
+        },
+        {
+          "id": "ATR-2026-02190",
+          "title": "DNS Exfiltration via Ping/Dig/Nslookup Command with Data-Encoded Subdomain Label",
+          "severity": "critical",
+          "category": "context-exfiltration",
+          "file": "rules/context-exfiltration/ATR-2026-02190-dns-exfiltration-ping-dig-encoded-subdomain.yaml"
         },
         {
           "id": "ATR-2026-00012",
@@ -4115,6 +4507,27 @@
           "file": "rules/context-exfiltration/ATR-2026-01929-mcp-unauthenticated-transport-token-fallback.yaml"
         },
         {
+          "id": "ATR-2026-01981",
+          "title": "Network-AI ApprovalInbox Unauthenticated Cross-Origin Approval Bypass (GHSA-mxjx-28vx-xjjj)",
+          "severity": "high",
+          "category": "privilege-escalation",
+          "file": "rules/privilege-escalation/ATR-2026-01981-network-ai-approval-inbox-unauth-cors-bypass.yaml"
+        },
+        {
+          "id": "ATR-2026-01984",
+          "title": "MCP Server Kubernetes kubectl_generic Flag Injection Bearer Token Exfiltration (CVE-2026-47250)",
+          "severity": "high",
+          "category": "context-exfiltration",
+          "file": "rules/context-exfiltration/ATR-2026-01984-mcp-server-kubernetes-kubectl-generic-token-exfil.yaml"
+        },
+        {
+          "id": "ATR-2026-02025",
+          "title": "MCP Full Schema Poisoning — Injected Directive in Non-Description inputSchema Field (MCP-11)",
+          "severity": "high",
+          "category": "tool-poisoning",
+          "file": "rules/tool-poisoning/ATR-2026-02025-mcp-full-schema-poisoning-nondescription-field.yaml"
+        },
+        {
           "id": "ATR-2026-00041",
           "title": "Agent Scope Creep Detection",
           "severity": "medium",
@@ -4137,7 +4550,7 @@
       "official_description": "Runtime composition of third-party capabilities (MCP servers, plugins, skills, A2A endpoints) lets adversaries poison the call graph after deployment. Canonical instance: GitHub MCP exploit.",
       "reference_attack": "GitHub MCP exploit",
       "coverage_note": "Skill impersonation, hidden capability, polymorphic skill, registry poisoning, malicious skill code, parameter injection.",
-      "rule_count": 71,
+      "rule_count": 75,
       "strength": "STRONG",
       "rules": [
         {
@@ -4407,6 +4820,20 @@
           "file": "rules/context-exfiltration/ATR-2026-01754-ransom-file-cloud-exfil-delete-extortion.yaml"
         },
         {
+          "id": "ATR-2026-01931",
+          "title": "gemini-mcp-tool execAsync Command Injection & @file Exfiltration (CVE-2026-0755)",
+          "severity": "critical",
+          "category": "tool-poisoning",
+          "file": "rules/tool-poisoning/ATR-2026-01931-gemini-mcp-tool-command-injection-file-exfil.yaml"
+        },
+        {
+          "id": "ATR-2026-02195",
+          "title": "Dangerous Process-Hijacking Environment Variable Injected via Config/Env-Update Tool",
+          "severity": "critical",
+          "category": "privilege-escalation",
+          "file": "rules/privilege-escalation/ATR-2026-02195-dangerous-env-var-injection-config-tool.yaml"
+        },
+        {
           "id": "ATR-2026-00060",
           "title": "MCP Skill Impersonation and Supply Chain Attack",
           "severity": "high",
@@ -4624,6 +5051,20 @@
           "file": "rules/prompt-injection/ATR-2026-01926-cross-lingual-authorization-laundering.yaml"
         },
         {
+          "id": "ATR-2026-01930",
+          "title": "MCP Sampling Prompt Injection (Server-to-Client createMessage Abuse)",
+          "severity": "high",
+          "category": "tool-poisoning",
+          "file": "rules/tool-poisoning/ATR-2026-01930-mcp-sampling-prompt-injection.yaml"
+        },
+        {
+          "id": "ATR-2026-01932",
+          "title": "Shadow / Undeclared MCP Server Registration (MCP-38: MCP-18)",
+          "severity": "high",
+          "category": "tool-poisoning",
+          "file": "rules/tool-poisoning/ATR-2026-01932-shadow-undeclared-mcp-server-registration.yaml"
+        },
+        {
           "id": "ATR-2026-00061",
           "title": "Skill Description-Behavior Mismatch",
           "severity": "medium",
@@ -4646,7 +5087,7 @@
       "official_description": "Agents generate and execute code (\"vibe coding\"), opening RCE paths through natural-language instructions. Canonical instance: AutoGPT RCE.",
       "reference_attack": "AutoGPT RCE",
       "coverage_note": "eval injection, shell metacharacter escape, dynamic import exploitation, indirect tool injection leading to code exec.",
-      "rule_count": 65,
+      "rule_count": 76,
       "strength": "STRONG",
       "rules": [
         {
@@ -4902,6 +5343,48 @@
           "file": "rules/prompt-injection/ATR-2026-01018-evasion-shell-injection-eval.yaml"
         },
         {
+          "id": "ATR-2026-01931",
+          "title": "gemini-mcp-tool execAsync Command Injection & @file Exfiltration (CVE-2026-0755)",
+          "severity": "critical",
+          "category": "tool-poisoning",
+          "file": "rules/tool-poisoning/ATR-2026-01931-gemini-mcp-tool-command-injection-file-exfil.yaml"
+        },
+        {
+          "id": "ATR-2026-01935",
+          "title": "LiteLLM Custom-Code Guardrail Sandbox Escape (CVE-2026-40217)",
+          "severity": "critical",
+          "category": "tool-poisoning",
+          "file": "rules/tool-poisoning/ATR-2026-01935-litellm-custom-code-sandbox-escape-cve-2026-40217.yaml"
+        },
+        {
+          "id": "ATR-2026-01968",
+          "title": "DeepChat Markdown Deeplink shell.openExternal Protocol Bypass RCE (CVE-2026-43899, GHSA-cp8j-jx7q-7r5f)",
+          "severity": "critical",
+          "category": "tool-poisoning",
+          "file": "rules/tool-poisoning/ATR-2026-01968-deepchat-markdown-deeplink-openexternal-rce-bypass.yaml"
+        },
+        {
+          "id": "ATR-2026-02021",
+          "title": "MCP Inspector Unauthenticated Proxy stdio Command Execution (CVE-2025-49596)",
+          "severity": "critical",
+          "category": "tool-poisoning",
+          "file": "rules/tool-poisoning/ATR-2026-02021-mcp-inspector-unauthenticated-proxy-rce.yaml"
+        },
+        {
+          "id": "ATR-2026-02101",
+          "title": "Python Sandbox Escape via Dynamically-Constructed Dunder Attribute Chain",
+          "severity": "critical",
+          "category": "privilege-escalation",
+          "file": "rules/privilege-escalation/ATR-2026-02101-dynamic-dunder-attribute-sandbox-escape.yaml"
+        },
+        {
+          "id": "ATR-2026-02145",
+          "title": "Python Sandbox Escape via Generator/Coroutine Frame Object Introspection",
+          "severity": "critical",
+          "category": "tool-poisoning",
+          "file": "rules/tool-poisoning/ATR-2026-02145-python-sandbox-escape-generator-frame-introspection.yaml"
+        },
+        {
           "id": "ATR-2026-00050",
           "title": "Runaway Agent Loop Detection",
           "severity": "high",
@@ -5098,6 +5581,41 @@
           "file": "rules/tool-poisoning/ATR-2026-01928-framelink-figma-mcp-curl-fallback-command-injection.yaml"
         },
         {
+          "id": "ATR-2026-01930",
+          "title": "MCP Sampling Prompt Injection (Server-to-Client createMessage Abuse)",
+          "severity": "high",
+          "category": "tool-poisoning",
+          "file": "rules/tool-poisoning/ATR-2026-01930-mcp-sampling-prompt-injection.yaml"
+        },
+        {
+          "id": "ATR-2026-02022",
+          "title": "CurXecute — Cursor .cursor/mcp.json Injected-Server Auto-Exec RCE (CVE-2025-54135)",
+          "severity": "high",
+          "category": "tool-poisoning",
+          "file": "rules/tool-poisoning/ATR-2026-02022-curxecute-cursor-mcp-json-injected-server-rce.yaml"
+        },
+        {
+          "id": "ATR-2026-02024",
+          "title": "EscapeRoute — Filesystem MCP Symlink Escape to LaunchAgent Persistence (CVE-2025-53109)",
+          "severity": "high",
+          "category": "tool-poisoning",
+          "file": "rules/tool-poisoning/ATR-2026-02024-escaperoute-filesystem-mcp-symlink-launchagent.yaml"
+        },
+        {
+          "id": "ATR-2026-02105",
+          "title": "Prototype Pollution via constructor.prototype Path Bypassing __proto__-Only Filters",
+          "severity": "high",
+          "category": "agent-manipulation",
+          "file": "rules/agent-manipulation/ATR-2026-02105-prototype-pollution-constructor-prototype-bypass.yaml"
+        },
+        {
+          "id": "ATR-2026-02193",
+          "title": "SSRF via Non-Canonical IPv6 Encoding of Loopback/Internal Addresses",
+          "severity": "high",
+          "category": "tool-poisoning",
+          "file": "rules/tool-poisoning/ATR-2026-02193-ssrf-ipv6-noncanonical-loopback-bypass.yaml"
+        },
+        {
           "id": "ATR-2026-00397",
           "title": "Snowball Impossible Reasoning Injection",
           "severity": "medium",
@@ -5113,7 +5631,7 @@
       "official_description": "Long-term memory, RAG stores, or shared context are corrupted so the agent's future behavior is shaped by attacker payloads. Canonical instance: Gemini Memory Attack.",
       "reference_attack": "Gemini Memory Attack",
       "coverage_note": "Agent memory manipulation, RAG poisoning, audit evasion, malicious finetuning data, consensus poisoning, persistent context drift.",
-      "rule_count": 54,
+      "rule_count": 87,
       "strength": "STRONG",
       "rules": [
         {
@@ -5297,6 +5815,181 @@
           "severity": "critical",
           "category": "prompt-injection",
           "file": "rules/prompt-injection/ATR-2026-01304-indirect-injection-carrier-important-override.yaml"
+        },
+        {
+          "id": "ATR-2026-01933",
+          "title": "LiteLLM User-Role Privilege Escalation (CVE-2026-47102)",
+          "severity": "critical",
+          "category": "privilege-escalation",
+          "file": "rules/privilege-escalation/ATR-2026-01933-litellm-user-role-privilege-escalation-cve-2026-47102.yaml"
+        },
+        {
+          "id": "ATR-2026-01934",
+          "title": "LiteLLM allowed_routes Authorization Bypass (CVE-2026-47101)",
+          "severity": "critical",
+          "category": "privilege-escalation",
+          "file": "rules/privilege-escalation/ATR-2026-01934-litellm-allowed-routes-authz-bypass-cve-2026-47101.yaml"
+        },
+        {
+          "id": "ATR-2026-01935",
+          "title": "LiteLLM Custom-Code Guardrail Sandbox Escape (CVE-2026-40217)",
+          "severity": "critical",
+          "category": "tool-poisoning",
+          "file": "rules/tool-poisoning/ATR-2026-01935-litellm-custom-code-sandbox-escape-cve-2026-40217.yaml"
+        },
+        {
+          "id": "ATR-2026-01948",
+          "title": "netlicensing-mcp Path Traversal in product_number Bypasses Token Redaction (GHSA-hxpf-9xvq-wph8)",
+          "severity": "critical",
+          "category": "context-exfiltration",
+          "file": "rules/context-exfiltration/ATR-2026-01948-netlicensing-mcp-product-number-path-traversal-token-leak.yaml"
+        },
+        {
+          "id": "ATR-2026-01949",
+          "title": "PraisonAI MCPServer Unauthenticated HTTP tools/call Authentication Bypass (GHSA-j4f3-55x4-r6q2)",
+          "severity": "critical",
+          "category": "privilege-escalation",
+          "file": "rules/privilege-escalation/ATR-2026-01949-praisonai-mcpserver-unauth-tools-call.yaml"
+        },
+        {
+          "id": "ATR-2026-01952",
+          "title": "PraisonAI codeMode JS Sandbox Escape RCE via new Function/with() (GHSA-p69m-4f92-2v84)",
+          "severity": "critical",
+          "category": "tool-poisoning",
+          "file": "rules/tool-poisoning/ATR-2026-01952-praisonai-codemode-sandbox-escape-rce.yaml"
+        },
+        {
+          "id": "ATR-2026-01953",
+          "title": "npm PraisonAI codeMode Sandbox Escape via Function Constructor Prototype Chain (GHSA-vmmj-pfw7-fjwp)",
+          "severity": "critical",
+          "category": "tool-poisoning",
+          "file": "rules/tool-poisoning/ATR-2026-01953-praisonai-codemode-function-ctor-sandbox-escape.yaml"
+        },
+        {
+          "id": "ATR-2026-01957",
+          "title": "M365 Copilot Business Chat SearchLeak Open-Redirect Prompt-Injection Exfil (CVE-2026-47645)",
+          "severity": "critical",
+          "category": "context-exfiltration",
+          "file": "rules/context-exfiltration/ATR-2026-01957-m365-copilot-searchleak-open-redirect-exfil.yaml"
+        },
+        {
+          "id": "ATR-2026-01959",
+          "title": "OpenHuman Shell Tool Allowlist Bypass via Env-Prefix / find -execdir (CVE-2026-55743)",
+          "severity": "critical",
+          "category": "tool-poisoning",
+          "file": "rules/tool-poisoning/ATR-2026-01959-openhuman-shell-allowlist-env-prefix-bypass.yaml"
+        },
+        {
+          "id": "ATR-2026-01961",
+          "title": "Meta Ads MCP Unauthenticated Tool Execution Leaks META_ACCESS_TOKEN (CVE-2026-48039 / GHSA-9gw6-46qc-99vr)",
+          "severity": "critical",
+          "category": "context-exfiltration",
+          "file": "rules/context-exfiltration/ATR-2026-01961-meta-ads-mcp-unauth-token-leak.yaml"
+        },
+        {
+          "id": "ATR-2026-01963",
+          "title": "PraisonAI Action Orchestrator step.target Path Traversal Arbitrary File Write RCE (CVE-2026-39305 / GHSA-jfxc-v5g9-38xr)",
+          "severity": "critical",
+          "category": "tool-poisoning",
+          "file": "rules/tool-poisoning/ATR-2026-01963-praisonai-action-orchestrator-step-target-path-traversal-rce.yaml"
+        },
+        {
+          "id": "ATR-2026-01964",
+          "title": "LangChain GmailToolkit Indirect Prompt Injection Email Exfiltration (CVE-2025-46059)",
+          "severity": "critical",
+          "category": "context-exfiltration",
+          "file": "rules/context-exfiltration/ATR-2026-01964-langchain-gmailtoolkit-indirect-prompt-injection-email-exfil.yaml"
+        },
+        {
+          "id": "ATR-2026-01965",
+          "title": "Flowise Custom MCP node-load-method OS Command RCE (CVE-2025-8943)",
+          "severity": "critical",
+          "category": "tool-poisoning",
+          "file": "rules/tool-poisoning/ATR-2026-01965-flowise-custommcp-os-command-rce.yaml"
+        },
+        {
+          "id": "ATR-2026-01967",
+          "title": "DeepChat Mermaid XSS to RCE via Electron IPC MCP Server Registration (CVE-2025-66481 / GHSA-h9f5-7hhf-fqm4)",
+          "severity": "critical",
+          "category": "tool-poisoning",
+          "file": "rules/tool-poisoning/ATR-2026-01967-deepchat-mermaid-xss-rce-ipc-mcp-register.yaml"
+        },
+        {
+          "id": "ATR-2026-01968",
+          "title": "DeepChat Markdown Deeplink shell.openExternal Protocol Bypass RCE (CVE-2026-43899, GHSA-cp8j-jx7q-7r5f)",
+          "severity": "critical",
+          "category": "tool-poisoning",
+          "file": "rules/tool-poisoning/ATR-2026-01968-deepchat-markdown-deeplink-openexternal-rce-bypass.yaml"
+        },
+        {
+          "id": "ATR-2026-01970",
+          "title": "PraisonAI FileTools _validate_path normpath Path Traversal (CVE-2026-35615 / GHSA-693f-pf34-72c5)",
+          "severity": "critical",
+          "category": "tool-poisoning",
+          "file": "rules/tool-poisoning/ATR-2026-01970-praisonai-filetools-normpath-path-traversal.yaml"
+        },
+        {
+          "id": "ATR-2026-01973",
+          "title": "AnythingLLM Logo Endpoint Path Traversal File Read/Delete (CVE-2024-3025)",
+          "severity": "critical",
+          "category": "tool-poisoning",
+          "file": "rules/tool-poisoning/ATR-2026-01973-anythingllm-logo-endpoint-path-traversal.yaml"
+        },
+        {
+          "id": "ATR-2026-01974",
+          "title": "AnythingLLM unauthenticated /system/data-import access control bypass (CVE-2024-3279)",
+          "severity": "critical",
+          "category": "privilege-escalation",
+          "file": "rules/privilege-escalation/ATR-2026-01974-anything-llm-data-import-access-control.yaml"
+        },
+        {
+          "id": "ATR-2026-01978",
+          "title": "AnythingLLM collector /process filename Path Traversal Arbitrary File Deletion (CVE-2023-5832)",
+          "severity": "critical",
+          "category": "tool-poisoning",
+          "file": "rules/tool-poisoning/ATR-2026-01978-anythingllm-collector-process-filename-path-traversal-delete.yaml"
+        },
+        {
+          "id": "ATR-2026-01979",
+          "title": "PandasAI Interactive Prompt Injection -> Python Sandbox Escape RCE (CVE-2024-12366 / GHSA-vv2h-2w3q-3fx7)",
+          "severity": "critical",
+          "category": "tool-poisoning",
+          "file": "rules/tool-poisoning/ATR-2026-01979-pandasai-prompt-injection-dunder-sandbox-escape-rce.yaml"
+        },
+        {
+          "id": "ATR-2026-01980",
+          "title": "Agentic-Flow MCP Tool-Parameter OS Command Injection (GHSA-vcv2-r9jh-99m5)",
+          "severity": "critical",
+          "category": "tool-poisoning",
+          "file": "rules/tool-poisoning/ATR-2026-01980-agentic-flow-mcp-tool-param-command-injection.yaml"
+        },
+        {
+          "id": "ATR-2026-01983",
+          "title": "MCP-for-Stata: Command Injection via log_file_name Parameter (CVE-2026-47708)",
+          "severity": "critical",
+          "category": "tool-poisoning",
+          "file": "rules/tool-poisoning/ATR-2026-01983-mcp-for-stata-log-file-name-command-injection.yaml"
+        },
+        {
+          "id": "ATR-2026-01985",
+          "title": "MCP Connect: Unauthenticated /bridge Endpoint Arbitrary Process Spawn RCE (GHSA-wvr4-3wq4-gpc5)",
+          "severity": "critical",
+          "category": "tool-poisoning",
+          "file": "rules/tool-poisoning/ATR-2026-01985-mcp-connect-bridge-unauth-process-spawn-rce.yaml"
+        },
+        {
+          "id": "ATR-2026-01986",
+          "title": "Windows-MCP Unauthenticated HTTP PowerShell via Wildcard CORS (CVE-2026-48989)",
+          "severity": "critical",
+          "category": "privilege-escalation",
+          "file": "rules/privilege-escalation/ATR-2026-01986-windows-mcp-unauth-http-powershell-cors.yaml"
+        },
+        {
+          "id": "ATR-2026-01987",
+          "title": "Langroid SQLChatAgent Prompt-to-SQL Remote Code Execution (CVE-2026-25879)",
+          "severity": "critical",
+          "category": "tool-poisoning",
+          "file": "rules/tool-poisoning/ATR-2026-01987-langroid-sqlchatagent-prompt-to-sql-rce.yaml"
         },
         {
           "id": "ATR-2026-00002",
@@ -5488,11 +6181,67 @@
           "file": "rules/prompt-injection/ATR-2026-01925-encoded-payload-decoding-coercion.yaml"
         },
         {
+          "id": "ATR-2026-01981",
+          "title": "Network-AI ApprovalInbox Unauthenticated Cross-Origin Approval Bypass (GHSA-mxjx-28vx-xjjj)",
+          "severity": "high",
+          "category": "privilege-escalation",
+          "file": "rules/privilege-escalation/ATR-2026-01981-network-ai-approval-inbox-unauth-cors-bypass.yaml"
+        },
+        {
+          "id": "ATR-2026-01984",
+          "title": "MCP Server Kubernetes kubectl_generic Flag Injection Bearer Token Exfiltration (CVE-2026-47250)",
+          "severity": "high",
+          "category": "context-exfiltration",
+          "file": "rules/context-exfiltration/ATR-2026-01984-mcp-server-kubernetes-kubectl-generic-token-exfil.yaml"
+        },
+        {
+          "id": "ATR-2026-01989",
+          "title": "Agent-Initiated Internal Network Service Sweep",
+          "severity": "high",
+          "category": "excessive-autonomy",
+          "file": "rules/excessive-autonomy/ATR-2026-01989-t1046-agent-internal-network-sweep.yaml"
+        },
+        {
+          "id": "ATR-2026-02023",
+          "title": "EscapeRoute — Filesystem MCP Server Directory Prefix-Bypass (CVE-2025-53110)",
+          "severity": "high",
+          "category": "tool-poisoning",
+          "file": "rules/tool-poisoning/ATR-2026-02023-escaperoute-filesystem-mcp-prefix-bypass.yaml"
+        },
+        {
+          "id": "ATR-2026-02104",
+          "title": "MEDIA:/file:// Directive Injection in Tool Result for Local File Exfiltration",
+          "severity": "high",
+          "category": "context-exfiltration",
+          "file": "rules/context-exfiltration/ATR-2026-02104-media-directive-tool-result-file-exfil.yaml"
+        },
+        {
+          "id": "ATR-2026-02106",
+          "title": "Catastrophic-Backtracking Regex Payload in a Search/Query Tool Argument",
+          "severity": "high",
+          "category": "excessive-autonomy",
+          "file": "rules/excessive-autonomy/ATR-2026-02106-redos-regex-payload-tool-argument.yaml"
+        },
+        {
+          "id": "ATR-2026-02107",
+          "title": "SSRF via Non-IP Internal Hostname or Domain-Allowlist Authority Bypass",
+          "severity": "high",
+          "category": "context-exfiltration",
+          "file": "rules/context-exfiltration/ATR-2026-02107-ssrf-internal-hostname-domain-allowlist-bypass.yaml"
+        },
+        {
           "id": "ATR-2026-01155",
           "title": "Direct Memory Plant Command — Persistent Fact or Code Storage Injection",
           "severity": "medium",
           "category": "data-poisoning",
           "file": "rules/data-poisoning/ATR-2026-01155-memory-plant-direct-command.yaml"
+        },
+        {
+          "id": "ATR-2026-01982",
+          "title": "dbt-mcp node_selection/resource_type Argument Injection (CVE-2026-44968)",
+          "severity": "medium",
+          "category": "tool-poisoning",
+          "file": "rules/tool-poisoning/ATR-2026-01982-dbt-mcp-node-selection-argument-injection.yaml"
         }
       ]
     },
@@ -5557,7 +6306,7 @@
         },
         {
           "id": "ATR-2026-00451",
-          "title": "LiteLLM Proxy Admin Endpoint SQL Injection — CISA KEV (CVE-2026-42208)",
+          "title": "LiteLLM Proxy Authorization-Header SQL Injection — CISA KEV (CVE-2026-42208)",
           "severity": "critical",
           "category": "privilege-escalation",
           "file": "rules/privilege-escalation/ATR-2026-00451-litellm-admin-sqli-cisa-kev.yaml"
@@ -6010,7 +6759,7 @@
       "official_description": "Adversaries exploit anthropomorphism and authority bias so humans approve harmful agent actions they would otherwise reject.",
       "reference_attack": null,
       "coverage_note": "Human trust exploitation, approval fatigue, social engineering via agent, unauthorized financial action, high-risk tool gate bypass.",
-      "rule_count": 16,
+      "rule_count": 18,
       "strength": "STRONG",
       "rules": [
         {
@@ -6112,6 +6861,20 @@
           "file": "rules/tool-poisoning/ATR-2026-01303-tool-schema-enumeration-social-engineering.yaml"
         },
         {
+          "id": "ATR-2026-01932",
+          "title": "Shadow / Undeclared MCP Server Registration (MCP-38: MCP-18)",
+          "severity": "high",
+          "category": "tool-poisoning",
+          "file": "rules/tool-poisoning/ATR-2026-01932-shadow-undeclared-mcp-server-registration.yaml"
+        },
+        {
+          "id": "ATR-2026-02009",
+          "title": "Bare Key Elicitation with Trailing Colon",
+          "severity": "high",
+          "category": "prompt-injection",
+          "file": "rules/prompt-injection/ATR-2026-02009-bare-key-elicitation-trailing-colon.yaml"
+        },
+        {
           "id": "ATR-2026-00118",
           "title": "Human Approval Fatigue Exploitation",
           "severity": "medium",
@@ -6134,8 +6897,8 @@
       "official_description": "Agents deviate from their intended function, optionally collude with other agents, and operate as autonomous threats. Canonical instance: Replit meltdown.",
       "reference_attack": "Replit meltdown",
       "coverage_note": "Goal hijacking, cross-agent privilege escalation, runaway loop, scope creep, delayed execution bypass, polymorphic behavior.",
-      "rule_count": 7,
-      "strength": "MODERATE",
+      "rule_count": 8,
+      "strength": "STRONG",
       "rules": [
         {
           "id": "ATR-2026-00030",
@@ -6178,6 +6941,13 @@
           "severity": "high",
           "category": "agent-manipulation",
           "file": "rules/agent-manipulation/ATR-2026-00132-casual-authority-escalation.yaml"
+        },
+        {
+          "id": "ATR-2026-02192",
+          "title": "Agent Self-Modifying Its Own Trust/Approval Configuration to a Wildcard",
+          "severity": "high",
+          "category": "privilege-escalation",
+          "file": "rules/privilege-escalation/ATR-2026-02192-self-privesc-wildcard-trust-config-write.yaml"
         },
         {
           "id": "ATR-2026-00099",

--- a/website/app/[locale]/spec/page.tsx
+++ b/website/app/[locale]/spec/page.tsx
@@ -280,6 +280,8 @@ test_cases:
     <tr><td>MITRE ATLAS</td><td>Per-rule references</td><td>Per-rule <code>references.mitre_atlas</code></td></tr>
     <tr><td>NIST AI RMF (community OSCAL catalog)</td><td>4/4 functions</td><td><a href="https://github.com/Agent-Threat-Rule/ai-rmf-oscal-catalog" target="_blank" rel="noopener noreferrer">ai-rmf-oscal-catalog</a></td></tr>
     <tr><td>Five Eyes joint guidance (2026-04-30)</td><td>5-category mapping</td><td><a href="https://github.com/Agent-Threat-Rule/agent-threat-rules/blob/main/docs/FIVE-EYES-MAPPING.md" target="_blank" rel="noopener noreferrer">FIVE-EYES-MAPPING.md</a></td></tr>
+    <tr><td>CSA MAESTRO (2025)</td><td>7-layer architectural mapping</td><td><a href="https://github.com/Agent-Threat-Rule/agent-threat-rules/blob/main/docs/CSA-MAESTRO-MAPPING.md" target="_blank" rel="noopener noreferrer">CSA-MAESTRO-MAPPING.md</a></td></tr>
+    <tr><td>ETSI TS 104 223</td><td>13-principle mapping</td><td><a href="https://github.com/Agent-Threat-Rule/agent-threat-rules/blob/main/docs/ETSI-TS-104223-MAPPING.md" target="_blank" rel="noopener noreferrer">ETSI-TS-104223-MAPPING.md</a></td></tr>
   </tbody>
 </table>
 <p>NIST has not endorsed the community OSCAL catalog. The mapping is community-maintained.</p>`,
@@ -296,6 +298,8 @@ test_cases:
     <tr><td>MITRE ATLAS</td><td>Per-rule references</td><td>Per-rule <code>references.mitre_atlas</code></td></tr>
     <tr><td>NIST AI RMF (community OSCAL catalog)</td><td>4/4 functions</td><td><a href="https://github.com/Agent-Threat-Rule/ai-rmf-oscal-catalog" target="_blank" rel="noopener noreferrer">ai-rmf-oscal-catalog</a></td></tr>
     <tr><td>Five Eyes joint guidance (2026-04-30)</td><td>5-category mapping</td><td><a href="https://github.com/Agent-Threat-Rule/agent-threat-rules/blob/main/docs/FIVE-EYES-MAPPING.md" target="_blank" rel="noopener noreferrer">FIVE-EYES-MAPPING.md</a></td></tr>
+    <tr><td>CSA MAESTRO (2025)</td><td>7 層架構對應</td><td><a href="https://github.com/Agent-Threat-Rule/agent-threat-rules/blob/main/docs/CSA-MAESTRO-MAPPING.md" target="_blank" rel="noopener noreferrer">CSA-MAESTRO-MAPPING.md</a></td></tr>
+    <tr><td>ETSI TS 104 223</td><td>13 項原則對應</td><td><a href="https://github.com/Agent-Threat-Rule/agent-threat-rules/blob/main/docs/ETSI-TS-104223-MAPPING.md" target="_blank" rel="noopener noreferrer">ETSI-TS-104223-MAPPING.md</a></td></tr>
   </tbody>
 </table>
 <p>NIST 並未背書社群 OSCAL catalog。該對應由社群維護。</p>`,


### PR DESCRIPTION
Compliance crosswalk maintenance pass (2026-07-12). No rule files touched.

New crosswalk
- docs/CSA-MAESTRO-MAPPING.md — maps ATR's 10 categories / 747 rules onto CSA MAESTRO's 7 architectural layers (L1 Foundation Models through L7 Agent Ecosystem). L5 Evaluation and Observability plus cross-cutting L6 Security and Compliance are framed as where ATR supplies runtime evidence. Category-level mapping, explicitly honest about granularity; not a CSA endorsement.

Corpus re-stamp (headers only)
Every hand-authored crosswalk header was stamped against an older corpus (v3.5.2 / v3.5.6, 708 rules). audit:mappings confirms the corpus is now 747 rules across the same 10 categories with zero compliance-identifier drift, so the category-level mappings still hold. This refreshes only the corpus-size stamp; per-rule enumeration version notes in each doc body are left intact (they honestly record when rule IDs were last individually checked).
- Regenerated OWASP-AGENTIC-MAPPING.md and .json via scripts/generate-owasp-mapping.ts (mechanical, 747).
- Re-stamped 708 -> 747 / v3.5.8: SAFE-MCP, FIVE-EYES, OWASP-AST10, NSA-MCP, ETSI-TS-104223, FINOS-AI-GOVERNANCE, MITRE-ATLAS, OWASP-AGENTIC-MATURITY, OWASP-AISVS, OWASP-AIVSS, MCP-38.
- disk == data/stats.json == 747, 10 categories, verified 2026-07-12.

Website
- spec Framework Coverage table now surfaces CSA MAESTRO (7-layer) and ETSI TS 104 223 (13-principle) rows, EN + ZH. Rule counts on the site are already sourced dynamically from stats.json.

Verification
- npm run validate:compliance -> 0 violations across 747 mapped rules
- npm run audit:mappings -> 0 stale crosswalk docs remaining
- npm test -> 565 passed / 3 skipped

Note: the repealed Colorado AI Act (SB24-205) removal is a separate PR (#301) to keep the rule-file change isolated from this docs/website pass.