### PR TITLE
fix(ci): gate modified rules, and stop failing correctness on CI latency noise

### DIFF
--- a/scripts/check-rules-safety.ts
+++ b/scripts/check-rules-safety.ts
@@ -38,6 +38,7 @@ import {
   statSync,
   mkdtempSync,
   copyFileSync,
+  writeFileSync,
   rmSync,
 } from "node:fs";
 import { join, resolve, dirname, basename } from "node:path";
@@ -104,6 +105,46 @@ function getNewRuleFiles(base: string): string[] {
       `[safety-gate] git diff failed: ${err instanceof Error ? err.message : String(err)}`,
     );
     return [];
+  }
+}
+
+/** Diff against base to find modified (already-existing) rule files. */
+function getModifiedRuleFiles(base: string): string[] {
+  try {
+    const out = execFileSync(
+      "git",
+      [
+        "diff",
+        "--name-only",
+        "--diff-filter=M",
+        `${base}...HEAD`,
+        "--",
+        "rules/",
+      ],
+      { cwd: REPO_ROOT, encoding: "utf-8" },
+    ).trim();
+    return out
+      .split("\n")
+      .filter((f) => f.endsWith(".yaml") || f.endsWith(".yml"))
+      .filter(Boolean);
+  } catch (err) {
+    console.error(
+      `[safety-gate] git diff (modified) failed: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    return [];
+  }
+}
+
+/** Read a file's contents at a git ref. Null when it is absent there. */
+function readFileAtRef(ref: string, file: string): string | null {
+  try {
+    return execFileSync("git", ["show", `${ref}:${file}`], {
+      cwd: REPO_ROOT,
+      encoding: "utf-8",
+      maxBuffer: 32 * 1024 * 1024,
+    });
+  } catch {
+    return null;
   }
 }
 
@@ -523,6 +564,127 @@ function extractTruePositives(doc: Record<string, unknown>): string[] {
     .filter((s): s is string => typeof s === "string" && s.length > 0);
 }
 
+/** Every benign sample the gate knows about, flattened to labelled text. */
+function collectBenignCorpus(): Array<{ label: string; text: string }> {
+  const out: Array<{ label: string; text: string }> = [];
+  if (existsSync(BENIGN_DIR)) {
+    for (const f of readdirSync(BENIGN_DIR).filter((x) => x.endsWith(".md"))) {
+      out.push({ label: f, text: readFileSync(join(BENIGN_DIR, f), "utf-8") });
+    }
+  }
+  for (const s of loadExtendedBenign())
+    out.push({ label: `${s.source}/${s.source_id}`, text: s.text });
+  for (const s of loadBenignCode())
+    out.push({ label: `benign-code/${s.source_id}`, text: s.text });
+  for (const s of loadResearchMentions())
+    out.push({ label: "research-mention", text: s.text });
+  return out;
+}
+
+/**
+ * Build an engine holding exactly the supplied rule sources. Draft/test
+ * statuses are activated so an inert rule still gets measured — the same
+ * treatment the new-rule path gives them.
+ */
+async function buildScopedEngine(
+  name: string,
+  content: string,
+): Promise<{ engine: ATREngine; dir: string }> {
+  const dir = mkdtempSync(join(tmpdir(), "atr-safety-modified-"));
+  writeFileSync(join(dir, name), content, "utf-8");
+  const engine = new ATREngine({ rulesDir: dir });
+  await engine.loadRules();
+  for (const rule of engine.getRules() as unknown as Array<
+    Record<string, unknown>
+  >) {
+    if (rule["status"] === "draft" || rule["status"] === "test") {
+      rule["status"] = "active";
+    }
+  }
+  return { engine, dir };
+}
+
+/**
+ * Check 6 — a modified rule may not introduce NEW benign false positives.
+ *
+ * Deliberately differential rather than absolute. A rule that already
+ * false-positives is pre-existing debt, and failing whichever PR happens to
+ * touch it next would only teach contributors to route around the gate. What
+ * must never land is a change that makes a rule match benign samples it did
+ * not match before.
+ *
+ * Each rule is evaluated twice over the same corpus — once as it exists at
+ * base, once as modified — and only the difference is reported. That also
+ * means a PR which strictly narrows a pattern passes with no work, which is
+ * the outcome we want to encourage.
+ */
+async function checkModifiedRulesNoNewFP(
+  base: string,
+  files: string[],
+): Promise<Failure[]> {
+  const failures: Failure[] = [];
+  const corpus = collectBenignCorpus();
+  if (corpus.length === 0) {
+    console.error(
+      "[safety-gate] benign corpora empty — skipping modified-rule FP check",
+    );
+    return failures;
+  }
+
+  for (const file of files) {
+    const baseContent = readFileAtRef(base, file);
+    const headPath = join(REPO_ROOT, file);
+    if (!baseContent || !existsSync(headPath)) continue;
+    const headContent = readFileSync(headPath, "utf-8");
+    if (baseContent === headContent) continue;
+
+    const name = basename(file);
+    let baseBuilt: { engine: ATREngine; dir: string } | null = null;
+    let headBuilt: { engine: ATREngine; dir: string } | null = null;
+    try {
+      baseBuilt = await buildScopedEngine(name, baseContent);
+      headBuilt = await buildScopedEngine(name, headContent);
+    } catch (err) {
+      // A rule that no longer loads is a real problem, but it is the schema
+      // validator's to report, not this gate's.
+      console.error(
+        `[safety-gate] could not build scoped engines for ${file}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      if (baseBuilt) rmSync(baseBuilt.dir, { recursive: true, force: true });
+      if (headBuilt) rmSync(headBuilt.dir, { recursive: true, force: true });
+      continue;
+    }
+
+    const introduced: string[] = [];
+    for (const { label, text } of corpus) {
+      const before = matchAllRuleIds(baseBuilt.engine, text);
+      const after = matchAllRuleIds(headBuilt.engine, text);
+      for (const id of after) {
+        if (!before.has(id)) introduced.push(`${id} now matches ${label}`);
+      }
+    }
+
+    rmSync(baseBuilt.dir, { recursive: true, force: true });
+    rmSync(headBuilt.dir, { recursive: true, force: true });
+
+    if (introduced.length > 0) {
+      for (const detail of introduced.slice(0, 3)) {
+        failures.push({
+          file,
+          reason: `modification introduces a new benign false positive: ${detail}`,
+        });
+      }
+      if (introduced.length > 3) {
+        failures.push({
+          file,
+          reason: `(+${introduced.length - 3} more newly introduced benign FPs suppressed)`,
+        });
+      }
+    }
+  }
+  return failures;
+}
+
 async function main(): Promise<void> {
   const { base, file: singleFile } = parseArgs();
   const newFiles = singleFile ? [singleFile] : getNewRuleFiles(base);
@@ -532,13 +694,36 @@ async function main(): Promise<void> {
   } else {
     console.log(`[safety-gate] base=${base}`);
   }
+  const modifiedFiles = singleFile ? [] : getModifiedRuleFiles(base);
   console.log(`[safety-gate] ${newFiles.length} new rule file(s) detected`);
+  if (modifiedFiles.length > 0) {
+    console.log(
+      `[safety-gate] ${modifiedFiles.length} modified rule file(s) detected`,
+    );
+  }
+
+  // Modified rules are checked differentially — a change may not introduce
+  // benign FPs the rule did not already have. Runs even when no rule is added,
+  // which is the case this gate previously ignored entirely.
+  const modifiedFailures =
+    modifiedFiles.length > 0
+      ? await checkModifiedRulesNoNewFP(base, modifiedFiles)
+      : [];
 
   if (newFiles.length === 0) {
+    if (modifiedFailures.length === 0) {
+      console.log(
+        modifiedFiles.length > 0
+          ? `[safety-gate] PASS — ${modifiedFiles.length} modified rule(s) introduce no new benign FPs`
+          : "[safety-gate] No new or modified rule files — nothing to check, treating as safe.",
+      );
+      process.exit(0);
+    }
     console.log(
-      "[safety-gate] No new rule files — nothing to check, treating as safe.",
+      `[safety-gate] FAIL — ${modifiedFailures.length} finding(s) need human review:`,
     );
-    process.exit(0);
+    modifiedFailures.forEach((f) => console.log(`  ✗ ${f.file} — ${f.reason}`));
+    process.exit(1);
   }
 
   if (!singleFile && newFiles.length > MAX_NEW_PER_PR) {
@@ -548,7 +733,7 @@ async function main(): Promise<void> {
     process.exit(1);
   }
 
-  const failures: Failure[] = [];
+  const failures: Failure[] = [...modifiedFailures];
   const newRuleIds = new Set<string>();
   const fileToId = new Map<string, string>();
   const ruleEntries: Array<{ id: string; file: string; tps: string[] }> = [];

--- a/src/eval/metrics.ts
+++ b/src/eval/metrics.ts
@@ -160,8 +160,28 @@ export function computeEvalReport(results: readonly SampleResult[]): EvalReport 
 // ---------------------------------------------------------------------------
 
 export interface RegressionCheck {
+  /**
+   * Correctness only. Latency is deliberately excluded — see perfWarnings.
+   */
   readonly passed: boolean;
+  /** Correctness violations (recall / FP rate / F1). These are blocking. */
   readonly violations: readonly string[];
+  /**
+   * Performance observations (p95 latency). Advisory, never blocking.
+   *
+   * Recall, FP rate and F1 are deterministic: the same corpus and rules give
+   * the same numbers on any machine. Wall-clock p95 is not — on a shared CI
+   * runner executing the rest of the suite in parallel it measures how busy
+   * the box is, and it has produced red builds on branches that were in fact
+   * faster than main. Gating correctness on it made a real recall regression
+   * and a noisy neighbour indistinguishable, which devalues both signals.
+   *
+   * The genuinely dangerous latency case — catastrophic backtracking — is
+   * caught structurally and deterministically by the ReDoS gate
+   * (tests/redos-safety.test.ts), so demoting this check loses no real
+   * protection.
+   */
+  readonly perfWarnings: readonly string[];
 }
 
 export interface BaselineThresholds {
@@ -202,11 +222,13 @@ export function checkRegression(
     );
   }
 
+  // Advisory only — see RegressionCheck.perfWarnings for why this does not block.
+  const perfWarnings: string[] = [];
   if (report.latency.p95 > thresholds.maxP95LatencyMs) {
-    violations.push(
+    perfWarnings.push(
       `P95 latency ${report.latency.p95.toFixed(1)}ms > maximum ${thresholds.maxP95LatencyMs}ms`
     );
   }
 
-  return { passed: violations.length === 0, violations };
+  return { passed: violations.length === 0, violations, perfWarnings };
 }

--- a/tests/eval-harness.test.ts
+++ b/tests/eval-harness.test.ts
@@ -259,8 +259,15 @@ describe('Full Eval Harness', () => {
 
   it('regression check passes with default thresholds', async () => {
     const { regression } = await runEval({ rulesDir: RULES_DIR });
-    // Default thresholds are conservative (60% recall, 5% FP, 70% F1)
+    // Default thresholds are conservative (60% recall, 5% FP, 70% F1).
+    // Assert on violations rather than the bare boolean so a failure names the
+    // offending metric instead of just reporting "expected true, got false".
+    expect(regression.violations).toEqual([]);
     expect(regression.passed).toBe(true);
+    // Latency is advisory (shared CI runners are noisy) — surface, never fail on it.
+    if (regression.perfWarnings.length > 0) {
+      console.warn(`performance advisory: ${regression.perfWarnings.join('; ')}`);
+    }
   });
 
   it('identifies missed attacks correctly', async () => {


### PR DESCRIPTION
Two gaps surfaced while tightening seven rules for benign false positives
in #342. One let a real regression through; the other manufactured a fake
one.

1. The safety gate ignored modified rules entirely

check-rules-safety diffed with --diff-filter=A, so a PR that only changed
existing rules printed "No new rule files - nothing to check, treating as
safe" and exited 0. Every rule change in #342 went through unchecked, and
the verification there had to be done by hand.

The gate now also collects --diff-filter=M and checks each modified rule
differentially. The rule is built into a scoped engine twice, once as it
exists at base and once as modified, and both are run over all four benign
corpora. Only false positives the modification introduces are reported.

Differential rather than absolute is deliberate. A rule that already
false-positives is pre-existing debt, and failing whichever PR happens to
touch it next would teach contributors to route around the gate. A change
that strictly narrows a pattern passes with no work, which is the
behaviour worth encouraging.

Verified in both directions, because a gate nobody has watched fail has
not been tested:

  the seven tightenings from #342, checked against their own base
    7 modified rule files detected, PASS, exit 0

  the same branch with one rule deliberately widened back
    FAIL naming 8 specific benign samples, exit 1

Recording one detail honestly: the first negative test passed when it
should have failed. It had reverted the rule to exactly its base state, so
there was genuinely no diff to detect. The gate was right and the test was
wrong, but only re-running it with the correct base proved which.

2. p95 latency sat inside the correctness regression check

checkRegression mixed recall, FP rate and F1 together with a wall-clock
p95 against maxP95LatencyMs, defaulted to 50ms. Recall and FP rate are
deterministic - same corpus and rules, same numbers on any machine. A
wall-clock p95 on a shared CI runner executing the rest of the suite in
parallel measures how busy the box is.

That produced a red build on a branch measured locally at 20.8-21.9ms p95
against main at 21.2-22.0ms, and because the test asserted on the bare
boolean the output never said which metric had failed. A real recall
regression and a noisy neighbour were indistinguishable, which devalues
both signals.

Latency now comes back as perfWarnings: reported, never blocking. The
harness test asserts on the violations array, so a genuine failure names
the offending metric instead of reporting "expected true, got false". The
threshold itself is untouched, since raising it would only hide the
question.

Nothing real is lost by this. The dangerous latency case is catastrophic
backtracking, and that is caught structurally and deterministically by the
ReDoS gate in tests/redos-safety.test.ts, which rejects exponential
patterns, compiles the full bundled corpus, and demonstrates that a
rejected pattern would in fact have hung.

Full suite: 645 passed, 0 failed.