### PR TITLE
fix(rules): narrow the 2 over-threshold stable rules (00442 51->1, 00203 7->0)

### DIFF
--- a/rules/prompt-injection/ATR-2026-00203-context-pollution-skill-description.yaml
+++ b/rules/prompt-injection/ATR-2026-00203-context-pollution-skill-description.yaml
@@ -81,7 +81,7 @@ detection:
 
     - field: content
       operator: regex
-      value: "(?i)(?:attack|threat|vulnerability|injection)[\\s_-]*(?:pattern|vector|type)s?\\s*[:=]"
+      value: "(?i)(?:attack|threat|injection)[\\s_-]*(?:pattern|vector|type)s?\\s*[:=]\\s*[\\[\\{]?\\s*[\"']?(?:prompt[\\s_-]?inject|role[\\s_-]?hijack|jailbreak|memory[\\s_-]?tamper|goal[\\s_-]?hijack|data[\\s_-]?exfil|context[\\s_-]?pollut|tool[\\s_-]?poison|instruction[\\s_-]?override)"
       description: "Enumeration of attack patterns in a key-value format LLMs may follow"
 
   condition: any

--- a/rules/prompt-injection/ATR-2026-00442-quoted-exact-output-forcing.yaml
+++ b/rules/prompt-injection/ATR-2026-00442-quoted-exact-output-forcing.yaml
@@ -81,10 +81,18 @@ detection:
     #   - example-contrast continuations like "Say X not Y", "Say X or Y"
     #   - reported-speech contexts: "users say X", "when they say X" (meta-language
     #     describing user phrasing, not an imperative to the model)
+    # 1a: imperative output + an explicit EXACT-FORCING modifier + quoted target.
     - field: user_input
       operator: regex
-      value: "(?i)(?<![\"'])(?<!\\b(?:they|user|users|people|customer|customers|developer|developers|client|clients|when|if|whenever|caller|callers|operator|operators)\\s)\\b(say|output|retype|repeat|emit|reply\\s+with|respond\\s+with)\\s+(?:(?:exactly|only|just|the|following|exact|literal|string|phrase|text|words|content|line|chorus|caption|sentence|verse)\\s*[:,-]?\\s*)*[\"'][\\sA-Za-z0-9][^\"\\n]{3,200}[\"'](?!\\s*(?:not|or|nor|but|instead|rather\\s+than|--|—|,\\s*(?:not|or)\\s+[\"']))"
-      description: "Imperative output (excl. write/return/print + reported speech + inside-string) + flexible modifier chain + quoted natural-language target"
+      value: "(?i)(?<![\"'])(?<!\\b(?:they|user|users|people|customer|customers|developer|developers|client|clients|when|if|whenever|caller|callers|operator|operators)\\s)\\b(say|output|retype|repeat|emit|reply\\s+with|respond\\s+with)\\s+(?:exactly|only|just|verbatim|literally|precisely|word[\\s-]for[\\s-]word|nothing\\s+but|the\\s+(?:exact|literal)\\s+(?:string|phrase|text|words?|line)?)\\b[^\"\\n]{0,40}[\"'][\\sA-Za-z0-9][^\"\\n]{3,200}[\"'](?!\\s*(?:not|or|nor|but|instead|rather\\s+than|--|—))"
+      description: "Imperative output + explicit exact-forcing modifier (exactly/only/just/verbatim/word-for-word) + quoted target"
+
+    # 1b: imperative output forcing a security/status canonical assertion (catches the
+    # bare 'say \"I have been PWNED\"' shape without matching benign 'say \"hello world\"').
+    - field: user_input
+      operator: regex
+      value: "(?i)(?<![\"'])(?<!\\b(?:they|user|users|people|customer|customers|developer|developers|client|clients|when|if|whenever|caller|callers|operator|operators)\\s)\\b(say|output|retype|repeat|emit|reply\\s+with|respond\\s+with)\\s+(?:(?:exactly|only|just|the|following|exact|literal|string|phrase|text|words|line)\\s*[:,-]?\\s*)*[\"'][^\"\\n]{0,80}\\b(pwned|approved|granted|accepted|authori[sz]ed|overrid(?:e|den)|unlocked|jailbroken|bypass(?:ed)?|hacked|admin(?:istrator)?\\s+access|root\\s+access|no\\s+threats?|all\\s+clear|access\\s+granted|system\\s+override)\\b[^\"\\n]{0,80}[\"'](?!\\s*(?:not|or|nor|but|instead))"
+      description: "Imperative output forcing a security/status canonical assertion (approved/granted/PWNED/override/all clear)"
 
     # Answer-must-be quoted phrase (natural-language target only)
     - field: user_input


### PR DESCRIPTION
Completes the enforce-lane FP audit. Of the remaining dirty stable rules, only two genuinely exceeded the enforce-lane FP tolerance (~0.24%); the rest are <=9 FP (<0.17%) on the 5,317-sample benign corpus.

## ATR-2026-00442 (quoted-exact-output-forcing): 51 -> 1 FP
The imperative `say/output 'X'` branch matched benign `say "hello world"`. Split into two precise branches, both preserving every TP:
- 1a: imperative + explicit exact-forcing modifier (exactly/only/just/verbatim/word-for-word)
- 1b: imperative forcing a security/status canonical assertion (approved/granted/PWNED/override/all clear) — catches the bare `say "I have been PWNED"` without matching benign non-security quoted output.

## ATR-2026-00203 (context-pollution-skill-description): 7 -> 0 FP
The `attack pattern:` branch fired on benign security-tool skill *descriptions* (the MiroFish anti-pattern of matching description text). Now requires the value to contain an actual technique name (`prompt_injection`/`role_hijack`/`jailbreak`/...), matching the TP `attack_patterns: [prompt_injection, ...]` while ignoring prose.

## Verification
- test_cases: 00442 6/6 TP + 5/5 TN; 00203 2/2 + 1/1 — all pass.
- Full suite: 645 passed / 3 skipped.

## Scope note
The other ~25 dirty stable rules are within enforce-grade tolerance (1-9 FP). They are specific-payload detectors (SQLi/SSRF/XSS/path-traversal/reverse-shell) whose residual FP is benign security/DB skills *documenting* the payload, plus a few extraction/encoding heuristics whose TPs depend on the same tokens. Narrowing them would trade real detection for marginal FP — not recommended; the lane system (hunt vs enforce) is the right tool if any individual one is later judged too noisy.