### PR TITLE
fix(adopters): Microsoft Agent Framework in-review -> shipped (drift fix)

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -190,7 +190,7 @@ Listed when the integration code has been merged or released.
 - **Integration**: Sample showing ATR as a deterministic action-boundary validator in the Microsoft Agent Framework
 - **Evidence**: <https://github.com/microsoft/agent-framework/pull/6528>
 - **Since**: 2026-06-16
-- **Status**: in-review
+- **Status**: shipped
 
 ### OpenAI Guardrails
 - **Org**: OpenAI

--- a/data/adopters-verification.json
+++ b/data/adopters-verification.json
@@ -2,15 +2,8 @@
   "$comment": "AUTO by scripts/verify-adopters.mjs — every ADOPTERS.md evidence link re-checked against GitHub. Do not edit by hand.",
   "verified_at": "2026-07-13",
   "total": 34,
-  "ok": 33,
-  "drift": [
-    {
-      "name": "Microsoft Agent Framework",
-      "declared": "in-review",
-      "observed": "merged",
-      "evidence": "https://github.com/microsoft/agent-framework/pull/6528"
-    }
-  ],
+  "ok": 34,
+  "drift": [],
   "results": [
     {
       "name": "MISP / CIRCL",
@@ -151,10 +144,10 @@
       "name": "Microsoft Agent Framework",
       "tier": "2",
       "evidence": "https://github.com/microsoft/agent-framework/pull/6528",
-      "declared": "in-review",
+      "declared": "shipped",
       "kind": "pr",
       "observed": "merged",
-      "ok": false
+      "ok": true
     },
     {
       "name": "OpenAI Guardrails",


### PR DESCRIPTION
## Summary
The scheduled "Verify Adopters Evidence" workflow failed today (2026-07-13T06:22:46Z) with 1 drift: Microsoft Agent Framework was declared `in-review` in ADOPTERS.md, but the linked PR (microsoft/agent-framework#6528) is actually MERGED (confirmed via `gh pr view 6528`, mergedAt 2026-07-08T11:22:43Z).

This is a status upgrade (we were under-claiming), not a new claim.

## Test plan
- [x] `gh pr view 6528 --repo microsoft/agent-framework --json state,mergedAt` confirms MERGED
- [x] Ran `node scripts/verify-adopters.mjs` locally: 34/34 verified, 0 drift (was 33/34, 1 drift)