### PR TITLE
fix(rules): precision-repair 4 stable auto-blocking rules (149->37 FP, TP preserved)

### DIFF
--- a/rules/agent-manipulation/ATR-2026-00030-cross-agent-attack.yaml
+++ b/rules/agent-manipulation/ATR-2026-00030-cross-agent-attack.yaml
@@ -118,24 +118,24 @@ detection:
       description: "Agent claiming to be a privileged agent role"
     - field: content
       operator: regex
-      value: "(?i)(?:ignore|disregard|forget|override|overwrite)\\s+(?:all\\s+)?(?:your\\s+)?(?:previous|prior|above|earlier|existing)\\s+(?:instructions?|rules?|constraints?|guidelines?|prompt|directives?)"
-      description: "Instruction override attempt in inter-agent message"
+      value: "(?i)(?<![\"'`])(?:ignore|disregard|forget|override|overwrite)\\s+(?:all\\s+)?(?:your\\s+)?(?:previous|prior|above|earlier|existing)\\s+(?:instructions?|rules?|constraints?|guidelines?|prompt|directives?)"
+      description: "Instruction override attempt in inter-agent message (must be a live directive, not a quoted/listed mention in security docs — negative lookbehind excludes quote/backtick-prefixed occurrences)"
     - field: content
       operator: regex
-      value: "(?i)\\[\\s*(?:OVERRIDE|ROOT|SUDO)\\s*\\]|<<\\s*SYS\\s*>>|<\\|im_start\\|>system"
-      description: "Fake system-level message tags in agent communication (common benign labels [SYSTEM]/[ADMIN]/[PRIORITY]/[URGENT] dropped; kept override/root/sudo tags and chat-template markers)"
+      value: "(?i)(?<![\"'`])(?<!:\\s)(?:\\[\\s*(?:OVERRIDE|ROOT|SUDO)\\s*\\]|<<\\s*SYS\\s*>>|<\\|im_start\\|>system)"
+      description: "Fake system-level message tags in agent communication (common benign labels [SYSTEM]/[ADMIN]/[PRIORITY]/[URGENT] dropped; kept override/root/sudo tags and chat-template markers). Negative lookbehinds require a live forged role marker: excludes quoted/backticked doc references and YAML/JSON mapping values (parent_ids: [root])"
     - field: content
       operator: regex
-      value: "(?i)(?:new\\s+instructions?|updated\\s+(?:prompt|directive)|revised\\s+(?:rules?|orders?)|emergency\\s+(?:override|protocol))\\s*[:=]"
-      description: "Attempt to inject new instructions via agent messages"
+      value: "(?i)(?<![\"'`])(?:new\\s+instructions?|updated\\s+(?:prompt|directive)|revised\\s+(?:rules?|orders?)|emergency\\s+(?:override|protocol))\\s*[:=]"
+      description: "Attempt to inject new instructions via agent messages (live directive only; negative lookbehind excludes quoted/listed occurrences in prompt-injection detection docs)"
     - field: content
       operator: regex
       value: "(?i)(?:you\\s+are\\s+now|from\\s+now\\s+on|henceforth|going\\s+forward|effective\\s+immediately)\\s+(?:a|an|the)?\\s*(?:unrestricted|unfiltered|jailbroken)?\\s*[a-zA-Z]+\\s+(?:agent|assistant|bot)"
       description: "Attempt to redefine target agent's identity or role"
     - field: content
       operator: regex
-      value: "(?i)(?:do\\s+not|don'?t|never)\\s+(?:tell|inform|alert|notify|report|mention|log|record)\\s+(?:the\\s+)?(?:user|admin|orchestrator|supervisor|human|monitor)"
-      description: "Instruction to hide actions from oversight"
+      value: "(?i)(?:do\\s+not|don'?t|never)\\s+(?:tell|inform|alert|notify|report|mention|log|record)\\s+(?:the\\s+)?(?:user|admin|orchestrator|supervisor|human|monitor)(?!s?\\s+to\\b)"
+      description: "Instruction to hide actions from oversight (excludes benign coaching form 'never tell users to <verb>' via negative lookahead; keeps concealment form 'do not tell the user about <info>')"
     - field: content
       operator: regex
       value: "(?i)(?:acting|speaking|operating)\\s+(?:on\\s+behalf\\s+of|as\\s+a?\\s*proxy\\s+for|in\\s+place\\s+of)\\s+[a-zA-Z0-9_-]+\\s*(?:agent)?"
@@ -146,8 +146,8 @@ detection:
       description: "Explicit attempt to override identity or permissions"
     - field: content
       operator: regex
