### PR TITLE
chore(maturity): demote 33 enforce-lane rules that FP on the benign corpus

### DIFF
--- a/rules/context-exfiltration/ATR-2026-00020-system-prompt-leak.yaml
+++ b/rules/context-exfiltration/ATR-2026-00020-system-prompt-leak.yaml
@@ -15,7 +15,7 @@ author: "ATR Community"
 date: "2026/03/08"
 schema_version: "0.1"
 detection_tier: pattern
-maturity: "stable"
+maturity: "test"
 severity: high
 
 references:

--- a/rules/context-exfiltration/ATR-2026-00021-api-key-exposure.yaml
+++ b/rules/context-exfiltration/ATR-2026-00021-api-key-exposure.yaml
@@ -14,7 +14,7 @@ author: "ATR Community"
 date: "2026/03/08"
 schema_version: "0.1"
 detection_tier: pattern
-maturity: "stable"
+maturity: "test"
 severity: critical
 
 references:

--- a/rules/context-exfiltration/ATR-2026-00201-credential-pipe-exfiltration.yaml
+++ b/rules/context-exfiltration/ATR-2026-00201-credential-pipe-exfiltration.yaml
@@ -11,7 +11,7 @@ author: "TYSYS (Wind) — skill-sanitizer project"
 date: "2026/04/05"
 schema_version: "0.1"
 detection_tier: pattern
-maturity: stable
+maturity: test
 severity: critical
 
 references:

--- a/rules/context-exfiltration/ATR-2026-00514-system-prompt-extraction.yaml
+++ b/rules/context-exfiltration/ATR-2026-00514-system-prompt-extraction.yaml
@@ -15,7 +15,7 @@ author: "ATR Community"
 date: "2026/05/12"
 schema_version: "0.1"
 detection_tier: pattern
-maturity: "stable"
+maturity: "test"
 severity: high
 
 references:

--- a/rules/context-exfiltration/ATR-2026-00516-output-xss-via-llm.yaml
+++ b/rules/context-exfiltration/ATR-2026-00516-output-xss-via-llm.yaml
@@ -16,7 +16,7 @@ author: "ATR Community"
 date: "2026/05/12"
 schema_version: "0.1"
 detection_tier: pattern
-maturity: "stable"
+maturity: "test"
 severity: high
 
 references:

--- a/rules/context-exfiltration/ATR-2026-01451-img-onerror-xss-injection.yaml
+++ b/rules/context-exfiltration/ATR-2026-01451-img-onerror-xss-injection.yaml
@@ -16,7 +16,7 @@ author: "ATR Community"
 date: "2026/06/12"
 schema_version: "0.1"
 detection_tier: pattern
-maturity: stable
+maturity: test
 severity: high
 
 references:

--- a/rules/context-exfiltration/ATR-2026-01456-debug-cli-mode-sysprompt-extraction.yaml
+++ b/rules/context-exfiltration/ATR-2026-01456-debug-cli-mode-sysprompt-extraction.yaml
@@ -21,7 +21,7 @@ author: "ATR Community"
 date: "2026/06/12"
 schema_version: "0.1"
 detection_tier: pattern
-maturity: stable
+maturity: test
 severity: high
 
 references:

--- a/rules/context-exfiltration/ATR-2026-01605-ssrf-aws-metadata-endpoint.yaml
+++ b/rules/context-exfiltration/ATR-2026-01605-ssrf-aws-metadata-endpoint.yaml
@@ -14,7 +14,7 @@ author: ATR Community
 date: 2026/06/12
 schema_version: "0.1"
 detection_tier: pattern
-maturity: stable
+maturity: test
 severity: critical
 references:
   owasp_llm:

--- a/rules/context-exfiltration/ATR-2026-01607-ssrf-localhost-service-probe.yaml
+++ b/rules/context-exfiltration/ATR-2026-01607-ssrf-localhost-service-probe.yaml
@@ -14,7 +14,7 @@ author: ATR Community
 date: 2026/06/12
 schema_version: "0.1"
 detection_tier: pattern
