### PR TITLE
spec: ATR Observation v1.0 — the input format (PROPOSED)

### DIFF
--- a/STANDARDIZATION-STATUS.md
+++ b/STANDARDIZATION-STATUS.md
@@ -35,7 +35,8 @@ of those interfaces have changed**. Continue as before.
 | **New event format spec** | `spec/atr-event-v1.0.md` | **PROPOSED** | Target event format. **Current engine does NOT yet emit this format.** Do not migrate your SIEM ingestion yet. |
 | **New language detection spec** | `spec/atr-language-detection-v1.0.md` | **PROPOSED** | Target algorithm. Current engine uses existing per-rule logic. |
 | **New profile spec** | `spec/atr-profile-v1.0.md` | **PROPOSED** | Target profile format. No formal profile resolver shipping yet. |
-| **New correlation spec** | `spec/atr-correlation-v1.0.md` | **PROPOSED** | Target multi-event format. No correlation rules in the canonical corpus yet. |
+| **New correlation spec** | `spec/atr-correlation-v1.0.md` | **PROPOSED** | Target multi-event format. No correlation rules in the canonical corpus yet. Its join keys are defined by the observation spec below, which is also unratified — correlation is not evaluable until both land. |
+| **New observation spec** | `spec/atr-observation-v1.0.md` | **PROPOSED** | Target *input* format (the engine's existing `AgentEvent` shape is unchanged). Defines the correlation join keys, an `outcome` enum that is not collapsible to a boolean, and a machine-readable coverage declaration. Current engine does NOT ingest this format. |
 | **New category registry** | `spec/category-registry/v1.0.yaml` | **PROPOSED** | Documents the 10 categories currently used + reserved namespaces for the future. |
 | **JSON Schemas** | `spec/schema/*.json` | **PROPOSED** | Validation schemas matching the proposed spec prose. |
 | **Conformance corpus** | `spec/conformance/` | **PROPOSED — SCAFFOLDING ONLY** | Structure documented; actual fixture files not yet populated. No engine currently claims formal conformance. |

--- a/spec/README.md
+++ b/spec/README.md
@@ -46,7 +46,8 @@ spec/
 │
 ├── SPEC.md                     ← (existing, repo root) rule format spec
 ├── atr-language-detection-v1.0.md     ← (new) deterministic language detection algorithm
-├── atr-event-v1.0.md                  ← (new) OTEL-compatible event format
+├── atr-event-v1.0.md                  ← (new) OTEL-compatible event format (engine OUTPUT)
+├── atr-observation-v1.0.md            ← (new) observation format (engine INPUT) + declared coverage
 ├── atr-profile-v1.0.md                ← (new) rule-set composition for tiered conformance
 ├── atr-correlation-v1.0.md            ← (new) multi-event correlation rule format
 ├── atr-method-v1.1.md                 ← (new) detection method extensions: signature/semantic/behavioral/trace
@@ -60,10 +61,14 @@ spec/
 ├── schema/                            ← (new) JSON Schemas
 │   ├── rule.schema.json               ← rule format JSON Schema
 │   ├── event.schema.json              ← event output JSON Schema
+│   ├── observation.schema.json        ← observation input JSON Schema
 │   ├── profile.schema.json            ← profile JSON Schema
 │   └── correlation.schema.json        ← correlation rule JSON Schema
 │
 └── conformance/                       ← (Phase 2) test corpus + expected-results.json
+    └── baseline/                      ← only directory populated today;
+                                         profiles/ and correlation/ are not
+                                         yet created (see STANDARDIZATION-STATUS.md)
 ```
 
 ---
@@ -160,11 +165,15 @@ levels:
 - Passes `spec/conformance/profiles/` corpus
 
 **Level 3 — Correlation Conformance.** Adds:
+- Observation ingest (`spec/atr-observation-v1.0.md` and schema), including
+  a machine-readable coverage declaration. Correlation join keys are
+  defined there; an engine cannot claim L3 while treating `session.id`
+  and `agent.id` as optional.
 - Correlation rule evaluation (`spec/atr-correlation-v1.0.md` and schema)
 - State management across events
 - Implements at least `temporal_sequence`, `count_threshold`, and
   `chain_propagation` correlation types
-- Passes `spec/conformance/correlation/` corpus
+- Passes `spec/conformance/correlation/` corpus (not yet created)
 
 Engines may claim any subset of levels (e.g., L1+L3 without L2). The
 ATR-Certified™ program awards trust marks per level.
@@ -197,7 +206,8 @@ vote per governance/CHARTER.md § 4.
 | Component | Version | Status | Files |
 |---|---|---|---|
 | Rule format | v1.0 | existing-draft | `SPEC.md`, `spec/atr-schema.yaml`, `spec/schema/rule.schema.json` |
-| Event format | v1.0 | draft (new May 2026) | `spec/atr-event-v1.0.md`, `spec/schema/event.schema.json` |
+| Event format (output) | v1.0 | draft (new May 2026) | `spec/atr-event-v1.0.md`, `spec/schema/event.schema.json` |
+| Observation format (input) | v1.0 | draft (new July 2026) | `spec/atr-observation-v1.0.md`, `spec/schema/observation.schema.json` |
 | Profile format | v1.0 | draft (new May 2026) | `spec/atr-profile-v1.0.md`, `spec/schema/profile.schema.json` |
 | Correlation format | v1.0 | draft (new May 2026) | `spec/atr-correlation-v1.0.md`, `spec/schema/correlation.schema.json` |
 | Language detection algorithm | v1.0 | draft (new May 2026) | `spec/atr-language-detection-v1.0.md` |

--- a/spec/atr-observation-v1.0.md
+++ b/spec/atr-observation-v1.0.md
@@ -1,0 +1,323 @@
+# ATR Observation Format v1.0 — the input side
+
+> **STATUS: PROPOSED v1.0 — NOT YET RATIFIED.** This specification describes
+> a target *input* format for community comment. The current TypeScript
+> production engine continues to accept its existing `AgentEvent` shape.
+> Adopters should NOT migrate until ratification. See
+> `STANDARDIZATION-STATUS.md` for full status.
+
+**Status:** Draft for AEP-005 ratification — NOT RATIFIED
+**Date:** 2026-07-29
+**License:** MIT
+**Required by (on ratification):** Correlation rule evaluation
+(`spec/atr-correlation-v1.0.md`), honest coverage reporting, quantitative
+detection primitives
+
+---
+
+## Purpose
+
+ATR has an event format for what an engine **emits** when a rule fires
+(`spec/atr-event-v1.0.md`). It has no format for what an engine
+**ingests**.
+
+The practical consequence is visible in the corpus. The production
+`AgentEvent` interface carries a required `content: string` — the text to
+analyse — while `sessionId` and `agentId` are optional. A rule therefore
+receives a blob of text rather than a description of something that
+happened, which is why almost every rule in the canonical corpus is a
+regular expression over one string, and why behavioural rules degrade
+into matching an agent's own narration of its behaviour.
+
+It also leaves `spec/atr-correlation-v1.0.md` suspended. That spec
+defines join keys (`session.id`, `agent.id`, `agent.delegation_chain`)
+that no schema in this repository defines or requires.
+
+This document specifies the minimum observation an engine must receive
+before correlation, counting, or absence-of-consent detection can mean
+anything.
+
+### Non-goals
+
+- **Not a replacement for `AgentEvent`.** The production interface stays.
+  An `AgentEvent` is a lossy projection of an Observation; §6 gives the
+  mapping.
+- **Not a telemetry collector.** ATR defines the shape, not the plumbing.
+- **Not a claim of completeness.** §5 exists precisely because most
+  deployments will observe a subset of dimensions. Declaring the subset
+  honestly is a requirement of this spec, not a footnote.
+
+---
+
+## 1. Design constraints
+
+1. **Small enough to adopt.** Six required fields. A host that cannot
+   populate six fields cannot support correlation, and should say so
+   rather than emit a degraded stream.
+2. **Aligned, not invented.** Where OpenTelemetry GenAI semantic
+   conventions already name a concept, this spec adopts the name.
+   Unilateral adoption costs nothing and removes a future migration.
+3. **Failure is first class.** See §3.
+4. **Coverage is declared, not assumed.** See §5.
+
+---
+
+## 2. Required fields
+
+| Field | Type | Notes |
+|---|---|---|
+| `@timestamp` | RFC 3339 string | Ordering key. Ties broken by `observation.id`. |
+| `observation.id` | string | Unique within a stream. Deduplication and evidence-chain anchor. |
+| `observation.kind` | enum, §4 | Which dimension this observation belongs to. |
+| `agent.id` | string | OTel: `gen_ai.agent.id`. |
+| `session.id` | string | OTel: `gen_ai.conversation.id`. |
+| `outcome` | enum, §3 | See §3 — this is the field this spec exists for. |
+
+`session.id` and `agent.id` are **required here although optional in
+`AgentEvent`**. A correlation rule grouped by a field that may be absent
+is not a detection, it is a coin flip.
+
+### 2.1 Recommended: `delegation.root`
+
+| Field | Type | Notes |
+|---|---|---|
+| `delegation.root` | string | The `session.id` of the originating session in a delegation chain. |
+
+When an agent is not a delegate, `delegation.root` **MUST** equal
+`session.id`. It is therefore always populated and always safe to group
+by.
+
+This field exists because grouping by `session.id` alone is trivially
+defeated: an actor that spawns a sub-agent usually receives a fresh
+session identifier from the host, so a two-step chain lands in two
+buckets and no correlation rule can ever complete. Grouping by
+`delegation.root` survives the hop.
+
+It does not make delegation-based evasion impossible. It makes each hop
+leave an edge in a graph that can be reconstructed afterwards. That is
+the honest claim.
+
+---
+
+## 3. `outcome`
+
+```
+ok | error | denied | refused | timeout | rate_limited
+```
+
+| Value | Meaning |
+|---|---|
+| `ok` | The action was attempted and succeeded. |
+| `error` | Attempted, failed for a reason unrelated to policy. |
+| `denied` | Refused by a policy or permission boundary. |
+| `refused` | Refused by the model or a guardrail (not a permission boundary). |
+| `timeout` | No result within the host's limit. |
+| `rate_limited` | Throttled by the host or a remote service. |
+
+`denied`, `refused`, `error`, and `timeout` **MUST NOT** be collapsed
+into a single boolean. OpenTelemetry GenAI, ECS, and OCSF all reduce
+these to an `is_error`-shaped flag, which is why this spec defines its
+own enum rather than adopting one.
+
+The distinction carries the load. An agent searching for a way out of a
+boundary produces a dense run of `denied` against a small number of
+distinct targets with high argument variety. An agent that is merely
+broken produces `error`. An agent behaving normally produces neither at
+volume. None of those three shapes is visible if the host emits
+`is_error: true` for all of them.
+
+Stated plainly: for this class of incident the signal is in the attempts
+that failed, not the one that worked.
+
+### 3.1 What this does not do
+
+Thresholds over `outcome` are cheap to compute and cheap to evade, since
+the rules are public. A ruleset that publishes "50 denials in 15
+minutes" has published a speed limit. Correlation rules over `outcome`
+**SHOULD** therefore keep the *logic* in the public corpus and take
+*numeric thresholds* from a host-injected profile
+(`spec/atr-profile-v1.0.md`). The public artefact stays verifiable; the
+operating numbers do not have to be.
+
+---
+
+## 4. `observation.kind`
+
+The first nine values correspond to `agent_source.type` in the rule
+schema and cover what the corpus can already express:
+
+```
+llm_io | tool_call | tool_response | mcp_exchange | multi_agent_comm
+memory_access | skill_lifecycle | context_window | agent_behavior
+```
+
+The next three are defined here and have **no corresponding rules in the
+canonical corpus at the time of writing**:
+
+```
+network | file | process
+```
+
+They are specified because they are the dimensions in which several
+well-understood agent attack steps actually occur, and because a
+dimension that has no name cannot be declared missing. A deployment that
+observes only tool-level activity should report that fact (§5) rather
+than return "no match" for a question it was never able to ask.
+
+### 4.1 Dimension-specific fields
+
+Fields beyond §2 are **OPTIONAL** and depend on `observation.kind`. A
+non-normative starting set:
+
+| Kind | Fields |
+|---|---|
+| `tool_call` | `tool.name`, `tool.arguments`, `target.host`, `target.path` |
+| `tool_response` | `tool.name`, `content` |
+| `network` | `target.host`, `target.port`, `target.scheme`, `bytes.out` |
+| `file` | `file.path`, `file.operation` |
+| `process` | `process.executable`, `process.argv` |
+
+`target.host` and `target.path` are shared across kinds deliberately.
+Correlation joins on a canonical target require one name for one
+concept; see `spec/atr-correlation-v1.0.md` on join keys.
+
+Canonicalisation before any join: hostnames lowercased with the port
+removed, paths resolved, URLs reduced to scheme and host. Two
+observations that refer to the same target and do not produce the same
+join value will silently never correlate, and the rule author will
+reasonably conclude the engine is broken.
+
+---
+
+## 5. Declared coverage
+
+An engine or host that consumes Observations **MUST** be able to report
+which dimensions it can actually observe:
+
+```json
+{
+  "atr.observation_spec_version": "1.0",
+  "covered_dimensions": ["llm_io", "tool_call", "tool_response", "mcp_exchange"],
+  "uncovered_dimensions": ["network", "file", "process"]
+}
+```
+
+Rules and correlation rules **MAY** declare `requires_dimensions`. When a
+required dimension is not covered, the engine **MUST** report the rule as
+`not_evaluated` and **MUST NOT** report it as `no_match`.
+
+This is the difference between "we looked and found nothing" and "we
+could not look", and reporting the second as the first is how a coverage
+number becomes a lie. It also bounds every claim made anywhere else in
+this repository: detection quality has a ceiling set by telemetry
+fidelity, and the telemetry is produced by the thing being observed. A
+single permitted `shell.exec` can compress thousands of network attempts
+into one observation with `outcome: ok`. No rule design fixes that. The
+only honest response is to make the blind spot machine-readable.
+
+---
+
+## 6. Mapping from the production `AgentEvent`
+
+An `AgentEvent` is a lossy projection. The mapping is defined so hosts
+can migrate incrementally rather than all at once:
+
+| `AgentEvent` | Observation |
+|---|---|
+| `timestamp` | `@timestamp` |
+| `type` | `observation.kind` |
+| `sessionId` | `session.id` (required here) |
+| `agentId` | `agent.id` (required here) |
+| `content` | kind-dependent field, §4.1 |
+| `fields` | kind-dependent fields, §4.1 |
+| `metrics` | out of scope for v1.0 |
+| — | `observation.id` (host must supply) |
+| — | `outcome` (host must supply) |
+| — | `delegation.root` (defaults to `session.id`) |
+
+A host that supplies only the mappable fields is conformant to §2 minus
+`outcome` and **MUST** declare `network`, `file`, and `process` as
+uncovered.
+
+---
+
+## 7. Example
+
+A dataset-processing agent reads an environment variable, then reaches an
+internal endpoint, then opens an outbound connection. Three observations,
+one delegation root, one of them denied:
+
+```json
+[
+  {
+    "@timestamp": "2026-07-29T09:14:02.113Z",
+    "observation.id": "obs-8f21a0",
+    "observation.kind": "tool_call",
+    "agent.id": "dataset-normaliser",
+    "session.id": "sess-4419",
+    "delegation.root": "sess-4419",
+    "outcome": "ok",
+    "tool.name": "shell.read_file",
+    "file.path": "/proc/self/environ"
+  },
+  {
+    "@timestamp": "2026-07-29T09:14:19.882Z",
+    "observation.id": "obs-8f21a1",
+    "observation.kind": "network",
+    "agent.id": "dataset-normaliser",
+    "session.id": "sess-4420",
+    "delegation.root": "sess-4419",
+    "outcome": "denied",
+    "target.host": "169.254.169.254",
+    "target.path": "/latest/meta-data/iam/security-credentials/"
+  },
+  {
+    "@timestamp": "2026-07-29T09:15:41.006Z",
+    "observation.id": "obs-8f21a2",
+    "observation.kind": "network",
+    "agent.id": "dataset-normaliser",
+    "session.id": "sess-4420",
+    "delegation.root": "sess-4419",
+    "outcome": "ok",
+    "target.host": "collect.example.net",
+    "target.scheme": "https",
+    "bytes.out": 4192
+  }
+]
+```
+
+The second and third observations carry a different `session.id` from the
+first, because a sub-agent was spawned. Grouping by `session.id` splits
+this into two buckets and nothing correlates. Grouping by
+`delegation.root` keeps it in one.
+
+Note also that this example is constructed, not observed. Fixtures
+derived from public incident reporting rather than from a captured
+stream **MUST** be marked `derived-not-observed` in their manifest. A
+corpus that learns to match the prose of incident write-ups repeats a
+failure this project has already documented once.
+
+---
+
+## 8. Open questions
+
+- Whether `metrics` from `AgentEvent` should become first-class
+  observation fields or stay host-side.
+- Whether `observation.kind` should be extensible by registry (as
+  `spec/category-registry/v1.0.yaml` does for categories) rather than a
+  closed enum.
+- Whether `outcome: refused` is stable enough to define across hosts, or
+  whether guardrail refusals belong in a separate dimension.
+- How `covered_dimensions` should be attested rather than self-declared.
+  Self-declaration is a statement of intent, not a control; a host can
+  claim any coverage it likes.
+
+---
+
+## References
+
+- `spec/atr-event-v1.0.md` — the output side
+- `spec/atr-correlation-v1.0.md` — consumes the join keys defined here
+- `spec/atr-profile-v1.0.md` — where numeric thresholds belong
+- OpenTelemetry GenAI semantic conventions — `gen_ai.agent.id`,
+  `gen_ai.conversation.id`

--- a/spec/schema/observation.schema.json
+++ b/spec/schema/observation.schema.json
@@ -1,0 +1,131 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://spec.agentthreatrule.org/observation/v1.0/schema.json",
+  "title": "ATR Observation v1.0",
+  "description": "Machine-readable schema for ATR observations — the input an engine ingests, as distinct from the detection events it emits (see event.schema.json). Normative spec at spec/atr-observation-v1.0.md. STATUS: PROPOSED, NOT RATIFIED. License: MIT.",
+  "type": "object",
+  "required": [
+    "@timestamp",
+    "observation.id",
+    "observation.kind",
+    "agent.id",
+    "session.id",
+    "outcome"
+  ],
+  "properties": {
+    "@timestamp": {
+      "type": "string",
+      "format": "date-time",
+      "description": "RFC 3339. Primary ordering key; ties broken by observation.id."
+    },
+    "observation.id": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Unique within a stream. Deduplication and evidence-chain anchor."
+    },
+    "observation.kind": {
+      "type": "string",
+      "enum": [
+        "llm_io",
+        "tool_call",
+        "tool_response",
+        "mcp_exchange",
+        "multi_agent_comm",
+        "memory_access",
+        "skill_lifecycle",
+        "context_window",
+        "agent_behavior",
+        "network",
+        "file",
+        "process"
+      ],
+      "description": "Dimension this observation belongs to. The first nine align with agent_source.type in rule.schema.json. network, file and process are defined so that a deployment unable to observe them can declare the gap rather than return no_match."
+    },
+    "agent.id": {
+      "type": "string",
+      "minLength": 1,
+      "description": "OTel GenAI: gen_ai.agent.id."
+    },
+    "session.id": {
+      "type": "string",
+      "minLength": 1,
+      "description": "OTel GenAI: gen_ai.conversation.id. Required here although optional in the production AgentEvent interface: a correlation grouped by a field that may be absent is not a detection."
+    },
+    "outcome": {
+      "type": "string",
+      "enum": ["ok", "error", "denied", "refused", "timeout", "rate_limited"],
+      "description": "MUST NOT be collapsed to a boolean. denied (policy boundary), refused (model or guardrail), error (neither) and timeout carry different signal. See spec/atr-observation-v1.0.md section 3."
+    },
+    "delegation.root": {
+      "type": "string",
+      "minLength": 1,
+      "description": "RECOMMENDED. session.id of the originating session in a delegation chain; MUST equal session.id when the agent is not a delegate. Grouping by session.id alone is defeated by spawning a sub-agent, which usually receives a fresh session identifier."
+    },
+    "tool.name": { "type": "string" },
+    "tool.arguments": {
+      "type": "object",
+      "additionalProperties": true,
+      "description": "Host-shaped. Not interpreted by this schema."
+    },
+    "target.host": {
+      "type": "string",
+      "description": "Canonicalised: lowercased, port removed. Shared across kinds so joins have one name for one concept."
+    },
+    "target.port": { "type": "integer", "minimum": 0, "maximum": 65535 },
+    "target.scheme": { "type": "string" },
+    "target.path": {
+      "type": "string",
+      "description": "Canonicalised: resolved, no trailing slash normalisation ambiguity."
+    },
+    "file.path": { "type": "string" },
+    "file.operation": {
+      "type": "string",
+      "enum": ["read", "write", "append", "delete", "rename", "chmod", "stat"]
+    },
+    "process.executable": { "type": "string" },
+    "process.argv": { "type": "array", "items": { "type": "string" } },
+    "bytes.out": { "type": "integer", "minimum": 0 },
+    "content": {
+      "type": "string",
+      "description": "Free text for kinds that carry it (llm_io, tool_response). Present for compatibility with the production AgentEvent projection; correlation MUST NOT join on it."
+    },
+    "consent": {
+      "type": "object",
+      "description": "Present when a human authorised this action. bound_to matters: an authorisation not bound to a specific target unlocks one action, not a window.",
+      "required": ["granted", "bound_to"],
+      "properties": {
+        "granted": { "type": "boolean" },
+        "bound_to": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Canonical target values this consent covers, e.g. a target.host. An empty array means unbound and MUST be treated as covering nothing."
+        },
+        "at": { "type": "string", "format": "date-time" }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": true,
+  "$defs": {
+    "coverageDeclaration": {
+      "title": "ATR Observation coverage declaration",
+      "description": "Emitted by a host or engine to state which dimensions it can actually observe. Rules declaring requires_dimensions against an uncovered dimension MUST be reported not_evaluated, never no_match.",
+      "type": "object",
+      "required": ["atr.observation_spec_version", "covered_dimensions"],
+      "properties": {
+        "atr.observation_spec_version": { "type": "string", "const": "1.0" },
+        "covered_dimensions": {
+          "type": "array",
+          "items": { "$ref": "#/properties/observation.kind" },
+          "uniqueItems": true
+        },
+        "uncovered_dimensions": {
+          "type": "array",
+          "items": { "$ref": "#/properties/observation.kind" },
+          "uniqueItems": true
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}


### PR DESCRIPTION
ATR specifies what an engine emits when a rule fires (spec/atr-event-v1.0.md). It has never specified what an engine ingests.

The consequence is visible in the corpus. The production AgentEvent interface requires content: string while sessionId and agentId are optional, so a rule receives a blob of text rather than a description of something that happened. That is why almost every rule here is a regular expression over one string, and why the behavioural rules degrade into matching an agent's own narration of its behaviour.

It also leaves spec/atr-correlation-v1.0.md suspended. That spec defines join keys (session.id, agent.id, agent.delegation_chain) that no schema in this repository defines or requires.

This PR adds the missing input side.

What is in it

- spec/atr-observation-v1.0.md, normative prose, PROPOSED / NOT RATIFIED like its siblings
- spec/schema/observation.schema.json, JSON Schema 2020-12, $id consistent with the existing four
- spec/README.md and STANDARDIZATION-STATUS.md updated to record it

Design notes

Six required fields. session.id and agent.id are required here although they are optional in AgentEvent, because a correlation grouped by a field that may be absent is not a detection.

An outcome enum: ok, error, denied, refused, timeout, rate_limited. It MUST NOT collapse to a boolean. OpenTelemetry GenAI, ECS and OCSF all reduce these to an is_error-shaped flag, which erases the difference between an agent stopped at a policy boundary and an agent that is merely broken. For a class of incident where an agent probes a boundary repeatedly, the signal is in the attempts that failed rather than the one that worked, and that signal does not survive the flattening.

delegation.root, defaulting to session.id when the agent is not a delegate. Grouping by session.id alone is defeated by spawning a sub-agent, which usually receives a fresh session identifier from the host, so a two-step chain lands in two buckets and no correlation can complete. This does not make delegation-based evasion impossible; it makes each hop leave a reconstructable edge.

Declared coverage. A rule that requires a dimension the deployment cannot observe MUST be reported not_evaluated and MUST NOT be reported no_match. Reporting the second as the first is how a coverage number becomes untrue.

network, file and process are named as dimensions although no rule in the corpus uses them today, because a dimension with no name cannot be declared missing.

Scope

Additive only. No rule, no engine code and no existing schema is modified. AgentEvent stays as it is; section 6 gives the mapping so hosts can migrate incrementally rather than all at once. Status remains PROPOSED, and STANDARDIZATION-STATUS.md now records that correlation is not evaluable until both specs land.

Validation

- Schema valid against draft 2020-12
- The three examples in the spec validate
- Negative cases rejected: missing outcome, boolean-shaped outcome, unknown observation.kind, consent without bound_to
- 768/768 rules validate
- 647 tests pass

One test fails, tests/eval-harness.test.ts, and it is pre-existing rather than caused by this change: it times out under parallel load but passes in 4.7s against a 30s budget when run alone, and it does not reference spec/. Worth a separate fix.

Open questions are listed in section 8 of the spec. The one I would most like comment on is whether covered_dimensions should be attested rather than self-declared, since a host can currently claim any coverage it likes.