-      value: "(?i)(?:status|error|result)\\s*[:=]\\s*(?:failed|error|timeout|unauthorized).*(?:retry|fallback|use\\s+alternative|switch\\s+to)"
-      description: "Fake error or status injection to trigger fallback behavior"
+      value: "(?i)(?:status|error|result)\\s*[:=]\\s*(?:failed|error|timeout|unauthorized).{0,80}(?:fallback|use\\s+alternative|switch\\s+to)"
+      description: "Fake error or status injection to trigger fallback behavior (requires a behavior-redirect directive fallback/switch-to/use-alternative within 80 chars; bare 'retry' dropped as it matches benign error-handling prose)"
     - field: content
       operator: regex
       value: "(?i)(?:message_type|msg_type)\\s*[:=]\\s*[\"']?(?:admin|orchestrator|supervisor|root)[\"']?"

--- a/rules/prompt-injection/ATR-2026-00001-direct-prompt-injection.yaml
+++ b/rules/prompt-injection/ATR-2026-00001-direct-prompt-injection.yaml
@@ -98,8 +98,8 @@ detection:
     # "ignore your instructions", "ignore any instructions", "ignore all instructions"
     - field: user_input
       operator: regex
-      value: "(?i)\\b(ignore|disregard|forget|override|bypass|suppress|discard)\\s+(all\\s+)?(the\\s+|your\\s+|my\\s+|any\\s+|these\\s+|those\\s+)?(previous|prior|above|earlier|preceding|original|existing|current|initial|default|given|assigned|preset|established)?\\s*(instructions?|prompts?|rules?|guidelines?|directives?|constraints?|context|programming|training|protocols?|policies|configuration|parameters|boundaries|guardrails?|safeguards?|restrictions?|tasks?|assignments?|information|directions?|orders?|commands?)"
-      description: "Instruction override with broad verb and noun synonym coverage, including determiners"
+      value: "(?i)\\b(ignore|disregard|forget|override|bypass|suppress|discard)\\s+(?:(?:all|the|any|these|those)\\s+)*(?:(?:your|my)\\s+|(?:previous|prior|above|earlier|preceding|original|existing|current|initial|default|given|assigned|preset|established)\\s+)(?:(?:previous|prior|above|earlier|preceding|original|existing|current|initial|default|given|assigned|preset|established)\\s+)?(instructions?|prompts?|rules?|guidelines?|directives?|constraints?|context|programming|training|protocols?|policies|configuration|parameters|boundaries|guardrails?|safeguards?|restrictions?|tasks?|assignments?|information|directions?|orders?|commands?)"
+      description: "Instruction override with broad verb/noun coverage, requiring a directed anchor (your/my or a prior-state adjective) so benign 'ignore rules'/'override these guidelines' prose does not match"
 
     # -- Layer 1b: Forget-everything / forget-all shorthand --
     - field: user_input
@@ -116,8 +116,8 @@ detection:
     # -- Layer 1d: Broad forget/ignore + everything/that/this --
     - field: user_input
       operator: regex
-      value: "(?i)\\b(forget|ignore|disregard|discard)\\s+(about\\s+)?(everything|all|that|this|what\\s+was|what\\s+I|anything\\s+you)\\s*(previously|before|earlier|said|told|above|prior|were|was|have)?"
-      description: "Broad forget-everything variants with extended word coverage"
+      value: "(?i)\\b(forget|ignore|disregard|discard)\\s+(about\\s+)?(everything|all|that|this|what\\s+was|what\\s+I|anything\\s+you)\\s+(previously|before|earlier|said|told|above|prior|mentioned|instructed)"
+      description: "Forget-everything variants, requiring a trailing prior-context anchor so benign 'ignore all warnings'/'discard this file' prose does not match"
 
     # -- Layer 1g: Bare ignore/forget + above/before + action --
     - field: user_input
@@ -128,8 +128,8 @@ detection:
     # -- Layer 1e: System prompt extraction --
     - field: user_input
       operator: regex
-      value: "(?i)(reveal|show|display|output|print|repeat|provide|give|share|tell|what\\s+are|what\\s+were|what\\s+is)\\s+(me\\s+)?(your|the|all)\\s+(secret|hidden|internal|system|original|previous|initial|complete|full|given|guard|entire)?\\s*(instructions?|prompts?|passwords?|secrets?|embeddings?|configuration|directives?|guidelines?|rules)"
-      description: "System prompt and secret extraction requests"
+      value: "(?i)(reveal|show|display|output|print|repeat|provide|give|share|tell|what\\s+are|what\\s+were|what\\s+is)\\s+(me\\s+)?(?:(your|my)\\s+((secret|hidden|internal|system|original|previous|initial|complete|full|given|guard|entire)\\s+)?|(the|all)\\s+(secret|hidden|internal|system|original|previous|initial|complete|full|given|guard|entire)\\s+)(instructions?|prompts?|passwords?|secrets?|embeddings?|configuration|directives?|guidelines?|rules)"
+      description: "System prompt/secret extraction, requiring possessive (your/my) or a sensitive adjective so benign 'show the prompt'/'what are the rules' prose does not match"
 
     # -- Layer 1f: Contextual task switching with praise prefix --
     - field: user_input
@@ -140,8 +140,8 @@ detection:
     # -- Layer 1h: Leave behind / start fresh context switch --
     - field: user_input
       operator: regex