-maturity: stable
+maturity: test
 severity: critical
 references:
   owasp_llm:

--- a/rules/context-exfiltration/ATR-2026-01608-ssrf-file-scheme-local-read.yaml
+++ b/rules/context-exfiltration/ATR-2026-01608-ssrf-file-scheme-local-read.yaml
@@ -14,7 +14,7 @@ author: ATR Community
 date: 2026/06/12
 schema_version: "0.1"
 detection_tier: pattern
-maturity: stable
+maturity: test
 severity: critical
 references:
   owasp_llm:

--- a/rules/excessive-autonomy/ATR-2026-00713-ipi-rce-network-shell-command.yaml
+++ b/rules/excessive-autonomy/ATR-2026-00713-ipi-rce-network-shell-command.yaml
@@ -14,7 +14,7 @@ author: "ATR Community"
 date: "2026/06/12"
 schema_version: "0.1"
 detection_tier: pattern
-maturity: stable
+maturity: test
 severity: critical
 
 references:

--- a/rules/privilege-escalation/ATR-2026-00204-stealth-execution-persistence.yaml
+++ b/rules/privilege-escalation/ATR-2026-00204-stealth-execution-persistence.yaml
@@ -11,7 +11,7 @@ author: "TYSYS (Wind) — skill-sanitizer project"
 date: "2026/04/05"
 schema_version: "0.1"
 detection_tier: pattern
-maturity: stable
+maturity: test
 severity: high
 
 references:

--- a/rules/privilege-escalation/ATR-2026-00441-semantic-kernel-sessions-python-plugin-startup-persistence.yaml
+++ b/rules/privilege-escalation/ATR-2026-00441-semantic-kernel-sessions-python-plugin-startup-persistence.yaml
@@ -22,7 +22,7 @@ author: "ATR Community"
 date: "2026/05/11"
 schema_version: "0.1"
 detection_tier: pattern
-maturity: stable
+maturity: test
 severity: critical
 
 references:

--- a/rules/privilege-escalation/ATR-2026-01600-sql-injection-tautology-rbac-bypass.yaml
+++ b/rules/privilege-escalation/ATR-2026-01600-sql-injection-tautology-rbac-bypass.yaml
@@ -14,7 +14,7 @@ author: ATR Community
 date: 2026/06/12
 schema_version: "0.1"
 detection_tier: pattern
-maturity: stable
+maturity: test
 severity: critical
 references:
   owasp_llm:

--- a/rules/privilege-escalation/ATR-2026-01603-sql-injection-stacked-dml-abuse.yaml
+++ b/rules/privilege-escalation/ATR-2026-01603-sql-injection-stacked-dml-abuse.yaml
@@ -14,7 +14,7 @@ author: ATR Community
 date: 2026/06/12
 schema_version: "0.1"
 detection_tier: pattern
-maturity: stable
+maturity: test
 severity: critical
 references:
   owasp_llm:

--- a/rules/privilege-escalation/ATR-2026-01604-sql-injection-schema-enumeration.yaml
+++ b/rules/privilege-escalation/ATR-2026-01604-sql-injection-schema-enumeration.yaml
@@ -13,7 +13,7 @@ author: ATR Community
 date: 2026/06/12
 schema_version: "0.1"
 detection_tier: pattern
-maturity: stable
+maturity: test
 severity: high
 references:
   owasp_llm:

--- a/rules/privilege-escalation/ATR-2026-01609-shell-injection-exfil-webhook.yaml
+++ b/rules/privilege-escalation/ATR-2026-01609-shell-injection-exfil-webhook.yaml
@@ -14,7 +14,7 @@ author: ATR Community
 date: 2026/06/12
 schema_version: "0.1"
 detection_tier: pattern
-maturity: stable
+maturity: test
 severity: critical
 references:
   owasp_llm:

--- a/rules/privilege-escalation/ATR-2026-01611-shell-evasion-eval-exec-injection.yaml
+++ b/rules/privilege-escalation/ATR-2026-01611-shell-evasion-eval-exec-injection.yaml
@@ -14,7 +14,7 @@ author: ATR Community
 date: 2026/06/12
 schema_version: "0.1"
 detection_tier: pattern
-maturity: stable
+maturity: test
 severity: high
 references:
   owasp_llm:

--- a/rules/privilege-escalation/ATR-2026-01612-debug-mode-privilege-escalation.yaml
+++ b/rules/privilege-escalation/ATR-2026-01612-debug-mode-privilege-escalation.yaml
@@ -14,7 +14,7 @@ author: ATR Community
 date: 2026/06/12
 schema_version: "0.1"
 detection_tier: pattern
-maturity: stable
+maturity: test
 severity: high
 references:
   owasp_llm:

--- a/rules/privilege-escalation/ATR-2026-01615-sandbox-escape-command-injection.yaml
+++ b/rules/privilege-escalation/ATR-2026-01615-sandbox-escape-command-injection.yaml
@@ -14,7 +14,7 @@ author: ATR Community
 date: 2026/06/12
 schema_version: "0.1"
 detection_tier: pattern
-maturity: stable
+maturity: test
 severity: critical
 references:
   owasp_llm:

--- a/rules/privilege-escalation/ATR-2026-01616-path-traversal-agent-file-access.yaml
+++ b/rules/privilege-escalation/ATR-2026-01616-path-traversal-agent-file-access.yaml
@@ -14,7 +14,7 @@ author: ATR Community
 date: 2026/06/12
 schema_version: "0.1"
 detection_tier: pattern
-maturity: stable
+maturity: test
 severity: high
 references:
   owasp_llm:

--- a/rules/prompt-injection/ATR-2026-00001-direct-prompt-injection.yaml
+++ b/rules/prompt-injection/ATR-2026-00001-direct-prompt-injection.yaml
@@ -15,7 +15,7 @@ date: "2026/03/08"
 schema_version: "0.1"
 detection_tier: pattern
 confirm: embedding
-maturity: "stable"
+maturity: "test"
 severity: high
 
 references:

--- a/rules/prompt-injection/ATR-2026-00002-indirect-prompt-injection.yaml
+++ b/rules/prompt-injection/ATR-2026-00002-indirect-prompt-injection.yaml
@@ -16,7 +16,7 @@ date: "2026/03/08"
 schema_version: "0.1"
 detection_tier: pattern
 confirm: embedding
-maturity: "stable"
+maturity: "test"
 severity: high
 
 references:

--- a/rules/prompt-injection/ATR-2026-00442-quoted-exact-output-forcing.yaml
+++ b/rules/prompt-injection/ATR-2026-00442-quoted-exact-output-forcing.yaml
@@ -16,7 +16,7 @@ date: "2026/05/11"
 schema_version: "0.1"
 detection_tier: pattern
 confirm: embedding
-maturity: stable
+maturity: test
 severity: medium
 
 references:

--- a/rules/prompt-injection/ATR-2026-00445-translation-hijack-with-side-output.yaml
+++ b/rules/prompt-injection/ATR-2026-00445-translation-hijack-with-side-output.yaml
@@ -14,7 +14,7 @@ author: "ATR Community"
 date: "2026/05/11"
 schema_version: "0.1"
 detection_tier: pattern
-maturity: stable
+maturity: test
 severity: medium
 
 references:

--- a/rules/prompt-injection/ATR-2026-00447-fictional-generation-containing-target.yaml
+++ b/rules/prompt-injection/ATR-2026-00447-fictional-generation-containing-target.yaml
@@ -16,7 +16,7 @@ author: "ATR Community"
 date: "2026/05/11"
 schema_version: "0.1"
 detection_tier: pattern
-maturity: stable
+maturity: test
 severity: medium
 
 references:

--- a/rules/prompt-injection/ATR-2026-00454-backslash-per-character-encoding.yaml
+++ b/rules/prompt-injection/ATR-2026-00454-backslash-per-character-encoding.yaml
@@ -21,7 +21,7 @@ author: "ATR Community"
 date: "2026/05/12"
 schema_version: "0.1"
 detection_tier: pattern
-maturity: "stable"
+maturity: "test"
 severity: medium
 
 references:

--- a/rules/prompt-injection/ATR-2026-00510-delayed-tool-invocation-injection.yaml
+++ b/rules/prompt-injection/ATR-2026-00510-delayed-tool-invocation-injection.yaml
@@ -15,7 +15,7 @@ author: "ATR Community"
 date: "2026/05/12"
 schema_version: "0.1"
 detection_tier: pattern
-maturity: "stable"
+maturity: "test"
 severity: critical
 
 references:

--- a/rules/prompt-injection/ATR-2026-00515-hidden-text-prompt-injection.yaml
+++ b/rules/prompt-injection/ATR-2026-00515-hidden-text-prompt-injection.yaml
@@ -17,7 +17,7 @@ author: "ATR Community"
 date: "2026/05/12"
 schema_version: "0.1"
 detection_tier: pattern
-maturity: "stable"
+maturity: "test"
 severity: high
 
 references:

--- a/rules/prompt-injection/ATR-2026-00701-ipi-tool-output-xss-injection.yaml
+++ b/rules/prompt-injection/ATR-2026-00701-ipi-tool-output-xss-injection.yaml
@@ -15,7 +15,7 @@ author: "ATR Community"
 date: "2026/06/12"
 schema_version: "0.1"
 detection_tier: pattern
-maturity: stable
+maturity: test
 severity: high
 
 references:

--- a/rules/prompt-injection/ATR-2026-01018-evasion-shell-injection-eval.yaml
+++ b/rules/prompt-injection/ATR-2026-01018-evasion-shell-injection-eval.yaml
@@ -16,7 +16,7 @@ author: "ATR Community"
 date: "2026/06/12"
 schema_version: "0.1"
 detection_tier: semantic
-maturity: stable
+maturity: test
 severity: critical
 
 references:

--- a/rules/tool-poisoning/ATR-2026-00010-mcp-malicious-response.yaml
+++ b/rules/tool-poisoning/ATR-2026-00010-mcp-malicious-response.yaml
@@ -16,7 +16,7 @@ author: "ATR Community"
 date: "2026/03/08"
 schema_version: "0.1"
 detection_tier: pattern
-maturity: "stable"
+maturity: "test"
 severity: critical
 
 references:

--- a/rules/tool-poisoning/ATR-2026-01300-mcp-notes-param-chat-history-exfil.yaml
+++ b/rules/tool-poisoning/ATR-2026-01300-mcp-notes-param-chat-history-exfil.yaml
@@ -18,7 +18,7 @@ author: "ATR Community"
 date: "2026/06/12"
 schema_version: "0.1"
 detection_tier: pattern
-maturity: stable
+maturity: test
 severity: critical
 
 references:


### PR DESCRIPTION
First application of the FP feedback loop (mechanism in #328). Auto-generated by demote-fp-rules.ts.

33 of 145 maturity:stable (enforce / auto-block lane) rules match benign samples in the 5,475-sample corpus — i.e. they auto-block on legitimate content. This is the structural source of 'FP too high' and of legitimate security tooling being wrongly blocked (the maintainer's own hook). Worst offenders: 00020 (215 FP), 00021 (205), 00001 (21), 00010 (19); they fire on legitimate pentest / privilege-escalation / XSS-testing / dev skills.

Demoted stable -> test: they drop OUT of the enforce lane but keep alerting in the alert/hunt lane — coverage does not regress, only the power to auto-block is revoked until each is tightened to 0-FP and re-promoted via promote-to-stable.ts.

Draft for review — this is 33 maturity changes; look them over before merging. After this, the enforce lane is 0-FP on the current corpus, and the weekly demote-fp-rules.yml (in #328) keeps it that way as the corpus grows.