### PR TITLE
docs(atlas): tag agent-tool supply-chain rules with AML.T0010.005

### DIFF
--- a/docs/crosswalks/atr-attack-crosswalk.md
+++ b/docs/crosswalks/atr-attack-crosswalk.md
@@ -32,7 +32,7 @@ columns are still extracted from ATR metadata, not authored here.
 - Rules carrying an enterprise ATT&CK id (`references.mitre_attack` Txxxx): 183
 - Distinct enterprise ATT&CK techniques referenced: 64
 - Rules carrying a MITRE ATLAS id (`references.mitre_atlas`): 768
-- Distinct MITRE ATLAS techniques referenced: 40
+- Distinct MITRE ATLAS techniques referenced: 41
 - Rules carrying an OWASP Agentic id (`references.owasp_agentic`): 768
 - ATR categories (distinct `tags.category` values): 9
 
@@ -309,7 +309,7 @@ ATT&CK techniques (join key):
 | T1552.001 | Credentials In Files | `ATR-2026-02261` |
 | T1565.001 | Data Manipulation: Stored Data Manipulation | `ATR-2026-00200` |
 
-ATLAS techniques ATR adds: AML.T0010, AML.T0011.000, AML.T0018.000, AML.T0020, AML.T0024, AML.T0040, AML.T0044, AML.T0048, AML.T0050, AML.T0051, AML.T0051.001, AML.T0053, AML.T0057, AML.T0060, AML.T0080, AML.T0104, AML.T0109
+ATLAS techniques ATR adds: AML.T0010, AML.T0010.005, AML.T0011.000, AML.T0018.000, AML.T0020, AML.T0024, AML.T0040, AML.T0044, AML.T0048, AML.T0050, AML.T0051, AML.T0051.001, AML.T0053, AML.T0057, AML.T0060, AML.T0080, AML.T0104, AML.T0109
 
 OWASP Agentic categories ATR adds: ASI01:2026, ASI02:2026, ASI03:2026, ASI04:2026, ASI05:2026, ASI06:2026, ASI07:2026, ASI08:2026, ASI09:2026
 
@@ -346,7 +346,7 @@ ATT&CK techniques (join key):
 | T1552 | Unsecured Credentials | `ATR-2026-00534`, `ATR-2026-01931` |
 | T1552.001 | Credentials In Files | `ATR-2026-00576` |
 
-ATLAS techniques ATR adds: AML.T0010, AML.T0019, AML.T0024, AML.T0040, AML.T0049, AML.T0051, AML.T0051.001, AML.T0053, AML.T0056, AML.T0057, AML.T0069, AML.T0070, AML.T0104, AML.T0110
+ATLAS techniques ATR adds: AML.T0010, AML.T0010.005, AML.T0019, AML.T0024, AML.T0040, AML.T0049, AML.T0051, AML.T0051.001, AML.T0053, AML.T0056, AML.T0057, AML.T0069, AML.T0070, AML.T0104, AML.T0110
 
 OWASP Agentic categories ATR adds: ASI01:2026, ASI02:2026, ASI03:2026, ASI04:2026, ASI05:2026, ASI06:2026, ASI07:2026, ASI08:2026, ASI09:2026
 

--- a/rules/skill-compromise/ATR-2026-00060-skill-impersonation.yaml
+++ b/rules/skill-compromise/ATR-2026-00060-skill-impersonation.yaml
@@ -25,6 +25,7 @@ references:
   mitre_atlas:
     - AML.T0010 - AI Supply Chain Compromise
     - AML.T0104 - Publish Poisoned AI Agent Tool
+    - AML.T0010.005 - AI Supply Chain Compromise of AI Agent Tool
   mitre_attack:
     - T1195 - Supply Chain Compromise
 

--- a/rules/skill-compromise/ATR-2026-00126-skill-rug-pull-setup.yaml
+++ b/rules/skill-compromise/ATR-2026-00126-skill-rug-pull-setup.yaml
@@ -18,6 +18,7 @@ references:
   mitre_atlas:
     - AML.T0010 - AI Supply Chain Compromise
     - AML.T0109 - AI Supply Chain Rug Pull
+    - AML.T0010.005 - AI Supply Chain Compromise of AI Agent Tool
   owasp_llm:
     - LLM05:2025 - Supply Chain Vulnerabilities
   owasp_agentic:

--- a/rules/skill-compromise/ATR-2026-00134-fork-claim-impersonation.yaml
+++ b/rules/skill-compromise/ATR-2026-00134-fork-claim-impersonation.yaml
@@ -18,6 +18,7 @@ severity: medium
 references:
   mitre_atlas:
     - AML.T0010 - AI Supply Chain Compromise
+    - AML.T0010.005 - AI Supply Chain Compromise of AI Agent Tool
   owasp_agentic:
     - ASI04:2026 - Agentic Supply Chain Vulnerabilities
   owasp_ast:

--- a/rules/tool-poisoning/ATR-2026-00096-registry-poisoning.yaml
+++ b/rules/tool-poisoning/ATR-2026-00096-registry-poisoning.yaml
@@ -17,6 +17,7 @@ references:
     - LLM06:2025 - Excessive Agency
   mitre_atlas:
     - AML.T0056
+    - AML.T0010.005
   owasp_agentic:
     - ASI05:2026 - Unexpected Code Execution
 metadata_provenance:


### PR DESCRIPTION
What

Adds the MITRE ATLAS sub-technique AML.T0010.005 (AI Supply Chain Compromise: AI Agent Tool) to four rules that detect supply-chain distribution of a compromised agent tool or skill:

- ATR-2026-00060  MCP skill impersonation / supply chain attack
- ATR-2026-00096  skill registry poisoning and compromised tool distribution
- ATR-2026-00126  skill rug-pull setup
- ATR-2026-00134  fork-claim impersonation

Why

These rules are squarely about an agent tool or skill being poisoned in the distribution/registry channel, but none was tagged with T0010.005 - the ATLAS sub-technique that international and national frameworks use for that class. Concretely, KISA's July 2026 AI Security Threat Mitigation Manual maps its S04 category (vulnerable / unverified agent extension) to exactly AML.T0010.005. A crosswalk from ATR to that framework does not join today because the tag is absent. Repo-wide, zero of the ~145 skill-compromise and tool-poisoning rules currently carry T0010.005.

Scope

Additive metadata only - one ATLAS reference line per rule. No detection logic, conditions, test cases, thresholds, or benchmarks change. T0010.005 is present in the vendored ATLAS data (data/threat-frameworks/mitre-atlas.json), so the allowlist check passes.

Notes

This is the highest-confidence subset (unambiguous supply-chain distribution). A broader audit of the remaining skill-compromise and tool-poisoning rules for T0010.005 is intentionally out of scope here to keep the change small and reviewable. ATR-2026-00096 carries a MiroFish-Predicted author tag; this PR does not touch its detection content, only its ATLAS reference.