-      value: "(?i)(leave|put)\\s+(all\\s+)?(the\\s+)?(previous|prior|earlier|old)\\s+(information|tasks?|instructions?|context)\\s+(behind|aside|away)|start\\s+(from\\s+the\\s+)?(front|beginning|scratch|zero|neu|vorne)"
-      description: "Leave-behind / start-fresh context switch patterns"
+      value: "(?i)(leave|put)\\s+(all\\s+)?(the\\s+)?(previous|prior|earlier|old)\\s+(information|tasks?|instructions?|context)\\s+(behind|aside|away)|start\\s+(over|fresh|anew|from\\s+(the\\s+)?(scratch|zero|beginning|front))\\s+(with\\s+(a\\s+)?new\\s+(task|instructions?|persona|role|prompt)|and\\s+(ignore|forget|disregard))"
+      description: "Leave-behind / start-fresh context switch, requiring the fresh-start to redirect to a new task or an override so benign 'start from the beginning' prose does not match"
 
     # -- Layer 1i: German praise-then-redirect extended --
     - field: user_input
@@ -152,8 +152,8 @@ detection:
     # -- Layer 2: Persona switching / identity hijacking --
     - field: user_input
       operator: regex
-      value: "(?i)\\b(you\\s+are\\s+now|you\\s+have\\s+become|you\\s+will\\s+act\\s+as|you\\s+shall\\s+be|transform\\s+into|switch\\s+to\\s+being|morph\\s+into|adopt\\s+the\\s+persona|now\\s+you\\s+are|jetzt\\s+bist\\s+du|du\\s+bist\\s+(jetzt|nun)|stell\\s+dir\\s+vor\\s+du\\s+bist)\\s+(a|an|the|my|ein[ea]?)?\\s*[a-zA-Z\\u00C0-\\u024F]+"
-      description: "Persona switching and identity reassignment attempts"
+      value: "(?i)\\b(you\\s+are\\s+now|you\\s+have\\s+become|you\\s+will\\s+act\\s+as|you\\s+shall\\s+be|transform\\s+into|switch\\s+to\\s+being|morph\\s+into|adopt\\s+the\\s+persona|now\\s+you\\s+are|jetzt\\s+bist\\s+du|du\\s+bist\\s+(jetzt|nun)|stell\\s+dir\\s+vor\\s+du\\s+bist)\\s+(a|an|the|my|ein[ea]?)?\\s*(?:(unrestricted|unfiltered|uncensored|unlimited|unbound|unchained|jailbroken|jailbreak|evil|malicious|rogue|amoral|immoral|unethical|lawless|god[- ]?mode|developer\\s+mode|hacker|villain|DAN|STAN|dark\\s+[a-z]+)\\b|[a-zA-Z\\u00C0-\\u024F]+\\s+(?:with\\s+no|without\\s+(?:any\\s+)?)\\s*(restrictions?|limits?|limitations?|filters?|rules?|guidelines?|safety|guardrails?|morals?|ethics?|boundaries))"
+      description: "Persona switching to an adversarial identity (jailbreak/harmful persona lexicon or an explicit 'without restrictions' identity) so benign 'you are now an expert'/'transform into an X' prose does not match"
 
     # -- Layer 2b: Act-as roleplay with task assignment --
     - field: user_input
@@ -182,14 +182,14 @@ detection:
     # -- Layer 4: Do-not-follow-rules patterns --
     - field: user_input
       operator: regex
-      value: "(?i)(do\\s+not|don'?t|never|stop|cease|quit|refuse\\s+to)\\s+(follow|obey|adhere\\s+to|comply\\s+with|respect|honor|enforce|apply|observe|uphold)\\s+(your|the|any|all|those|these)\\s+(instructions?|rules?|guidelines?|programming|training|protocols?|policies|directives?|constraints?|boundaries|restrictions?)"
-      description: "Negation-verb patterns telling agent to stop following rules"
+      value: "(?i)(do\\s+not|don'?t|never|stop|cease|quit|refuse\\s+to)\\s+(follow|obey|adhere\\s+to|comply\\s+with|respect|honor|enforce|apply|observe|uphold)\\s+(your|all\\s+your|any\\s+of\\s+your|those|these)\\s+(instructions?|rules?|guidelines?|programming|training|protocols?|policies|directives?|constraints?|boundaries|restrictions?)"
+      description: "Negation-verb patterns telling agent to stop following its OWN rules (anchored on your/those/these) so benign 'do not follow any instructions from it' guidance does not match"
 
     # -- Layer 5: New instruction assignment --
     - field: user_input
       operator: regex
