### PR TITLE
docs(rules): record why 00003 and 00502 were tightened

### DIFF
--- a/rules/model-abuse/ATR-2026-00502-training-data-extraction-via-divergent-repetition-attack.yaml
+++ b/rules/model-abuse/ATR-2026-00502-training-data-extraction-via-divergent-repetition-attack.yaml
@@ -110,7 +110,13 @@ detection:
     - field: content
       operator: regex
       value: '(?i)(?:repeat|say|print|output|write)\b[\s\S]{0,60}\b([A-Za-z]{3,})\b(?:\W+\1\b){3,}'
-      description: 'Divergent repetition: repeat/print followed by the same token 4+ times'
+      description: >-
+        Divergent repetition — repeat/print followed by the same alphabetic
+        token 4+ times (v2 — the repeated token was \w, which includes digits,
+        so an ISO timestamp such as 10:00:00+00:00 read as the token 00
+        repeated four times separated by punctuation. That FP'd on a benign
+        Airflow CLI reference table. Restricting the token to letters keeps the
+        word-repetition true_positives and drops numeric coincidences)
   condition: any
   false_positives:
     - "Legitimate requests to repeat something a finite, small number of times"

--- a/rules/prompt-injection/ATR-2026-00003-jailbreak-attempt.yaml
+++ b/rules/prompt-injection/ATR-2026-00003-jailbreak-attempt.yaml
@@ -91,7 +91,15 @@ detection:
     - field: user_input
       operator: regex
       value: "(?i)\\b(?:(?:enable|activate|enter|switch\\s+to|turn\\s+on|engage|initiate|boot\\s+into|start)\\s+(?:unrestricted|unlimited|unfiltered|uncensored|god|jailbreak|hacker|unsafe)\\s+(?:mode|access|state|level|tier|permissions?)\\b|(?:enable|activate|enter|switch\\s+to|turn\\s+on|engage|initiate|boot\\s+into|start)\\s+(?:developer|dev|maintenance|debug|admin|root|sudo|super|test|raw|override|master|privileged)\\s+(?:mode|access|state|level|tier|permissions?)\\b[\\s\\S]{0,120}?(?:no\\s+(?:restrictions?|limits?|filters?|rules?|guidelines?)|without\\s+(?:restrictions?|limits?|filters?)|ignore\\s+(?:all\\s+)?(?:previous|your|the)\\b|answer\\s+any\\s+question|bypass\\b|unfiltered|uncensored|do\\s+anything))"
-      description: "Mode-switching requests to elevate agent capabilities"
+      description: >-
+        Mode-switching requests to elevate agent capabilities (v2 — split into
+        an unambiguous group and an ambiguous one. Phrases like enable debug
+        mode or enable developer mode are ordinary developer documentation and
+        FP'd on benign skills, but developer mode is also a real jailbreak
+        persona, so those adjectives now require an accompanying
+        no-restrictions claim within the same passage. The unambiguous
+        adjectives such as unrestricted, uncensored and jailbreak still fire on
+        their own. Both mode-switching true_positives are unaffected)
 
     # -- Layer 3: Roleplay with constraint removal --
     - field: user_input
@@ -109,7 +117,15 @@ detection:
     - field: user_input
       operator: regex
       value: "(?i)(as\\s+your\\s+(developer|creator|programmer|engineer|designer|admin|administrator|owner|operator|maintainer)|I\\s+am\\s+(your|the|an?)\\s+(developer|creator|admin|owner|operator|maker|programmer)|I\\s+(work\\s+(for|at)|represent|am\\s+from)\\s+(OpenAI|Anthropic|Google\\s+DeepMind|Meta\\s+AI|Microsoft|the\\s+company\\s+that\\s+(made|created|built|trained)\\s+you)|I\\s+have\\s+(admin|root|developer|elevated|special|override|master|super|full)\\s+(access|privileges?|permissions?|authority|clearance|rights?))"
-      description: "False authority claims to establish trust for bypassing restrictions"
+      description: >-
+        False authority claims to establish trust for bypassing restrictions
+        (v2 — the article in the as-a-role branch was narrowed from
+        your/the/a to your only. "as the Admin" is how administration
+        documentation refers to the reader's own role and FP'd on benign
+        workspace-admin skills, whereas an impersonation attempt addresses the
+        agent and claims to be its developer. The first-person I-am branch is
+        unchanged and still covers the-role phrasing, and the
+        as-your-developer true_positive is unaffected)
 
     # -- Layer 6: Emotional manipulation and urgency --
     - field: user_input
@@ -139,7 +155,13 @@ detection:
     - field: user_input
       operator: regex
       value: "(?i)\\b(opposite\\s+mode|anti-?policy|bypass\\s+(the\\s+)?(content|safety|ethical|output)\\s+(filter|policy|guidelines?|rules?|restrictions?)|token\\s+smuggling|guard\\s*rail\\s+(evasion|bypass|removal)|safety\\s+(bypass|override|removal|disable|circumvent)|content\\s+filter\\s+(bypass|evasion|circumvention|workaround))\\b"
-      description: "Explicit filter bypass and evasion terminology"
+      description: >-
+        Explicit filter bypass and evasion terminology (v2 — dropped the bare
+        prompt-leak noun. That is the name of a technique rather than an
+        attempt to perform it, and it matched a benign AI-safety review skill
+        that legitimately discusses the technique by name. The remaining terms
+        all describe an action being taken; no true_positive relied on the
+        dropped noun)
 
     # -- Layer 11: Encoding-wrapped jailbreak instructions --
     - field: user_input


### PR DESCRIPTION
Follow-up to #342.

That PR narrowed four conditions across ATR-2026-00003 and ATR-2026-00502
but left their descriptions untouched, so the repo convention of recording
each tightening inline (the one 00051 already follows) was only half
applied. Without the rationale, a future maintainer or the maturity
promoter cannot tell why the pattern is narrow and may widen it back.

Documentation only. No regex is modified, and both rules still pass their
own test cases. Diff removes zero value lines.

What is now recorded:

00003 mode-switching — the ambiguous adjectives require an accompanying
no-restrictions claim, because developer and debug mode phrasing is
ordinary in dev documentation while still being a real jailbreak persona.
The unambiguous adjectives still fire alone.

00003 authority claims — the article was narrowed to "your", because
"as the Admin" is how administration documentation refers to its reader,
whereas an impersonation attempt addresses the agent.

00003 evasion terminology — a bare technique name was dropped, because
naming a technique is not performing it, and it matched a benign AI-safety
review skill discussing it.

00502 repetition — the repeated token must be alphabetic, because the
previous character class included digits and an ISO timestamp read as the
same token repeated four times.