### PR TITLE
feat(sarif): emit the shared envelope profile (artifacts digest + layer)

### DIFF
--- a/src/converters/sarif.ts
+++ b/src/converters/sarif.ts
@@ -66,6 +66,23 @@ function collectRules(
 }
 
 /**
+ * Relative SARIF artifact URI for a scanned file.
+ *
+ * Absolute paths are never emitted — a SARIF report is routinely attached to
+ * public CI runs, and the local filesystem layout is not the consumer's
+ * business.
+ */
+function toArtifactUri(inputFile: string): string {
+  const cwd = process.cwd() + '/';
+  if (inputFile.startsWith(cwd)) return inputFile.slice(cwd.length);
+  if (inputFile.startsWith('/') || /^[A-Z]:\\/.test(inputFile)) {
+    // Absolute path outside CWD — strip to filename only.
+    return inputFile.split('/').pop() ?? inputFile.split('\\').pop() ?? 'unknown';
+  }
+  return inputFile;
+}
+
+/**
  * Convert ATR scan results to SARIF v2.1.0 format.
  *
  * @param results - Array of ScanResult from evaluate/scanSkill
@@ -94,6 +111,24 @@ export function scanResultToSARIF(
     },
   }));
 
+  // SARIF run.artifacts — one entry per scanned file, carrying the SHA-256 that
+  // the shared envelope profile (skil-lock#37 / SPEC 14.3) joins layers on.
+  // Emitting it here rather than only in result.properties is what lets a
+  // consumer match an ATR finding to the same artifact reported by another
+  // layer without parsing tool-specific property bags.
+  const artifacts: object[] = [];
+  const artifactIndex = new Map<string, number>();
+  for (const result of results) {
+    if (!result.input_file) continue;
+    const uri = toArtifactUri(result.input_file);
+    if (artifactIndex.has(uri)) continue;
+    artifactIndex.set(uri, artifacts.length);
+    artifacts.push({
+      location: { uri, uriBaseId: '%SRCROOT%' },
+      ...(result.content_hash ? { hashes: { 'sha-256': result.content_hash } } : {}),
+    });
+  }
+
   const sarifResults: object[] = [];
 
   for (const result of results) {
@@ -102,21 +137,15 @@ export function scanResultToSARIF(
 
       const location: Record<string, unknown> = {};
       if (result.input_file) {
-        // Make path relative to CWD — never expose absolute paths in SARIF
-        const cwd = process.cwd() + '/';
-        let uri: string;
-        if (result.input_file.startsWith(cwd)) {
-          uri = result.input_file.slice(cwd.length);
-        } else if (result.input_file.startsWith('/') || /^[A-Z]:\\/.test(result.input_file)) {
-          // Absolute path outside CWD — strip to filename only
-          uri = result.input_file.split('/').pop() ?? result.input_file.split('\\').pop() ?? 'unknown';
-        } else {
-          uri = result.input_file;
-        }
+        // Never expose absolute paths in SARIF — see toArtifactUri.
+        const uri = toArtifactUri(result.input_file);
+        const idxInArtifacts = artifactIndex.get(uri);
         location.physicalLocation = {
           artifactLocation: {
             uri,
             uriBaseId: '%SRCROOT%',
+            // Points at the run.artifacts entry holding this file's SHA-256.
+            ...(idxInArtifacts !== undefined ? { index: idxInArtifacts } : {}),
           },
           region: { startLine: 1 },
         };
@@ -131,9 +160,14 @@ export function scanResultToSARIF(
         },
         ...(result.input_file ? { locations: [location] } : {}),
         properties: {
+          // Identifies which layer of the shared envelope profile produced this
+          // result. Consumers that do not know the value treat it as opaque.
+          layer: 'atr',
           confidence: match.confidence,
           scan_type: result.scan_type,
           scan_context: match.scan_context,
+          // Retained alongside run.artifacts[].hashes for back-compat: anything
+          // parsing today's output keeps working.
           content_hash: result.content_hash,
         },
       });
@@ -154,6 +188,7 @@ export function scanResultToSARIF(
             rules: sarifRules,
           },
         },
+        ...(artifacts.length > 0 ? { artifacts } : {}),
         results: sarifResults,
       },
     ],

--- a/tests/converter.test.ts
+++ b/tests/converter.test.ts
@@ -292,6 +292,70 @@ describe('SARIF Converter', () => {
     expect(driver['rules']).toBeInstanceOf(Array);
   });
 
+  // The shared envelope profile (skil-lock#37 / SPEC 14.3) joins layers on the
+  // artifact digest, so these four properties are an interop contract with the
+  // drift and content layers rather than cosmetic output details.
+  it('emits the shared envelope profile: artifacts[], digest, index and layer', () => {
+    const sarif = scanResultToSARIF(
+      [makeScanResult({ input_file: 'skills/demo/SKILL.md', content_hash: 'a'.repeat(64) })],
+      '1.0.0',
+    ) as {
+      runs: Array<{
+        artifacts?: Array<{
+          location: { uri: string; uriBaseId: string };
+          hashes?: Record<string, string>;
+        }>;
+        results: Array<{
+          properties: Record<string, unknown>;
+          locations: Array<{
+            physicalLocation: { artifactLocation: { uri: string; index?: number } };
+          }>;
+        }>;
+      }>;
+    };
+
+    const run = sarif.runs[0]!;
+    expect(run.artifacts).toHaveLength(1);
+    expect(run.artifacts![0]!.location.uri).toBe('skills/demo/SKILL.md');
+    expect(run.artifacts![0]!.location.uriBaseId).toBe('%SRCROOT%');
+    expect(run.artifacts![0]!.hashes?.['sha-256']).toBe('a'.repeat(64));
+
+    const result = run.results[0]!;
+    expect(result.properties['layer']).toBe('atr');
+    // content_hash stays alongside the artifact digest so existing consumers keep working
+    expect(result.properties['content_hash']).toBe('a'.repeat(64));
+    expect(result.locations[0]!.physicalLocation.artifactLocation.index).toBe(0);
+  });
+
+  it('indexes each scanned file separately and omits artifacts when no file is known', () => {
+    const twoFiles = scanResultToSARIF(
+      [
+        makeScanResult({ input_file: 'a/SKILL.md', content_hash: 'a'.repeat(64) }),
+        makeScanResult({ input_file: 'b/SKILL.md', content_hash: 'b'.repeat(64) }),
+      ],
+      '1.0.0',
+    ) as {
+      runs: Array<{
+        artifacts?: unknown[];
+        results: Array<{
+          locations: Array<{ physicalLocation: { artifactLocation: { index?: number } } }>;
+        }>;
+      }>;
+    };
+    expect(twoFiles.runs[0]!.artifacts).toHaveLength(2);
+    expect(
+      twoFiles.runs[0]!.results.map(
+        (r) => r.locations[0]!.physicalLocation.artifactLocation.index,
+      ),
+    ).toEqual([0, 1]);
+
+    // A non-file scan (e.g. a raw event stream) has nothing to hash.
+    const noFile = scanResultToSARIF([makeScanResult()], '1.0.0') as {
+      runs: Array<{ artifacts?: unknown[] }>;
+    };
+    expect(noFile.runs[0]!.artifacts).toBeUndefined();
+  });
+
   it('maps severity to SARIF levels correctly', () => {
     const criticalResult = makeScanResult({
       matches: [makeMatch({ rule: makeRule({ severity: 'critical' }) })],


### PR DESCRIPTION
Delivers the change committed to in anthropics/skills#492 on 7/1. The diff
shape was specified in that thread but the PR was never opened, so the atr
leg of the three-layer envelope has been outstanding since.

What changes

scanResultToSARIF now emits, per the profile in skil-lock#37 / SPEC 14.3:

  runs[].artifacts[] with location.uri, uriBaseId %SRCROOT% and
  hashes["sha-256"] - one entry per scanned file

  locations[].physicalLocation.artifactLocation.index pointing at that entry

  properties.layer "atr" on every result

Additive only. content_hash stays in result.properties, so anything parsing
today's output keeps working. A scan with no input file, such as a raw event
stream, emits no artifacts entry rather than a synthetic one.

The URI computation moved into toArtifactUri so the artifact entry and the
result location cannot drift apart. The existing rule that absolute paths are
never emitted is preserved.

Interop verified, not assumed

  The digest is a real SHA-256 of file content, matching shasum -a 256 byte
  for byte.

  Cross-checked against the content layer's own artifact-digest.mjs
  (aliksir/claude-code-skill-security-check, lib/sarif) by running both over
  the same file: identical join key, layer correctly distinct (atr vs
  content), index agreeing.

Both new tests were run against the previous converter first and confirmed to
fail, so they assert the profile rather than restate the implementation.

Full suite: 647 passed, 0 failed.

One divergence found, reported rather than fixed here

ATR hashes the UTF-8 decoded string (src/content-hash.ts uses
update(content, 'utf8')) while the content layer hashes raw bytes
(readFileSync with no encoding, commented there as deliberate).

Measured: identical for ASCII, multi-byte text and a UTF-8 BOM; divergent for
invalid UTF-8 bytes and lone surrogates, where decoding substitutes U+FFFD
before hashing.

That is exploitable in principle - a skill carrying a few invalid bytes would
make two layers compute different digests for the same file, breaking the
join that the envelope depends on. Changing the hash basis would invalidate
every digest already published, so it is a cross-layer decision rather than
something to land unilaterally here. Raising it in #492.