### PR TITLE
fix(ci): FP-gate promotions into the enforce (auto-block) lane

### DIFF
--- a/.github/workflows/maturity-fp-gate.yml
+++ b/.github/workflows/maturity-fp-gate.yml
@@ -1,0 +1,35 @@
+name: Maturity FP gate
+
+# Blocks any PR that promotes a rule into the enforce (auto-block) lane
+# — maturity:stable / production — if that rule false-positives on the benign
+# corpus. The time-based promoter can promote on "≥60 days + 0 FP reports"
+# without ever scanning a benign corpus; this gate is the backstop that turns
+# such a promotion RED instead of letting it pollute the enforce lane.
+
+on:
+  pull_request:
+    paths:
+      - "rules/**"
+
+permissions:
+  contents: read
+
+jobs:
+  fp-gate:
+    name: Promoted rules must be FP-clean
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v5
+        with:
+          node-version: "20"
+      - name: Install dependencies
+        run: npm ci
+      - name: Build ATR engine
+        run: npm run build
+      - name: Fetch base ref
+        run: git fetch --no-tags origin "${{ github.base_ref }}"
+      - name: Gate rules promoted to the enforce lane
+        run: npx tsx scripts/gate-promotion-fp.ts --base "origin/${{ github.base_ref }}"

--- a/scripts/gate-promotion-fp.ts
+++ b/scripts/gate-promotion-fp.ts
@@ -1,0 +1,195 @@
+#!/usr/bin/env node
+/**
+ * gate-promotion-fp.ts — block a maturity promotion that would put an
+ * FP-producing rule into the enforce (auto-block) lane.
+ *
+ * WHY: maturity:stable is the enforce lane (see engine.ts — "enforce = only
+ * maturity=stable rules, auto-block, lowest FP"). A promoter that keys on time
+ * ("≥60 days in test + 0 FP *reports*") can promote a rule that has never been
+ * scanned against a benign corpus. This gate re-runs the rules a PR promotes to
+ * stable/production against the local benign corpora and FAILS if any of them
+ * false-positive — so a bad promotion turns the PR red instead of shipping.
+ *
+ * Modes:
+ *   gate-promotion-fp.ts --base origin/main   # auto-detect rules this branch
+ *                                             # sets to stable/production, gate them
+ *   gate-promotion-fp.ts --ids <file>         # gate an explicit ATR-id list
+ *
+ * Exit 0 = no promoted rule false-positives (or nothing promoted).
+ * Exit 1 = at least one promoted rule FPs on the benign corpus.
+ */
+import {
+  readFileSync,
+  readdirSync,
+  existsSync,
+  statSync,
+  mkdtempSync,
+  copyFileSync,
+} from "node:fs";
+import { join, resolve, dirname, basename } from "node:path";
+import { tmpdir } from "node:os";
+import { execFileSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { ATREngine } from "../src/engine.js";
+import type { AgentEvent } from "../src/types.js";
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const RULES_DIR = join(REPO_ROOT, "rules");
+const CORPORA = [
+  join(REPO_ROOT, "data/skill-benchmark/benign"),
+  join(REPO_ROOT, "data/benign-corpus-extended"),
+  join(REPO_ROOT, "data/benign-code"),
+];
+const ENFORCE_MATURITIES = new Set(["stable", "production"]);
+
+function arg(name: string): string | null {
+  const i = process.argv.indexOf(name);
+  return i >= 0 ? (process.argv[i + 1] ?? null) : null;
+}
+
+/** Rule files this branch sets to an enforce-lane maturity, vs the base ref. */
+function promotedFilesFromDiff(base: string): string[] {
+  const diff = execFileSync(
+    "git",
+    ["diff", `${base}...HEAD`, "--unified=0", "--", "rules/"],
+    { cwd: REPO_ROOT, encoding: "utf-8", maxBuffer: 64 * 1024 * 1024 },
+  );
+  const files = new Set<string>();
+  let current: string | null = null;
+  for (const line of diff.split("\n")) {
+    const m = /^\+\+\+ b\/(rules\/.*\.ya?ml)$/.exec(line);
+    if (m) {
+      current = m[1] ?? null;
+      continue;
+    }
+    const mm = /^\+\s*maturity:\s*["']?(\w+)["']?\s*$/.exec(line);
+    if (mm && current && ENFORCE_MATURITIES.has(mm[1] ?? "")) files.add(current);
+  }
+  return [...files];
+}
+
+function ruleIdOf(file: string): string | null {
+  for (const line of readFileSync(join(REPO_ROOT, file), "utf-8").split("\n")) {
+    const m = /^id:\s*(\S+)/.exec(line);
+    if (m) return m[1] ?? null;
+  }
+  return null;
+}
+
+function asTextEvent(content: string): AgentEvent {
+  return {
+    type: "mcp_exchange",
+    timestamp: new Date().toISOString(),
+    content,
+    fields: {
+      tool_name: "corpus-sample",
+      tool_input: content,
+      tool_response: content,
+      user_input: content,
+    },
+  };
+}
+
+function loadCorpusTexts(pathStr: string): string[] {
+  const texts: string[] = [];
+  if (!existsSync(pathStr)) return texts;
+  const files: string[] = [];
+  if (statSync(pathStr).isDirectory()) {
+    for (const e of readdirSync(pathStr))
+      if (e.endsWith(".jsonl") || e.endsWith(".md")) files.push(join(pathStr, e));
+  } else files.push(pathStr);
+  for (const f of files) {
+    let raw: string;
+    try {
+      raw = readFileSync(f, "utf-8");
+    } catch {
+      continue;
+    }
+    if (f.endsWith(".md")) {
+      texts.push(raw);
+      continue;
+    }
+    for (const line of raw.split("\n")) {
+      const t = line.trim();
+      if (!t) continue;
+      try {
+        const obj = JSON.parse(t) as { text?: string };
+        if (typeof obj.text === "string" && obj.text.length > 0) texts.push(obj.text);
+      } catch {
+        continue;
+      }
+    }
+  }
+  return texts;
+}
+
+/** Copy just the target rule files into a temp dir so the engine loads only them. */
+function scopedRulesDir(files: string[]): string {
+  const dir = mkdtempSync(join(tmpdir(), "atr-gate-"));
+  for (const f of files) copyFileSync(join(REPO_ROOT, f), join(dir, basename(f)));
+  return dir;
+}
+
+async function main(): Promise<void> {
+  const idsFile = arg("--ids");
+  const base = arg("--base") ?? "origin/main";
+
+  let targetFiles: string[];
+  let targetIds: Set<string>;
+
+  if (idsFile) {
+    targetIds = new Set(
+      readFileSync(idsFile, "utf-8").split("\n").map((s) => s.trim()).filter(Boolean),
+    );
+    targetFiles = [];
+    for (const f of execFileSync("git", ["ls-files", "rules/"], {
+      cwd: REPO_ROOT,
+      encoding: "utf-8",
+      maxBuffer: 64 * 1024 * 1024,
+    }).split("\n")) {
+      if (!f.endsWith(".yaml") && !f.endsWith(".yml")) continue;
+      const id = ruleIdOf(f);
+      if (id && targetIds.has(id)) targetFiles.push(f);
+    }
+  } else {
+    targetFiles = promotedFilesFromDiff(base);
+    targetIds = new Set(targetFiles.map(ruleIdOf).filter((x): x is string => !!x));
+  }
+
+  if (targetFiles.length === 0) {
+    console.log(`[fp-gate] no rules promoted to enforce lane vs ${base} — nothing to gate.`);
+    return;
+  }
+  console.log(`[fp-gate] gating ${targetFiles.length} promoted rule(s) against the benign corpus`);
+
+  const engine = new ATREngine({ rulesDir: scopedRulesDir(targetFiles) });
+  await engine.loadRules();
+
+  const samples: string[] = [];
+  for (const c of CORPORA) samples.push(...loadCorpusTexts(c));
+
+  const fp = new Map<string, number>();
+  for (const id of targetIds) fp.set(id, 0);
+  for (const text of samples) {
+    const matched = new Set<string>();
+    for (const m of engine.evaluate(asTextEvent(text))) matched.add(m.rule.id);
+    for (const m of engine.scanSkill(text)) matched.add(m.rule.id);
+    for (const id of matched) if (targetIds.has(id)) fp.set(id, (fp.get(id) ?? 0) + 1);
+  }
+
+  const dirty = [...fp.entries()].filter(([, n]) => n > 0).sort((a, b) => b[1] - a[1]);
+  console.log(`[fp-gate] corpus = ${samples.length} benign samples`);
+  console.log(`[fp-gate] clean = ${targetIds.size - dirty.length} · dirty = ${dirty.length}`);
+  if (dirty.length > 0) {
+    console.error(`\n[fp-gate] FAIL — these promoted rules false-positive on benign content and`);
+    console.error(`must not enter the enforce (auto-block) lane:`);
+    for (const [id, n] of dirty) console.error(`  ${id} — ${n} FP`);
+    process.exit(1);
+  }
+  console.log(`[fp-gate] PASS — all promoted rules are FP-clean on the benign corpus.`);
+}
+
+main().catch((e: unknown) => {
+  console.error(e instanceof Error ? e.stack : String(e));
+  process.exit(1);
+});


### PR DESCRIPTION
## Problem
maturity:stable is the enforce lane (engine.ts: \"enforce = only maturity=stable rules, auto-block, lowest FP\"). The daily promoter moves rules test->stable on a time signal — \"≥60 days in test + 0 FP *reports*\" — and never scans a benign corpus. So a rule that false-positives on benign skills can land in the auto-block lane, and the documented canPromote(->stable) gate (wild_fp_rate ≤ 0.5% on ≥1000 wild samples) is bypassed.

Caught in review: promotion PRs #291 (53 rules) and #303 (55 rules) were audited independently — **16 of 53 candidates FP** on the 5,317-sample benign corpus (worst ATR-2026-00522, 22 FP, flagging benign data-exploration skills like huggingface-best / explore-data). Both PRs were closed.

## Fix
- scripts/gate-promotion-fp.ts — loads exactly the rules a PR promotes to stable/production (git-diff aware vs the base ref, or an explicit --ids list), runs them against the local benign corpora, exits 1 if any FP.
- .github/workflows/maturity-fp-gate.yml — runs on every PR touching rules/, so a promotion that carries an FP rule turns the PR red instead of shipping into the enforce lane.

## Verification
- gate --ids on the #303 candidate set: exits 1, flags all 16 FP rules.
- gate --base on a branch that promotes nothing: exits 0 (\"nothing to gate\").

## Follow-up (separate)
A corpus scan found **32 of 145 already-merged stable rules also FP** (ATR-2026-00030 278 FP, ATR-2026-00002 168 FP, ATR-2026-00442 51 FP). The enforce lane is already polluted; demoting those is a separate cleanup. This gate stops it from getting worse.