-      value: "(?i)\\b(new|updated|revised|replacement|corrected|actual|real|true|overriding)\\s+(instructions?|rules?|directives?|guidelines?|orders?|commands?)\\s*[:=\\-]"
-      description: "New instruction assignment with delimiter"
+      value: "(?i)\\b(new|updated|revised|replacement|corrected|actual|real|true|overriding)\\s+(instructions?|rules?|directives?|guidelines?|orders?|commands?)\\s*[:=]\\s*(?=.{0,25}(ignore|disregard|forget|reveal|disclose|print|output|say|tell|respond|reply|write|execute|run|follow|act\\s+as|do\\s+not|don'?t|send|comply|obey|override|bypass|stop|now\\b|you\\s+(must|will|are|should)))"
+      description: "New-instruction assignment, requiring the payload after the delimiter to be an AI-directed imperative so benign 'New instructions:' headings / bullet lists do not match"
 
     # -- Layer 6: Temporal behavioral override --
     - field: user_input
@@ -200,8 +200,8 @@ detection:
     # -- Layer 7: Fake system/instruction delimiters --
     - field: user_input
       operator: regex
-      value: "(?i)(\\[\\s*(SYSTEM|INST|INSTRUCTION|SYS|ADMIN|ROOT|OVERRIDE|CONTROL|PRIORITY|URGENT)\\s*\\]|<<\\s*(SYS|SYSTEM|INST)\\s*>>|\\{\\{\\s*(SYSTEM|INSTRUCTION|OVERRIDE)\\s*\\}\\})"
-      description: "Fake system-level delimiter tags"
+      value: "(\\[\\s*(SYSTEM|INST|SYS|ADMIN|ROOT|OVERRIDE)\\s*\\]|<<\\s*(SYS|SYSTEM|INST)\\s*>>|\\{\\{\\s*(SYSTEM|INSTRUCTION|OVERRIDE)\\s*\\}\\})"
+      description: "Fake system-level delimiter tags (case-sensitive uppercase; dropped generic words CONTROL/PRIORITY/URGENT/INSTRUCTION-bracket that appear as benign template labels)"
 
     # -- Layer 8: Restriction removal via pretend/imagine --
     - field: user_input
@@ -212,14 +212,14 @@ detection:
     # -- Layer 9: Compliance demands --
     - field: user_input
       operator: regex
-      value: "(?i)\\b(you\\s+(must|shall|will|need\\s+to|have\\s+to|are\\s+(required|obligated|commanded|ordered)\\s+to)\\s+(obey|comply|listen|submit|respond\\s+to|follow)\\s+(me|my|this|these|the\\s+following|every|all)|I\\s+(command|order|demand|direct|instruct|require)\\s+you\\s+to)\\b"
-      description: "Authoritative compliance demands"
+      value: "(?i)\\b(you\\s+(must|shall|will|need\\s+to|have\\s+to|are\\s+(required|obligated|commanded|ordered)\\s+to)\\s+(obey|comply|listen|submit|respond\\s+to|follow)\\s+(me|my)\\b|I\\s+(command|order|demand|direct|instruct|require)\\s+you\\s+to)\\b"
+      description: "Authoritative compliance demands, anchored on me/my so benign 'you must follow these steps' prose does not match"
 
     # -- Layer 10: Base64-encoded injection indicators --
     - field: user_input
       operator: regex
-      value: "(?i)(decode|interpret|execute|run|process|follow|read)\\s+(this|the\\s+following)?\\s*:?\\s*[A-Za-z0-9+/]{20,}={0,2}"
-      description: "Instructions to decode and execute base64-like payloads"
+      value: "(?i)(decode|interpret|base64\\s*[-\\s]?decode)\\s+(this|the\\s+following|and\\s+(?:execute|run|follow))?\\s*:?\\s*[A-Za-z0-9+/]{24,}={0,2}"
+      description: "Instructions to decode/interpret base64 payloads (narrowed verbs to decode/interpret so benign 'run <longIdentifier>' / 'read <token>' code prose does not match; known base64 keyword fragments still covered by Layer 11)"
 
     # -- Layer 11: Known base64 fragments of injection keywords --
     - field: user_input
@@ -254,8 +254,8 @@ detection:
     # -- Layer 14c: Stop-write / stop-say command injection --
     - field: user_input
       operator: regex
-      value: "(?i)\\bstop\\s*[-:,.]?\\s*(write|say|print|output)\\s*[:,-]?\\s+[A-Z].{2,40}"
-      description: "Stop-and-redirect command injection (stop: write X)"
+      value: "(?i)\\bstop\\s*[-:,]?\\s*(write|say|print|output)\\s*[:,-]?\\s+[A-Z].{2,40}"
+      description: "Stop-and-redirect command injection (stop: write X); dropped '.' connector so a sentence boundary 'STOP. Write the formula instead.' does not match"
 
     # -- Layer 15: Markdown/formatting abuse to hide injections --
     - field: user_input

--- a/rules/prompt-injection/ATR-2026-00002-indirect-prompt-injection.yaml
+++ b/rules/prompt-injection/ATR-2026-00002-indirect-prompt-injection.yaml
@@ -97,9 +97,12 @@ agent_source:
 detection:
   conditions:
     # -- Layer 1: HTML comments containing injection-like instructions --
