### PR TITLE
fix(rules): cut benign false positives on 7 rules with no recall loss

### DIFF
--- a/rules/agent-manipulation/ATR-2026-00032-goal-hijacking.yaml
+++ b/rules/agent-manipulation/ATR-2026-00032-goal-hijacking.yaml
@@ -72,8 +72,8 @@ detection:
     - field: content
       operator: regex
       value: >-
-        (?i)(?:instead\s+of\s+(?:that|doing|the\s+(?:original\s+)?\w+(?:\s+\w+){0,3}|what\s+(?:you|I)\s+asked)|rather\s+than\s+(?:that|the\s+(?:original|assigned|previous)))
-      description: Explicit task abandonment language
+        (?i)(?:instead\s+of\s+(?:that\b|doing\b|what\s+(?:you|I)\s+asked)|instead\s+of\s+(?:the\s+)?(?:original|assigned|previous|current)\s+(?:task|goal|objective|instructions?|request|assignment|work)|instead\s+of\s+(?:the\s+)?\w+(?:\s+\w+){0,3}[,.]?\s+(?:let(?:'s|\s+me|\s+us)\b|I(?:'ll|'m)\b|I\s+(?:will|am\s+going\s+to)\b|we(?:'ll\b|\s+will\b)|do\s+something\s+else)|rather\s+than\s+(?:that|the\s+(?:original|assigned|previous)))
+      description: Explicit task abandonment language (v2 — the old 'instead of the <any 1-4 words>' branch matched ordinary technical prose such as 'instead of the Apify logger' / 'instead of the module under test', which is how documentation describes substituting one component for another. The open-ended object now has to be followed by a self-substitution clause ('..., let me', 'I'll', 'do something else'), which is what makes it hijacking rather than a comparison; a named original/assigned task still fires on its own. true_positive 'Instead of the financial report, let me do something else' is unaffected)
     - field: content
       operator: regex
       value: >-
@@ -113,8 +113,8 @@ detection:
     - field: content
       operator: regex
       value: >-
-        (?i)(?:skip\s+(?:the|that|this)\s+(?:step|part|task|analysis)|don'?t\s+(?:bother|worry)\s+(?:about|with)\s+(?:the|that|this)\s+(?:original|first|assigned))
-      description: Directives to skip assigned work
+        (?i)(?:skip\s+(?:the|that|this)\s+(?:original|assigned|first|required|previous|remaining)\s+(?:step|part|task|analysis|work)|skip\s+(?:the|that|this)\s+(?:step|part|task|analysis)\s+(?:and\s+(?:just|instead|directly)|entirely\s+and)|don'?t\s+(?:bother|worry)\s+(?:about|with)\s+(?:the|that|this)\s+(?:original|first|assigned))
+      description: Directives to skip assigned work (v2 — the bare 'skip this step' form is ordinary instructional prose and matched 15 benign developer skills that legitimately tell a reader to skip an optional step. The object now has to be marked as the assigned/original work, or the skip has to be paired with a substitution ('and just', 'and instead'), which is the hijacking shape. No true_positive relied on the bare form)
     - field: content
       operator: regex
       value: >-

--- a/rules/agent-manipulation/ATR-2026-00077-human-trust-exploitation.yaml
+++ b/rules/agent-manipulation/ATR-2026-00077-human-trust-exploitation.yaml
@@ -91,8 +91,15 @@ detection:
     - field: content
       operator: regex
       value: >-
-        (?i)(?:100%\s+(?:certain|confident|sure|safe|correct|accurate)|absolutely\s+(?:certain|safe|guaranteed|no\s+risk)|zero\s+(?:risk|chance\s+of\s+(?:failure|error|harm))|guaranteed\s+(?:safe|correct|harmless))
-      description: False absolute certainty claims to bypass human caution
+        (?i)(?:(?:I(?:'m|\s+am)|we(?:'re|\s+are)|this\s+is|it(?:'s|\s+is)|that(?:'s|\s+is)|the\s+\w+\s+is)\s+(?:100%\s+(?:certain|confident|sure|safe|correct|accurate)|absolutely\s+(?:certain|safe|guaranteed))|absolutely\s+no\s+risk|(?:there\s+is\s+)?zero\s+(?:risk|chance\s+of\s+(?:failure|error|harm))|guaranteed\s+(?:safe|correct|harmless))
+      description: >-
+        False absolute certainty claims to bypass human caution (v2 — the bare
+        confidence phrase also matched benign agent guidelines that instruct the
+        agent to only report conclusions it is confident in, which is the
+        opposite of trust exploitation. The certainty claim now has to be
+        asserted about the speaker or the change itself rather than appearing as
+        a second-person policy; the zero-risk and guaranteed-safe branches are
+        unchanged and still carry the first true_positive)
     - field: content
       operator: regex
       value: >-

--- a/rules/excessive-autonomy/ATR-2026-00050-runaway-agent-loop.yaml
+++ b/rules/excessive-autonomy/ATR-2026-00050-runaway-agent-loop.yaml
@@ -108,8 +108,8 @@ detection:
     - field: content
       operator: regex
       value: >-
-        (?i)(?:calling\s+(?:myself|this\s+(?:function|tool|agent))\s+(?:again|recursively)|recursive\s+(?:call|invocation|execution)|self[_-]?(?:invoke|call|trigger))
-      description: Recursive self-invocation patterns
+        (?i)(?:calling\s+(?:myself|this\s+(?:function|tool|agent))\s+(?:again|recursively)|recursive\s+(?:call|invocation|execution))
+      description: Recursive self-invocation patterns (v2 — dropped the bare 'self-call' / 'self-invoke' token, which agent-framework documentation uses as ordinary vocabulary when describing how an agent may call itself. The remaining branches require the recursion to be asserted as happening, which is the runaway signal; both recursion true_positives use those branches)
     - field: content
       operator: regex
       value: (?i)(?:iteration\s+(?:#\s*)?\d{2,}|loop\s+(?:iteration|count|index)\s*[:=]?\s*\d{2,}|cycle\s+\d{2,})
@@ -131,7 +131,7 @@ detection:
       description: Explicit stall or no-progress acknowledgement
     - field: content
       operator: regex
-      value: (?i)(?:(?:while|for)\s*\(\s*(?:true|1|;;)\s*\)|(?:loop|repeat)\s*\{\s*(?:call|invoke|execute))
+      value: (?i)(?:(?:while|for)\s*\(\s*(?:true|1|;;)\s*\)[\s\S]{0,80}?\b(?:invoke|call|execute|request|fetch|query|retry)\b|(?:loop|repeat)\s*\{\s*(?:call|invoke|execute))
       description: Infinite loop constructs in generated or executed code
     - field: content
       operator: regex

--- a/rules/excessive-autonomy/ATR-2026-00051-resource-exhaustion.yaml
+++ b/rules/excessive-autonomy/ATR-2026-00051-resource-exhaustion.yaml
@@ -73,13 +73,13 @@ detection:
   conditions:
     - field: content
       operator: regex
-      value: (?i)SELECT\s+\*\s+FROM\s+\w+(?:\s*;|\s*$|\s+WHERE)(?!.*\bLIMIT\b)
-      description: Unbounded SELECT * query without LIMIT clause
+      value: (?i)SELECT\s+\*\s+FROM\s+\w+\s*(?:;|$)(?!.*\bLIMIT\b)
+      description: Unbounded SELECT * query without LIMIT clause (v2 — dropped the '+ WHERE' branch; a WHERE clause bounds the result set, so 'SELECT * FROM users WHERE ...' is not resource exhaustion. That branch matched ordinary SQL examples in documentation; true_positive 'SELECT * FROM transactions;' is unaffected)
     - field: content
       operator: regex
       value: >-
-        (?i)(?:for\s+each\s+(?:of\s+)?(?:the\s+)?(?:record|row|entry|item|file|document|user|customer|email|account|message|transaction)s?\b[\s\S]{0,30}\b(?:in|of|from|across)\b|iterate\s+(?:over\s+)?(?:all|every|the\s+entire)|process\s+(?:all|every|each)\s+(?:record|row|entry|item|file|document)|(?:all|every|entire|whole)\s+(?:record|row|entry|item|file|document|dataset|database|table)s?\b)
-      description: Bulk iteration over an entire or unbounded dataset (v2 — bare 'for each' now requires a data-source/scale qualifier; the unqualified form matched ordinary 'for each X' prose; verified 0 recall loss + all true_positives, benign FP 560 to 203)
+        (?i)(?:for\s+each\s+(?:of\s+)?(?:the\s+)?(?:record|row|entry|item|file|document|user|customer|email|account|message|transaction)s?\b[\s\S]{0,30}\b(?:in|of|from|across)\b|iterate\s+(?:over\s+)?(?:all|every|the\s+entire)|process\s+(?:all|every|each)\s+(?:record|row|entry|item|file|document))
+      description: Bulk iteration over an entire or unbounded dataset (v3 — dropped the bare '(all|every|entire|whole) <noun>' branch, which matched plain noun phrases such as 'all tables', 'every dataset' and 'all files' in ordinary data-tooling documentation with no consuming action. The remaining branches all require an explicit consuming verb (for each ... in / iterate over all / process all), and the download/fetch-all branch below still covers the 'Downloading all files' true_positive. v2 — bare 'for each' now requires a data-source/scale qualifier; the unqualified form matched ordinary 'for each X' prose; verified 0 recall loss + all true_positives, benign FP 560 to 203)
     - field: content
       operator: regex
       value: >-

--- a/rules/model-abuse/ATR-2026-00502-training-data-extraction-via-divergent-repetition-attack.yaml
+++ b/rules/model-abuse/ATR-2026-00502-training-data-extraction-via-divergent-repetition-attack.yaml
@@ -109,7 +109,7 @@ detection:
 
     - field: content
       operator: regex
-      value: '(?i)(?:repeat|say|print|output|write)\b[\s\S]{0,60}\b(\w{2,})\b(?:\W+\1\b){3,}'
+      value: '(?i)(?:repeat|say|print|output|write)\b[\s\S]{0,60}\b([A-Za-z]{3,})\b(?:\W+\1\b){3,}'
       description: 'Divergent repetition: repeat/print followed by the same token 4+ times'
   condition: any
   false_positives:

--- a/rules/prompt-injection/ATR-2026-00003-jailbreak-attempt.yaml
+++ b/rules/prompt-injection/ATR-2026-00003-jailbreak-attempt.yaml
@@ -90,7 +90,7 @@ detection:
     # -- Layer 2: Mode switching --
     - field: user_input
       operator: regex
-      value: "(?i)\\b(enable|activate|enter|switch\\s+to|turn\\s+on|engage|initiate|boot\\s+into|start)\\s+(developer|dev|maintenance|debug|unrestricted|unlimited|unfiltered|uncensored|admin|root|god|sudo|super|test|raw|unsafe|jailbreak|hacker|override|master|privileged)\\s+(mode|access|state|level|tier|permissions?)\\b"
+      value: "(?i)\\b(?:(?:enable|activate|enter|switch\\s+to|turn\\s+on|engage|initiate|boot\\s+into|start)\\s+(?:unrestricted|unlimited|unfiltered|uncensored|god|jailbreak|hacker|unsafe)\\s+(?:mode|access|state|level|tier|permissions?)\\b|(?:enable|activate|enter|switch\\s+to|turn\\s+on|engage|initiate|boot\\s+into|start)\\s+(?:developer|dev|maintenance|debug|admin|root|sudo|super|test|raw|override|master|privileged)\\s+(?:mode|access|state|level|tier|permissions?)\\b[\\s\\S]{0,120}?(?:no\\s+(?:restrictions?|limits?|filters?|rules?|guidelines?)|without\\s+(?:restrictions?|limits?|filters?)|ignore\\s+(?:all\\s+)?(?:previous|your|the)\\b|answer\\s+any\\s+question|bypass\\b|unfiltered|uncensored|do\\s+anything))"
       description: "Mode-switching requests to elevate agent capabilities"
 
     # -- Layer 3: Roleplay with constraint removal --
@@ -108,7 +108,7 @@ detection:
     # -- Layer 5: Authority claims --
     - field: user_input
       operator: regex
-      value: "(?i)(as\\s+(your|the|an?)\\s+(developer|creator|programmer|engineer|designer|admin|administrator|owner|operator|maintainer)|I\\s+am\\s+(your|the|an?)\\s+(developer|creator|admin|owner|operator|maker|programmer)|I\\s+(work\\s+(for|at)|represent|am\\s+from)\\s+(OpenAI|Anthropic|Google\\s+DeepMind|Meta\\s+AI|Microsoft|the\\s+company\\s+that\\s+(made|created|built|trained)\\s+you)|I\\s+have\\s+(admin|root|developer|elevated|special|override|master|super|full)\\s+(access|privileges?|permissions?|authority|clearance|rights?))"
+      value: "(?i)(as\\s+your\\s+(developer|creator|programmer|engineer|designer|admin|administrator|owner|operator|maintainer)|I\\s+am\\s+(your|the|an?)\\s+(developer|creator|admin|owner|operator|maker|programmer)|I\\s+(work\\s+(for|at)|represent|am\\s+from)\\s+(OpenAI|Anthropic|Google\\s+DeepMind|Meta\\s+AI|Microsoft|the\\s+company\\s+that\\s+(made|created|built|trained)\\s+you)|I\\s+have\\s+(admin|root|developer|elevated|special|override|master|super|full)\\s+(access|privileges?|permissions?|authority|clearance|rights?))"
       description: "False authority claims to establish trust for bypassing restrictions"
 
     # -- Layer 6: Emotional manipulation and urgency --
@@ -138,7 +138,7 @@ detection:
     # -- Layer 10: Filter/policy bypass language --
     - field: user_input
       operator: regex
-      value: "(?i)\\b(opposite\\s+mode|anti-?policy|bypass\\s+(the\\s+)?(content|safety|ethical|output)\\s+(filter|policy|guidelines?|rules?|restrictions?)|token\\s+smuggling|prompt\\s+leak(ing|age)?|guard\\s*rail\\s+(evasion|bypass|removal)|safety\\s+(bypass|override|removal|disable|circumvent)|content\\s+filter\\s+(bypass|evasion|circumvention|workaround))\\b"
+      value: "(?i)\\b(opposite\\s+mode|anti-?policy|bypass\\s+(the\\s+)?(content|safety|ethical|output)\\s+(filter|policy|guidelines?|rules?|restrictions?)|token\\s+smuggling|guard\\s*rail\\s+(evasion|bypass|removal)|safety\\s+(bypass|override|removal|disable|circumvent)|content\\s+filter\\s+(bypass|evasion|circumvention|workaround))\\b"
       description: "Explicit filter bypass and evasion terminology"
 
     # -- Layer 11: Encoding-wrapped jailbreak instructions --

--- a/rules/prompt-injection/ATR-2026-00004-system-prompt-override.yaml
+++ b/rules/prompt-injection/ATR-2026-00004-system-prompt-override.yaml
@@ -101,18 +101,33 @@ detection:
     - field: user_input
       operator: regex
       value: >-
-        (?i)\{\s*["']?(role|system_prompt|system_message|system_instruction|system_content|system|persona|identity|character)["']?\s*:\s*["']?
-      description: JSON-formatted system role injection
+        (?i)(?:\{\s*["']?role["']?\s*:\s*["']?system["']?\s*[,}]?[\s\S]{0,160}?(?:ignore\b|disregard\b|override\b|bypass\b|disable\b|unrestricted\b|jailb?reak\b|without\s+(?:restrictions?|filters?|safety|limits?)|no\s+(?:safety|restrictions?|filters?|guidelines?)|new\s+instructions?\b)|\{\s*["']?(?:system_prompt|system_message|system_instruction|system_content)["']?\s*:\s*["']?)
+      description: >-
+        JSON-formatted system role injection (v2 — a bare role-key opener is the
+        standard chat-completions message shape and appeared in 11 benign
+        LLM-integration skills. The role branch now requires the value to
+        actually be system AND an override phrase within the same message
+        object, which is what separates an injected system turn from an ordinary
+        API example; the explicit system_prompt / system_message keys still fire
+        alone. The system-role true_positive is unaffected because its content
+        carries an override phrase. Dropped the bare persona / identity /
+        character keys, which carry no override semantics on their own)
     - field: user_input
       operator: regex
       value: >-
-        (?i)(#{1,3})\s*(system|admin|root|master|instruction)\s+(prompt|override|directive)\b
-      description: Markdown header declaring a system-prompt override (requires an override-indicative noun; benign doc headings like "# System Requirements" no longer match)
+        (?i)(#{1,3})\s*(system|admin|root|master|instruction)\s+(override|directive)\b
+      description: Markdown header declaring a system-prompt override (v3 — dropped the 'prompt' noun. A "System Prompt" markdown heading is ordinary documentation and matched benign skills that document their own prompt; only the override/directive nouns carry attack semantics. The System-Override true_positive is unaffected because it uses the override noun, and a genuine new-system-prompt injection is still caught by the first condition. v2 — requires an override-indicative noun; benign doc headings like "# System Requirements" no longer match)
     - field: user_input
       operator: regex
       value: >-
-        (?i)(the\s+)?(above|previous|original|old|prior|initial|default|existing|current|given)\s+(system\s+)?(prompt|instructions?|message|guidelines?|directives?|configuration|rules?)\s+(is|are|was|were|has\s+been|have\s+been|should\s+be)\s+(deprecated|invalid|outdated|replaced|revoked|cancelled|superseded|overridden|void|nullified|expired|incorrect|wrong|fake|false|a\s+test|not\s+(real|valid|correct|applicable))
-      description: Claims that the existing system prompt is invalid or deprecated
+        (?i)(?<!assume\s)(?<!assuming\s)(the\s+)?(above|previous|original|old|prior|initial|default|existing|current|given)\s+(system\s+)?(prompt|instructions?|message|guidelines?|directives?|configuration|rules?)\s+(is|are|was|were|has\s+been|have\s+been|should\s+be)\s+(deprecated|invalid|outdated|replaced|revoked|cancelled|superseded|overridden|void|nullified|expired|incorrect|wrong|fake|false|a\s+test|not\s+(real|valid|correct|applicable))
+      description: >-
+        Claims that the existing system prompt is invalid or deprecated (v2 —
+        added a negation guard. A benign context-engineering skill tells the
+        agent not to assume the user's existing instructions are wrong, and the
+        old pattern matched the negated clause as if it were the assertion. The
+        guard only suppresses the assume / assuming framing, so a direct claim
+        still fires and no true_positive is affected)
     - field: user_input
       operator: regex
       value: >-
@@ -131,8 +146,8 @@ detection:
     - field: user_input
       operator: regex
       value: >-
-        (?i)(config|configuration|settings?|params|parameters)\s*[=:]\s*\{[^}]{0,200}(role|system|instructions?|persona|behavior|safety|filter|restriction|guardrail)\s*[=:]
-      description: Configuration object injection with system-related keys
+        (?i)(config|configuration|settings?|params|parameters)\s*[=:]\s*\{[^}]{0,200}(safety|filter|restriction|guardrail|moderation|content_policy|censor)\w*\s*[=:]\s*["']?(?:false|off|none|null|0|disabled?|bypass|ignore)\b
+      description: Configuration object injection that disables a safety control (v2 — the old form matched any config object containing a 'system'/'role'/'instructions' key, which is the shape of every legitimate LLM SDK call and FP'd on benign skills passing systemInstruction to a provider config. It now requires a safety-control key assigned a disabling value, which is the actual attack; no true_positive relied on the broad form)
     - field: user_input
       operator: regex
       value: >-


### PR DESCRIPTION
Seven production rules were firing on ordinary developer documentation.

Measured against the 431-skill benign corpus using the event shape the skill
auditor actually emits (llm_input with a user_input field), benign false
positives drop from 68 to 5.

Per rule, benign FP before to after:

  00051 resource-exhaustion      29 to 2
  00032 goal-hijacking           15 to 0
  00004 system-prompt-override   11 to 0
  00003 jailbreak-attempt         5 to 0
  00050 runaway-agent-loop        4 to 1
  00502 divergent-repetition      1 to 0
  00077 trust-exploitation        1 to 0

Why the measurement changed the plan

The starting assumption was that 00020 and 00021 were the worst offenders,
at 215 and 205 FP. That turned out to be an artifact of the harness rather
than production behaviour. FP counts depend heavily on the event shape fed
to the engine, because field resolution is shape-sensitive: agent_output
resolves only for llm_output events, for events carrying an explicit
agent_output field, or via the tool_response fallback. Every condition in
00020 targets agent_output, and the skill auditor emits llm_input, where
EVENT_TYPE_TO_FIELD maps the default field to user_input. So 00020 cannot
fire on that path at all.

Four shapes measured over the same 431 files:

  safety-gate asTextEvent shape   313 FP across 32 rules
  demote-fp-rules shape          1498 FP across 38 rules
  skill auditor shape (real)       68 FP across  8 rules
  scanSkill compound gate           1 FP across  1 rule

This PR fixes the 8 rules that FP under the shape production actually uses.

What was over-broad

00051: a bare quantifier-noun branch matched plain phrases such as "all
tables" and "every dataset" with no consuming action. The SELECT branch also
fired when a WHERE clause was present, which bounds the result set.

00032: "instead of the <any words>" is how documentation describes swapping
one component for another, and "skip this step" is ordinary instructional
prose. The rule's own true positive uses the same phrasing, so the fix is to
require a self-substitution clause rather than to ban the phrase.

00004: the chat-completions message opener, a "System Prompt" markdown
heading, and any config object holding a system key are all ordinary
API-integration shapes. A negation guard was also added, because a benign
skill telling the agent not to assume existing instructions are wrong was
matching the negated clause as if it were the assertion.

00003: developer and debug mode phrasing is normal in dev docs. The
ambiguous adjectives now need an accompanying no-restrictions claim; the
unambiguous ones still fire alone. Naming a technique is not performing it.

00050: agent frameworks use self-call as vocabulary, and an infinite loop in
a code sample is an example rather than runaway behaviour.

00502: the repetition detector counted digits, so an ISO timestamp read as a
repeated token. Restricted to alphabetic tokens.

00077: matched an agent guideline instructing the agent to report only what
it is confident in, which is the opposite of trust exploitation.

Five FPs deliberately left in place

These are not rule defects and were not touched. Two are correct matches on
genuinely bulk or destructive operations that a data-tooling skill
legitimately documents. Two are a real instruction-override directive that a
vendor skill uses in good faith, textually indistinguishable from injection.
One is a loop example. Weakening the rules further would trade real detection
for cosmetic numbers.

Verification

All 7 rules pass their own test cases. skill-benchmark and eval-harness
regression suites pass, 29 tests. redos-safety, rule-contract, attack-corpus,
benign-code and quality suites pass, 124 tests. Benchmark recall, precision
and fp_rate are identical before and after: recall 1.0, precision 0.97,
fp_rate 0.002, zero false negatives.

Note on the gate: check-rules-safety only inspects newly added rule files, so
modified rules are not covered by it. The verification above was run manually
to compensate. Extending that gate to changed rules is worth doing separately.