### PR TITLE
ci: open bot PRs with a PAT so their own checks actually run

### DIFF
--- a/.github/workflows/atd-ingest.yml
+++ b/.github/workflows/atd-ingest.yml
@@ -99,7 +99,11 @@ jobs:
       - name: Open review PR
         if: steps.ingest.outputs.changed != '0' && inputs.dry_run != true
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # A PR opened with the default GITHUB_TOKEN is authored by app/github-actions, and
+          # every check on it parks at action_required forever instead of running. Opening it
+          # with a PAT makes a real user the author so the PR's own CI runs. Falls back to
+          # GITHUB_TOKEN when ATR_REPO_TOKEN is absent (PR still opens, checks still park).
+          GH_TOKEN: ${{ secrets.ATR_REPO_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
           set -eo pipefail
           # Guard against the maturity-promote anti-pattern: only commit + PR if

--- a/.github/workflows/fn-mine-scheduled.yml
+++ b/.github/workflows/fn-mine-scheduled.yml
@@ -121,7 +121,11 @@ jobs:
       - name: Open draft PR
         if: steps.mine.outputs.files != ''
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # A PR opened with the default GITHUB_TOKEN is authored by app/github-actions, and
+          # every check on it parks at action_required forever instead of running. Opening it
+          # with a PAT makes a real user the author so the PR's own CI runs. Falls back to
+          # GITHUB_TOKEN when ATR_REPO_TOKEN is absent (PR still opens, checks still park).
+          GH_TOKEN: ${{ secrets.ATR_REPO_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
           set -e
           gh pr create \

--- a/.github/workflows/garak-miss-proposals.yml
+++ b/.github/workflows/garak-miss-proposals.yml
@@ -79,7 +79,11 @@ jobs:
 
       - name: Open PR for refreshed proposals (human review required)
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # A PR opened with the default GITHUB_TOKEN is authored by app/github-actions, and
+          # every check on it parks at action_required forever instead of running. Opening it
+          # with a PAT makes a real user the author so the PR's own CI runs. Falls back to
+          # GITHUB_TOKEN when ATR_REPO_TOKEN is absent (PR still opens, checks still park).
+          GH_TOKEN: ${{ secrets.ATR_REPO_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
           git config user.name "ATR Garak Bridge"
           git config user.email "bridge@atr-framework.org"

--- a/.github/workflows/issue-to-proposal.yml
+++ b/.github/workflows/issue-to-proposal.yml
@@ -71,7 +71,11 @@ jobs:
       - name: Open draft PR
         id: pr
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # A PR opened with the default GITHUB_TOKEN is authored by app/github-actions, and
+          # every check on it parks at action_required forever instead of running. Opening it
+          # with a PAT makes a real user the author so the PR's own CI runs. Falls back to
+          # GITHUB_TOKEN when ATR_REPO_TOKEN is absent (PR still opens, checks still park).
+          GH_TOKEN: ${{ secrets.ATR_REPO_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
           set -e
           PR_URL=$(gh pr create \

--- a/.github/workflows/measure-all.yml
+++ b/.github/workflows/measure-all.yml
@@ -183,7 +183,11 @@ jobs:
       - name: Push branch + open PR
         if: steps.changes.outputs.has_changes == 'true'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # A PR opened with the default GITHUB_TOKEN is authored by app/github-actions, and
+          # every check on it parks at action_required forever instead of running. Opening it
+          # with a PAT makes a real user the author so the PR's own CI runs. Falls back to
+          # GITHUB_TOKEN when ATR_REPO_TOKEN is absent (PR still opens, checks still park).
+          GH_TOKEN: ${{ secrets.ATR_REPO_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
           set -e
           DATE=$(date -u +%Y-%m-%d)

--- a/.github/workflows/promote-semantic.yml
+++ b/.github/workflows/promote-semantic.yml
@@ -119,7 +119,11 @@ jobs:
 
       - name: Open PR for authored semantic rules (human review required)
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # A PR opened with the default GITHUB_TOKEN is authored by app/github-actions, and
+          # every check on it parks at action_required forever instead of running. Opening it
+          # with a PAT makes a real user the author so the PR's own CI runs. Falls back to
+          # GITHUB_TOKEN when ATR_REPO_TOKEN is absent (PR still opens, checks still park).
+          GH_TOKEN: ${{ secrets.ATR_REPO_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
           git config user.name "ATR Semantic Author"
           git config user.email "semantic-author@atr-framework.org"


### PR DESCRIPTION
A PR opened with the default GITHUB_TOKEN is authored by app/github-actions. Every check on such a PR is created in the action_required state and never executes, so the PR sits with no signal until a human approves each run by hand.

That is what has been happening. atd-ingest has opened a draft PR every day since 2026-07-19 and not one has been validated. 71 runs across 15 branches were parked: 60 on atd-ingest, plus garak-miss-bridge and pinguard/pin-actions.

The control group is in this same repo. maturity-promote PRs are opened with a PAT by the private scheduler, and their checks run normally. Same repo, same pull_request trigger, different PR author, different outcome.

Approving this run's five checks by hand confirms the content was never the problem. On atd-ingest/2026-07-30: ATD Validate enumeration, Validate ATR Rules, ATR Security Scan and no-private-leak all pass.

What changed

Six steps that open a PR now use ATR_REPO_TOKEN with a fallback to GITHUB_TOKEN: atd-ingest, fn-mine-scheduled, garak-miss-proposals, issue-to-proposal, measure-all, promote-semantic. The fallback means nothing breaks before the secret exists; it just reproduces today's parked behaviour.

The two steps in issue-to-proposal.yml that only post an issue comment stay on GITHUB_TOKEN. They do not need to trigger anything, and a narrower token is safer in a public repository.

Follow-up required

This is inert until an ATR_REPO_TOKEN secret exists on this repo. Recommend a fine-grained PAT scoped to this repository only, with contents write and pull-requests write, rather than a classic repo-scoped token, because any workflow in a public repo that can read the secret can exfiltrate it.

Test plan

- [ ] Add ATR_REPO_TOKEN, then wait for the 06:00 UTC atd-ingest run and confirm the PR author is a user and checks start on their own
- [ ] Confirm the same for the next promote-semantic and garak-miss-proposals runs
- [ ] Backfill: decide whether to approve or close the 11 superseded atd-ingest branches