+    # ignore/disregard/forget/override require a directive OBJECT (instruction/prompt/rule/...)
+    # so tooling pragmas ("<!-- prettier-ignore -->") and CSS labels ("<!-- Style override -->")
+    # do not match; multi-word directives (system:, you must, new instructions) stay as-is.
     - field: content
       operator: regex
-      value: "(?i)<!--[^>]{0,20}(ignore|disregard|override|new\\s+instructions?|system\\s*:|you\\s+must|you\\s+are\\s+now|forget\\s+previous|execute|perform|send\\s+to|exfiltrate|reveal|disclose|output\\s+the)[^>]{0,200}-->"
+      value: "(?i)<!--[^>]{0,20}((ignore|disregard|forget|override)\\s+(all\\s+|any\\s+|the\\s+|your\\s+)?(previous\\s+|prior\\s+|above\\s+|earlier\\s+|preceding\\s+|current\\s+)?(instruction|prompt|rule|guideline|direction|context|command|message|safety|system)|new\\s+instructions?|system\\s*:|you\\s+must|you\\s+are\\s+now|send\\s+to|exfiltrate|reveal|disclose|output\\s+the|execute|perform)[^>]{0,200}-->"
       description: "HTML comments with instruction-like content targeting the agent"
 
     # -- Layer 2: Zero-width character sequences (5+ consecutive to avoid multilingual FP) --
@@ -108,11 +111,22 @@ detection:
       value: "[\\u200B\\u200C\\u200D\\uFEFF\\u2060\\u180E\\u200E\\u200F\\u202A-\\u202E\\u2066-\\u2069]{5,}"
       description: "5+ consecutive zero-width or bidirectional control characters indicating obfuscation"
 
-    # -- Layer 3: Model-specific special tokens embedded in content --
+    # -- Layer 3a: Instruction-wrapper tokens (strong signal, rarely benign) --
+    # These delimiters wrap an injected instruction block; bare presence in consumed
+    # content is a reliable indicator (matches Llama [INST]/<<SYS>> injection).
     - field: content
       operator: regex
-      value: "(?i)(\\[INST\\]|\\[/INST\\]|\\[SYSTEM\\]|\\[/SYSTEM\\]|\\[HIDDEN\\]|<\\|im_start\\|>|<\\|im_end\\|>|<\\|endoftext\\|>|<\\|system\\|>|<\\|user\\|>|<\\|assistant\\|>|<\\|pad\\|>|<s>\\[INST\\]|<<SYS>>|<</SYS>>|<\\|begin_of_text\\|>|<\\|eot_id\\|>|<\\|start_header_id\\|>)"
-      description: "Model-specific special tokens and chat template delimiters"
+      value: "(?i)(\\[INST\\]|\\[/INST\\]|\\[HIDDEN\\]|<s>\\[INST\\]|<<SYS>>|<</SYS>>)"
+      description: "Instruction-wrapper tokens delimiting an injected instruction block"
+
+    # -- Layer 3b: ChatML/role/tokenizer tokens WITH an adjacent injection directive --
+    # Bare ChatML/tokenizer token names (<|im_start|>, <|endoftext|>, <|system|>, [SYSTEM])
+    # appear constantly in legitimate LLM/tokenizer documentation, so they only fire when
+    # followed within a short window by an actual override/jailbreak directive.
+    - field: content
+      operator: regex
+      value: "(?i)(\\[SYSTEM\\]|\\[/SYSTEM\\]|<\\|im_start\\|>|<\\|im_end\\|>|<\\|endoftext\\|>|<\\|system\\|>|<\\|user\\|>|<\\|assistant\\|>|<\\|pad\\|>|<\\|begin_of_text\\|>|<\\|eot_id\\|>|<\\|start_header_id\\|>)[\\s\\S]{0,120}(ignore\\s+(all|any|previous|prior|above|your)|disregard\\s+(all|any|previous|prior|above)|you\\s+are\\s+now\\s+|forget\\s+(all|previous|prior|everything)|reveal\\s+(the\\s+)?(system|prompt|key|secret)|exfiltrate|jailbreak|unrestricted\\s+assistant|do\\s+anything\\s+now|new\\s+instructions?|override\\s+(the\\s+)?(system|safety|previous|all))"
+      description: "ChatML/role/tokenizer tokens paired with an adjacent injection directive"
 
     # -- Layer 4: CSS-hidden text combined with injection keywords --
     - field: content

--- a/rules/tool-poisoning/ATR-2026-00010-mcp-malicious-response.yaml
+++ b/rules/tool-poisoning/ATR-2026-00010-mcp-malicious-response.yaml
@@ -110,8 +110,8 @@ detection:
     # -- Layer 1: Destructive shell commands --
     - field: tool_response
       operator: regex
-      value: "(?i)(\\brm\\s+-[rRf]{1,3}\\s+(--no-preserve-root|/[\\s*]|/$|~[\\s/])|\\bmkfs\\b|\\bdd\\s+if=|\\bformat\\s+[a-z]:|\\bdeltree\\b|\\bshred\\s+-|\\bwipefs\\b|\\bfdisk\\b.*--delete|:\\(\\)\\s*\\{\\s*:\\|:\\s*&\\s*\\})"
-      description: "Destructive filesystem commands including fork bombs (rm -rf narrowed to root/home targets; benign rm -rf <dir> no longer fires)"
+      value: "(?i)(\\brm\\s+-[rRf]{1,3}\\s+(--no-preserve-root|/[\\s*]|/$|~[\\s/])|\\bmkfs\\b|\\bdd\\s+if=[^\\n|;]{0,80}of=\\s*/dev/|\\bformat\\s+[a-z]:|\\bdeltree\\b|\\bshred\\s+-|\\bwipefs\\b|\\bfdisk\\b.*--delete|:\\(\\)\\s*\\{\\s*:\\|:\\s*&\\s*\\})"
+      description: "Destructive filesystem commands including fork bombs (rm -rf narrowed to root/home targets; benign rm -rf <dir> no longer fires). dd narrowed to writes onto a raw /dev/ device (of=/dev/...) — benign forensic imaging that reads a device INTO a file no longer fires"
 
     # -- Layer 2: Command execution via interpreters --
     - field: tool_response
@@ -122,14 +122,14 @@ detection:
     # -- Layer 3: Reverse shells (Unix) --
     - field: tool_response
       operator: regex
-      value: "(?i)(\\bnc\\s+-(e|c|l)\\s|\\bncat\\s|\\bnetcat\\s|/dev/tcp/|\\bbash\\s+-i\\s+>&\\s*/dev/tcp|\\bmkfifo\\b.{0,40}\\bnc\\b|\\bsocat\\b.{0,40}(exec|pty|tcp)|\\brm\\s+/tmp/f\\s*;)"
-      description: "Unix reverse shell patterns (netcat, bash, socat, fifo)"
+      value: "(?i)(\\bnc\\s+-(e|c|l)\\s|\\bncat\\s+-|/dev/tcp/|\\bbash\\s+-i\\s+>&\\s*/dev/tcp|\\bmkfifo\\b.{0,40}\\bnc\\b|\\bsocat\\b.{0,40}(exec|pty|tcp)|\\brm\\s+/tmp/f\\s*;)"
+      description: "Unix reverse shell patterns (bash /dev/tcp, socat exec, fifo). netcat/ncat tightened to a flagged invocation (ncat -...) — the bare English word 'Netcat'/'Ncat' in pentest prose no longer fires"
 
     # -- Layer 4: Download-and-execute (pipe to shell) --
     - field: tool_response
       operator: regex
-      value: "(?i)(curl|wget|fetch|lwp-download|aria2c|invoke-webrequest|iwr|Invoke-RestMethod|irm)\\s+[^|]{0,200}(https?://\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}|http://|\\$\\w|@)[^|]{0,120}\\|\\s*(bash|sh|zsh|python[23]?|perl|ruby|node|powershell|pwsh|cmd|source)"
-      description: "Download-and-execute pipe to shell, narrowed to malicious-leaning sources (raw IP, plain http://, shell-var, or userinfo@ URL). Benign https://official-domain installer pipes no longer auto-block (dual-use install idiom)"
+      value: "(?i)(curl|wget|fetch|lwp-download|aria2c|invoke-webrequest|iwr|Invoke-RestMethod|irm)\\s+[^|]{0,200}(https?://\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}|http://(?!localhost|127\\.|0\\.0\\.0\\.0|\\[::1\\])|@)[^|]{0,120}\\|\\s*(bash|sh|zsh|python[23]?|perl|ruby|node|powershell|pwsh|cmd|source)"
+      description: "Download-and-execute pipe to shell, narrowed to malicious-leaning sources (raw IP, plain external http://, or userinfo@ URL). Benign https://official-domain installer pipes, http://localhost health-check/deploy pipes, and shell-variable-authenticated API calls piped to a parser no longer auto-block (dual-use idioms)"
 
     # -- Layer 5: Command substitution with dangerous commands --
     # NOTE (v2): the legacy backtick form `...` was removed — it is indistinguishable
@@ -170,38 +170,38 @@ detection:
     # -- Layer 10: PowerShell attack patterns --
     - field: tool_response
       operator: regex
-      value: "(?i)(\\bIEX\\s*\\(|\\bInvoke-Expression|\\bInvoke-Command|\\bInvoke-WmiMethod|\\b-EncodedCommand\\b|\\bNew-Object\\s+Net\\.WebClient|\\bDownloadString\\s*\\(|\\bDownloadFile\\s*\\(|\\bStart-Process\\b.{0,60}\\b-Verb\\s+RunAs|\\bSet-MpPreference\\s+-Disable|\\bAdd-MpPreference\\s+-ExclusionPath|\\bNet\\.Sockets\\.TCPClient)"
+      value: "(?i)(\\bIEX\\s*\\(|\\bInvoke-Expression|\\bInvoke-Command|\\bInvoke-WmiMethod|\\b-EncodedCommand\\b|\\bNew-Object\\s+Net\\.WebClient|\\bDownloadString\\s*\\(\\s*['\\\"]?https?://|\\bDownloadFile\\s*\\(\\s*['\\\"]?https?://|\\bStart-Process\\b.{0,60}\\b-Verb\\s+RunAs|\\bSet-MpPreference\\s+-Disable|\\bAdd-MpPreference\\s+-ExclusionPath|\\bNet\\.Sockets\\.TCPClient)"
       description: "PowerShell-specific attack patterns (IEX, download cradles, AV bypass)"
 
     # -- Layer 11: Python reverse shells and code execution --
     - field: tool_response
       operator: regex
-      value: "(?i)(python[23]?\\s+-c\\s+['\"]import\\s+(socket|subprocess|os|pty)|import\\s+socket\\s*;\\s*import\\s+subprocess|socket\\.socket\\(socket\\.AF_INET|os\\.(popen|system|exec[lv]p?)\\s*\\(|subprocess\\.(call|run|Popen|check_output)\\s*\\(.{0,60}(sh|bash|cmd|powershell)|pty\\.spawn\\s*\\()"
-      description: "Python reverse shells and dangerous code execution patterns"
+      value: "(?i)(python[23]?\\s+-c\\s+['\"]import\\s+(socket|subprocess|os|pty)|import\\s+socket\\s*;\\s*import\\s+subprocess|socket\\.socket\\(socket\\.AF_INET|os\\.(popen|system|exec[lv]p?)\\s*\\(\\s*[^)]{0,140}(\\||;|\\$\\(|&&|\\bcurl\\b|\\bwget\\b|/dev/tcp|bash\\s+-i|/bin/(ba)?sh\\b)|subprocess\\.(call|run|Popen|check_output)\\s*\\(.{0,60}['\"/](sh|bash|zsh|cmd(\\.exe)?|powershell)\\b|pty\\.spawn\\s*\\()"
+      description: "Python reverse shells and dangerous code execution. os.system/os.popen/os.exec narrowed to arguments carrying a shell-injection indicator (pipe, semicolon, command substitution, curl/wget, /dev/tcp, bash -i, /bin/sh) — bare os.system('clear')/os.popen('git ...') and semgrep pattern-references no longer fire. subprocess shell match requires a quoted or path-prefixed shell literal (\"bash\", '/bin/sh', \"cmd.exe\") — the bare metavariable/variable names $CMD and cmd, 'shell=False', and '/tmp/screenshot' no longer match"
 
     # -- Layer 12: Node.js reverse shells --
     - field: tool_response
       operator: regex
-      value: "(?i)(require\\s*\\(\\s*['\"]child_process['\"]\\s*\\)|child_process\\.exec(Sync)?\\s*\\(|require\\s*\\(\\s*['\"]net['\"]\\s*\\).{0,100}connect|new\\s+net\\.Socket\\s*\\(|process\\.mainModule\\.require)"
-      description: "Node.js reverse shells and child_process command execution"
+      value: "(?i)(require\\s*\\(\\s*['\"]child_process['\"]\\s*\\)\\s*\\.\\s*(exec|execSync|spawn|spawnSync)|child_process\\.exec(Sync)?\\s*\\(\\s*[^)]{0,140}(\\||;|\\$\\(|`|&&|\\bcurl\\b|\\bwget\\b|/dev/tcp|/bin/(ba)?sh\\b|\\bnc\\s+-)|require\\s*\\(\\s*['\"]net['\"]\\s*\\).{0,100}connect|new\\s+net\\.Socket\\s*\\(|process\\.mainModule\\.require)"
+      description: "Node.js reverse shells and child_process command execution. require('child_process') narrowed to an immediately-chained .exec/.spawn (a bare import for benign tooling no longer fires); child_process.exec(...) narrowed to a shell-injection indicator in the argument (pipe, semicolon, command-substitution/backtick, curl/wget, /dev/tcp, /bin/sh, nc) — benign fixed-command execs like exec('tsserver')/execSync('npm test') no longer fire"
 
     # -- Layer 13: Prompt injection within tool response --
     - field: tool_response
       operator: regex
-      value: "(?i)(ignore\\s+(all\\s+)?(previous|prior|your)\\s+(instructions?|rules?|guidelines?|prompts?)|you\\s+are\\s+now\\s+(a|an|the)|new\\s+system\\s+(prompt|instructions?)\\s*:|disregard\\s+(all\\s+)?(previous|prior|your)|override\\s+(all\\s+)?(previous|prior|your|the)\\s+(instructions?|rules?|safety)|from\\s+now\\s+on,?\\s+you\\s+(are|will|must|should))"
+      value: "(?i)(ignore\\s+(all\\s+)?(previous|prior|your)\\s+(instructions?|rules?|guidelines?|prompts?)|you\\s+are\\s+now\\s+(a|an|the)\\s+(admin|root|developer|dan\\b|unrestricted|unfiltered|jailbroken|different|new\\s+(ai|assistant|persona|model|bot)|evil|malicious|rogue|hacker|god)|new\\s+system\\s+(prompt|instructions?)\\s*:|disregard\\s+(all\\s+)?(previous|prior|your)|override\\s+(all\\s+)?(previous|prior|your|the)\\s+(instructions?|rules?|safety)|from\\s+now\\s+on,?\\s+you\\s+(are|will|must|should))"
       description: "Prompt injection payloads embedded in tool response content"
 
     # -- Layer 14: Data exfiltration via tool response --
     - field: tool_response
       operator: regex
-      value: "(?i)(curl|wget)\\s+[^|\\n]{0,140}\\$\\(\\s*(cat|env|printenv|security\\s+find-generic|aws\\s+configure\\s+get)\\b"
-      description: "Data exfiltration: a download tool reading secrets via command substitution ($(cat ~/.aws/...), $(env), $(printenv)) into an outbound request. Prose branches (send-to-webhook, bare 'exfiltrate') dropped — they matched benign phrasing like 'send results to the server'"
+      value: "(?i)(curl|wget)\\s+[^|\\n]{0,140}\\$\\(\\s*(cat\\s+[^)]{0,80}(\\.ssh|\\.aws|id_rsa|id_ed25519|\\.pem|/etc/passwd|/etc/shadow|credentials|\\.env)|(env|printenv|security\\s+find-generic|aws\\s+configure\\s+get)\\b)"
+      description: "Data exfiltration: a download tool reading secrets via command substitution ($(cat ~/.aws/credentials|~/.ssh/id_rsa|.env|/etc/shadow), $(env), $(printenv)) into an outbound request. cat narrowed to well-known secret paths — reading a service's own API token file for that service's Authorization header (e.g. curl -H 'Bearer $(cat ~/.cache/.../token)') no longer fires. Prose branches (send-to-webhook, bare 'exfiltrate') already dropped"
 
     # -- Layer 15: Cron/scheduled task persistence --
     - field: tool_response
       operator: regex
-      value: "(?i)(echo\\s+.{0,100}>>\\s*/etc/cron|\\bcrontab\\s+.{0,60}(curl|wget|/tmp/|/dev/|bash\\s+-i|http)|\\bat\\s+-f\\b|\\bschtasks\\s+/create\\b|\\bRegister-ScheduledTask\\b|\\blaunchctl\\s+load)"
-      description: "Persistence: writing to /etc/cron, crontab loading a remote/tmp payload, schtasks/ScheduledTask creation, launchctl load. Benign systemctl enable and bare crontab -e/-l dropped (normal service management)"
+      value: "(?i)(echo\\s+.{0,100}>>\\s*/etc/cron|\\bcrontab\\s+.{0,60}(curl|wget|/tmp/|bash\\s+-i|http)|\\bat\\s+-f\\b|\\bschtasks\\s+/create\\b|\\bRegister-ScheduledTask\\b|\\blaunchctl\\s+load)"
+      description: "Persistence: writing to /etc/cron, crontab loading a remote/tmp payload, schtasks/ScheduledTask creation, launchctl load. Benign systemctl enable and bare crontab -e/-l dropped (normal service management). Dropped /dev/ from the crontab branch — it matched the standard '(crontab -l 2>/dev/null; echo job) | crontab -' add-a-job idiom on the 2>/dev/null redirect"
 
   condition: any
   false_positives:


### PR DESCRIPTION
Reduces false-positives on the four maturity:stable rules that auto-block in the enforce lane and were firing on benign SKILL.md manifests.

Measured on a 4,886-sample benign corpus (skills.sh, arxiv, npm/pypi, agent-ops, benign code):

  00001 direct-prompt-injection    80 to 16 FP
  00010 mcp-malicious-response      40 to 16 FP
  00030 cross-agent-attack          15 to 1 FP
  00002 indirect-prompt-injection   14 to 4 FP
  total                             149 to 37 FP

Method: each rule was tightened to require directed/structural attack signals instead of attack vocabulary alone (e.g. an override directed at the AI, or a real payload), never by deleting whole conditions.

Safety:
  - All 33 true-positive test cases across the four rules still match (per-rule verified).
  - Zero recall regression: every realistic attack the tightened rules miss was independently confirmed to also be missed by the pre-tightening rules, so the tightening opened no new hole.
  - The 37 remaining FPs are legitimate flags: security-tooling skills that quote canonical attack strings or ship real dangerous-command examples. A regex cannot separate those from live directives, and cutting them would drop true-positives.
  - Full test suite green (645 tests).

Note: the larger FP-dirty set flagged when PR #313 was closed was all maturity:test (not in the enforce lane); this PR targets only the stable rules that actually auto-block users.