### PR TITLE
feat(stats): report effective rule count alongside total

### DIFF
--- a/.github/workflows/reconcile-stats.yml
+++ b/.github/workflows/reconcile-stats.yml
@@ -53,9 +53,15 @@ jobs:
             echo "stats already in sync with disk — nothing to commit"
             exit 0
           fi
-          count=$(node -e 'process.stdout.write(String(JSON.parse(require("fs").readFileSync("stats.json","utf8")).ruleCount.total))')
+          # Both numbers go in the message. `total` is the file count; `effective`
+          # excludes rules the engine never evaluates (status draft/deprecated),
+          # and the two are not interchangeable — quoting total as detection
+          # coverage overstates it by exactly the difference.
+          field() { node -e 'process.stdout.write(String(JSON.parse(require("fs").readFileSync("stats.json","utf8")).ruleCount[process.argv[1]] ?? "?"))' "$1"; }
+          count=$(field total)
+          effective=$(field effective)
           git config user.name "ATR Stats Bot"
           git config user.email "bot@agentthreatrule.org"
           git add stats.json data/stats.json
-          git commit -m "chore(stats): auto-reconcile rule count to disk (${count} rules)"
+          git commit -m "chore(stats): auto-reconcile rule count to disk (${count} rule files, ${effective} effective)"
           git push origin main

--- a/docs/QUALITY-GATE.md
+++ b/docs/QUALITY-GATE.md
@@ -32,6 +32,26 @@ npx tsx scripts/check-rules-safety.ts --base origin/main
 npx tsx scripts/check-rules-safety.ts --file proposals/red-team-probes/foo.proposal.yaml
 ```
 
+## Counting rules honestly
+
+Two numbers, both true, not interchangeable:
+
+| Number      | Means                                                 |
+| ----------- | ----------------------------------------------------- |
+| `total`     | rule files on disk                                     |
+| `effective` | rules the engine loads AND that can fire in some lane   |
+
+`inert = total - effective` is the rules with `status: draft` / `deprecated`
+(or `maturity: deprecated`). Quoting `total` as detection coverage overstates
+it by exactly `inert`. Both are computed by
+[`scripts/reconcile-rule-count.mjs`](../scripts/reconcile-rule-count.mjs) and
+published into `stats.json` / `data/stats.json`:
+
+```bash
+npm run count:rules      # print total / effective / inert / lane ceilings
+npm run reconcile-stats  # write them into both caches
+```
+
 ## The maturity ladder
 
 Passing the gate gets a rule into `rules/` at `maturity: experimental`.

--- a/package.json
+++ b/package.json
@@ -96,7 +96,8 @@
     "prepublishOnly": "npm run build",
     "prepare": "npm run build 1>&2",
     "compile:pipelock": "tsx scripts/compile-pipelock.ts",
-    "reconcile-stats": "node scripts/reconcile-rule-count.mjs"
+    "reconcile-stats": "node scripts/reconcile-rule-count.mjs",
+    "count:rules": "node scripts/reconcile-rule-count.mjs --report"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.12.0",

--- a/scripts/reconcile-rule-count.mjs
+++ b/scripts/reconcile-rule-count.mjs
@@ -1,26 +1,46 @@
 #!/usr/bin/env node
 /**
- * reconcile-rule-count.mjs — keep the ATR rule count consistent across the repo.
+ * reconcile-rule-count.mjs — keep the ATR rule numbers consistent across the repo.
  *
- * Ground truth for the rule count is the set of `rules/**\/*.yaml` files in git
- * (every rule file carries a top-level `id: ATR-...`). Two derived caches restate
- * that number:
- *   - stats.json           -> ruleCount.total   (propagated to README / docs / MCP)
- *   - data/stats.json      -> rules.total       (used by the website + tooling)
+ * Ground truth is the set of `rules/**\/*.yaml` files in git (every rule file
+ * carries a top-level `id: ATR-...`). Two derived caches restate those numbers:
+ *   - stats.json           -> ruleCount.*   (propagated to README / docs / MCP)
+ *   - data/stats.json      -> rules.*       (used by the website + tooling)
  *
  * These caches drift whenever rules are added/removed without regenerating them,
  * and were historically fixed by hand with `chore(stats): reconcile ...` commits.
- * This script recomputes the disk count and writes it into BOTH caches so they
- * can never diverge from disk. Run it in CI on every push to main
- * (.github/workflows/reconcile-stats.yml) to close the drift window automatically.
+ * This script recomputes from disk and writes back, so they cannot diverge. Run it
+ * in CI on every push to main (.github/workflows/reconcile-stats.yml).
  *
- * Scope: only the `total` field — the number that is cited and that drifts. The
- * status breakdown (stable/experimental/draft) and byCategory remain owned by the
- * existing generators (sync-stats.ts / sync-stats-from-measurements.ts).
+ * TWO DIFFERENT NUMBERS, BOTH TRUE, AND THE DIFFERENCE MATTERS
+ *   total     — rule FILES on disk. What `find rules -name '*.yaml' | wc -l` says.
+ *   effective — rules the engine will load AND that can fire. A rule with
+ *               `status: draft` or `status: deprecated` is skipped by
+ *               src/engine.ts before the lane gate and before any pattern is
+ *               compiled, so it fires in NO lane, ever. Same for
+ *               `maturity: deprecated` (see src/quality/rule-contract.ts).
+ *
+ *   Quoting `total` as detection coverage overstates it by exactly `inert`. The
+ *   gap was 96 rules when this was added, and no published surface distinguished
+ *   the two. Both are computed here so a citation can be honest without anyone
+ *   re-deriving it by hand:
+ *
+ *     node scripts/reconcile-rule-count.mjs --report
+ *
+ * Scope: the numeric fields only (total, effective, inert, and the status
+ * breakdown). byCategory and the benchmark blocks remain owned by their existing
+ * generators (sync-stats.ts / sync-stats-from-measurements.ts). The status
+ * breakdown is now included because it sits directly beside `effective` —
+ * publishing a fresh `effective` next to a stale `draft` would read as an
+ * arithmetic error, and that breakdown had in fact gone stale (draft: 37 on
+ * record against 96 on disk).
+ *
+ * Stdlib only, no dependencies: reconcile-stats.yml runs it without npm install.
  *
  * Usage:
  *   node scripts/reconcile-rule-count.mjs           # reconcile in place (write)
- *   node scripts/reconcile-rule-count.mjs --check    # report drift, exit 1, write nothing
+ *   node scripts/reconcile-rule-count.mjs --check   # report drift, exit 1, write nothing
+ *   node scripts/reconcile-rule-count.mjs --report  # print the numbers, write nothing
  */
 import { readFileSync, writeFileSync, readdirSync } from 'node:fs';
 import { join, dirname } from 'node:path';
@@ -29,55 +49,200 @@ import { fileURLToPath } from 'node:url';
 const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
 const RULES_DIR = join(REPO_ROOT, 'rules');
 const ID_RE = /^id:\s*ATR-/m;
-const CHECK = process.argv.includes('--check');
 
-/** Count rule files on disk (a rule = a *.yaml carrying a top-level `id: ATR-`). */
-function countRules(dir) {
-  let n = 0;
-  for (const entry of readdirSync(dir, { withFileTypes: true })) {
-    const p = join(dir, entry.name);
-    if (entry.isDirectory()) n += countRules(p);
-    else if (entry.isFile() && entry.name.endsWith('.yaml') && ID_RE.test(readFileSync(p, 'utf8'))) n++;
-  }
-  return n;
+/** Statuses src/engine.ts refuses to evaluate, in either evaluation path. */
+export const INERT_STATUSES = new Set(['draft', 'deprecated']);
+/** A deprecated maturity never fires in any lane (src/quality/rule-contract.ts). */
+export const INERT_MATURITY = 'deprecated';
+/** Canonical maturity ladder; anything else normalizes to 'experimental'. */
+const MATURITIES = new Set(['draft', 'experimental', 'test', 'stable', 'deprecated']);
+
+// ---------------------------------------------------------------------------
+// Counting (pure)
+// ---------------------------------------------------------------------------
+
+/** Read the fields that decide whether a rule can ever fire. Null = not a rule. */
+export function parseRuleMeta(text) {
+  if (!ID_RE.test(text)) return null;
+  const status = /^status:\s*["']?([A-Za-z-]+)/m.exec(text)?.[1] ?? '';
+  const maturity = /^maturity:\s*["']?([A-Za-z-]+)/m.exec(text)?.[1] ?? '';
+  return { status, maturity: MATURITIES.has(maturity) ? maturity : 'experimental' };
 }
 
-const diskCount = countRules(RULES_DIR);
-let drift = false;
+/** Can the engine load this rule AND let it fire in at least one lane? */
+export function isEffective(meta) {
+  return !INERT_STATUSES.has(meta.status) && meta.maturity !== INERT_MATURITY;
+}
+
+/** Walk the rule tree once and derive every number the caches restate. */
+export function computeCounts(dir) {
+  const byStatus = { stable: 0, experimental: 0, draft: 0, deprecated: 0 };
+  const lanes = { enforce: 0, alert: 0, hunt: 0 };
+  let total = 0;
+  let effective = 0;
+
+  const walk = (d) => {
+    for (const entry of readdirSync(d, { withFileTypes: true })) {
+      const p = join(d, entry.name);
+      if (entry.isDirectory()) {
+        walk(p);
+        continue;
+      }
+      if (!entry.isFile() || !entry.name.endsWith('.yaml')) continue;
+      const meta = parseRuleMeta(readFileSync(p, 'utf8'));
+      if (meta === null) continue;
+      total++;
+      if (meta.status in byStatus) byStatus[meta.status]++;
+      if (!isEffective(meta)) continue;
+      effective++;
+      lanes.hunt++;
+      if (meta.maturity === 'stable') lanes.enforce++;
+      if (meta.maturity === 'stable' || meta.maturity === 'test') lanes.alert++;
+    }
+  };
+  walk(dir);
+  return { total, effective, inert: total - effective, byStatus, lanes };
+}
+
+// ---------------------------------------------------------------------------
+// Surgical JSON editing
+// ---------------------------------------------------------------------------
 
 /**
- * Reconcile one cache file's `total` to the disk count.
- * Edits only the total's digits in place (surgical) so the diff is a single line
- * and the file's existing formatting is preserved exactly.
+ * Character range of a named block's braces. Edits stay inside it so a field
+ * name that also appears elsewhere in the file cannot be hit by accident.
  */
-function reconcile(relPath, blockKey) {
+function blockRange(text, blockKey) {
+  const header = new RegExp(`"${blockKey}"\\s*:\\s*\\{`).exec(text);
+  if (!header) return null;
+  const open = header.index + header[0].length - 1;
+  let depth = 0;
+  for (let i = open; i < text.length; i++) {
+    if (text[i] === '{') depth++;
+    else if (text[i] === '}' && --depth === 0) return { open, close: i };
+  }
+  return null;
+}
+
+/**
+ * Set one numeric field inside a block, preserving the file's formatting so the
+ * diff stays a single line. The field is replaced when present, and inserted
+ * directly after `anchorField` when absent — callers chain the anchor so a run
+ * of inserts lands in the order they were requested rather than reversed.
+ * Returns null when the block or the anchor is missing; callers must treat that
+ * as fatal, never as "nothing to do".
+ */
+export function setBlockNumber(text, blockKey, field, value, anchorField = 'total') {
+  const range = blockRange(text, blockKey);
+  if (!range) return null;
+  const body = text.slice(range.open, range.close);
+  const splice = (nextBody) => text.slice(0, range.open) + nextBody + text.slice(range.close);
+
+  const existing = new RegExp(`("${field}"\\s*:\\s*)(-?\\d+)`).exec(body);
+  if (existing) {
+    const before = Number(existing[2]);
+    if (before === value) return { text, before, changed: false };
+    const head = body.slice(0, existing.index) + existing[1] + value;
+    return { text: splice(head + body.slice(existing.index + existing[0].length)), before, changed: true };
+  }
+
+  // Insert immediately after the anchor's digits and BEFORE whatever follows —
+  // that way the separator already in the file (a comma, or the newline before
+  // the closing brace) still terminates the new field correctly.
+  const anchor = new RegExp(`\\n(\\s*)"${anchorField}"\\s*:\\s*-?\\d+`).exec(body);
+  if (!anchor) return null;
+  const at = anchor.index + anchor[0].length;
+  const inserted = `${body.slice(0, at)},\n${anchor[1]}"${field}": ${value}${body.slice(at)}`;
+  return { text: splice(inserted), before: null, changed: true };
+}
+
+// ---------------------------------------------------------------------------
+// Reconcile
+// ---------------------------------------------------------------------------
+
+const CHECK = process.argv.includes('--check');
+const REPORT = process.argv.includes('--report');
+
+/** Fields written into each cache. stats.json also restates the status split. */
+function fieldsFor(blockKey, counts) {
+  const shared = { total: counts.total, effective: counts.effective, inert: counts.inert };
+  return blockKey === 'ruleCount' ? { ...shared, ...counts.byStatus } : shared;
+}
+
+function reconcile(relPath, blockKey, counts, log) {
   const abs = join(REPO_ROOT, relPath);
-  const text = readFileSync(abs, 'utf8');
-  const json = JSON.parse(text);
-  const block = json[blockKey] || {};
-  const before = block.total;
-  if (before === diskCount) {
-    console.log(`[reconcile] ${relPath}: ${blockKey}.total=${before} — in sync`);
-    return;
+  let text = readFileSync(abs, 'utf8');
+  let drift = false;
+  // Each newly inserted field becomes the anchor for the next, so a run of
+  // inserts reads in request order (total, effective, inert) rather than
+  // reversed. Fields that already exist are edited in place and leave the
+  // anchor where it was.
+  let anchor = 'total';
+
+  for (const [field, value] of Object.entries(fieldsFor(blockKey, counts))) {
+    const result = setBlockNumber(text, blockKey, field, value, anchor);
+    anchor = field;
+    if (result === null) {
+      console.error(
+        `[reconcile] FATAL: could not locate ${blockKey}.${field} (or the "total" anchor) in ${relPath}`,
+      );
+      process.exit(2);
+    }
+    if (!result.changed) {
+      log.push(`[reconcile] ${relPath}: ${blockKey}.${field}=${value} — in sync`);
+      continue;
+    }
+    drift = true;
+    const from = result.before === null ? 'absent' : result.before;
+    log.push(
+      `[reconcile] ${relPath}: ${blockKey}.${field} ${from} -> ${value}${CHECK ? ' (drift)' : ' (fixed)'}`,
+    );
+    text = result.text;
   }
-  drift = true;
-  console.log(`[reconcile] ${relPath}: ${blockKey}.total ${before} -> ${diskCount}${CHECK ? ' (drift)' : ' (fixed)'}`);
-  if (CHECK) return;
-  // Surgical replace: the "total": N inside the target block (total is the first key).
-  const re = new RegExp(`("${blockKey}"\\s*:\\s*\\{[^{}]*?"total"\\s*:\\s*)${before}\\b`);
-  const next = text.replace(re, `$1${diskCount}`);
-  if (next === text) {
-    console.error(`[reconcile] FATAL: could not locate ${blockKey}.total in ${relPath}`);
-    process.exit(2);
-  }
-  writeFileSync(abs, next);
+
+  if (drift && !CHECK) writeFileSync(abs, text);
+  return drift;
 }
 
-reconcile('stats.json', 'ruleCount');
-reconcile('data/stats.json', 'rules');
-
-console.log(`[reconcile] disk rule count = ${diskCount}`);
-if (CHECK && drift) {
-  console.error('[reconcile] FAIL: stats caches drift from disk. Fix: node scripts/reconcile-rule-count.mjs');
-  process.exit(1);
+function printReport(counts) {
+  const byStatus = Object.entries(counts.byStatus)
+    .map(([k, v]) => `${k}=${v}`)
+    .join(' ');
+  console.log(`rule files on disk        : ${counts.total}`);
+  console.log(`effective (can ever fire) : ${counts.effective}`);
+  console.log(`inert (never fires)       : ${counts.inert}   [status draft/deprecated, or maturity deprecated]`);
+  console.log(`  by status               : ${byStatus}`);
+  console.log(`lane ceilings (effective) : enforce=${counts.lanes.enforce} alert=${counts.lanes.alert} hunt=${counts.lanes.hunt}`);
+  console.log('');
+  console.log('Cite `total` for corpus size and `effective` for detection coverage.');
+  console.log('They are different numbers; quoting total as coverage overstates it by `inert`.');
 }
+
+export function main() {
+  const counts = computeCounts(RULES_DIR);
+  if (REPORT) {
+    printReport(counts);
+    return 0;
+  }
+
+  const log = [];
+  const drifted = [
+    reconcile('stats.json', 'ruleCount', counts, log),
+    reconcile('data/stats.json', 'rules', counts, log),
+  ];
+  console.log(log.join('\n'));
+  console.log(
+    `[reconcile] disk: ${counts.total} rule files, ${counts.effective} effective, ${counts.inert} inert`,
+  );
+
+  if (CHECK && drifted.some(Boolean)) {
+    console.error('[reconcile] FAIL: stats caches drift from disk. Fix: node scripts/reconcile-rule-count.mjs');
+    return 1;
+  }
+  return 0;
+}
+
+const INVOKED_DIRECTLY =
+  process.argv[1] !== undefined && process.argv[1].endsWith('reconcile-rule-count.mjs');
+
+if (INVOKED_DIRECTLY) process.exitCode = main();

--- a/tests/reconcile-rule-count.test.ts
+++ b/tests/reconcile-rule-count.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Tests for scripts/reconcile-rule-count.mjs — the effective-rule-count
+ * computation and the surgical stats edit that publishes it.
+ *
+ * WHY "EFFECTIVE" EXISTS
+ *   `total` counts rule FILES. src/engine.ts skips `status: draft` and
+ *   `status: deprecated` in both evaluation paths, so those files fire in no
+ *   lane, ever, and counting them as detection coverage overstates it. The two
+ *   numbers are now computed together and both published, because the honest
+ *   answer to "how many rules does ATR have" needs both.
+ *
+ * The surgical-edit tests run against the REAL stats.json / data/stats.json
+ * contents (read-only, never written): a formatting-preserving regex edit is
+ * only trustworthy against the file it will actually run on.
+ */
+
+import { describe, it, expect } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync } from "node:fs";
+import { join, resolve, dirname } from "node:path";
+import { tmpdir } from "node:os";
+import { fileURLToPath } from "node:url";
+// @ts-expect-error -- stdlib-only .mjs script, deliberately untyped (it runs in
+// CI without npm install, so it must not depend on the TypeScript toolchain).
+import {
+  parseRuleMeta,
+  isEffective,
+  computeCounts,
+  setBlockNumber,
+} from "../scripts/reconcile-rule-count.mjs";
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+function rule(id: string, status: string, maturity: string): string {
+  return `id: ${id}\ntitle: fixture\nstatus: ${status}\nmaturity: ${maturity}\n`;
+}
+
+describe("parseRuleMeta", () => {
+  it("reads unquoted status and maturity", () => {
+    expect(parseRuleMeta(rule("ATR-2026-00001", "experimental", "test"))).toEqual({
+      status: "experimental",
+      maturity: "test",
+    });
+  });
+
+  it("reads quoted values (both spellings exist in the corpus)", () => {
+    const text = 'id: ATR-2026-00001\nstatus: "draft"\nmaturity: "stable"\n';
+    expect(parseRuleMeta(text)).toEqual({ status: "draft", maturity: "stable" });
+  });
+
+  it("returns null for a file that is not a rule", () => {
+    expect(parseRuleMeta("title: just some yaml\n")).toBeNull();
+  });
+
+  it("normalizes an unknown maturity to experimental, never to stable", () => {
+    expect(parseRuleMeta(rule("ATR-2026-00001", "experimental", "needs-human-poc"))).toEqual({
+      status: "experimental",
+      maturity: "experimental",
+    });
+  });
+});
+
+describe("isEffective", () => {
+  it("excludes draft — the engine never evaluates it", () => {
+    expect(isEffective({ status: "draft", maturity: "stable" })).toBe(false);
+  });
+
+  it("excludes deprecated status", () => {
+    expect(isEffective({ status: "deprecated", maturity: "stable" })).toBe(false);
+  });
+
+  it("excludes a deprecated maturity, which fires in no lane", () => {
+    expect(isEffective({ status: "experimental", maturity: "deprecated" })).toBe(false);
+  });
+
+  it("includes a live rule at any firing maturity", () => {
+    expect(isEffective({ status: "experimental", maturity: "test" })).toBe(true);
+    expect(isEffective({ status: "stable", maturity: "stable" })).toBe(true);
+  });
+});
+
+describe("computeCounts", () => {
+  it("separates file count from effective count and reports lane ceilings", () => {
+    const root = mkdtempSync(join(tmpdir(), "atr-counts-"));
+    mkdirSync(join(root, "prompt-injection"), { recursive: true });
+    const put = (name: string, text: string) =>
+      writeFileSync(join(root, "prompt-injection", name), text, "utf-8");
+
+    put("a.yaml", rule("ATR-2026-00001", "stable", "stable"));
+    put("b.yaml", rule("ATR-2026-00002", "experimental", "test"));
+    put("c.yaml", rule("ATR-2026-00003", "draft", "stable"));
+    put("d.yaml", rule("ATR-2026-00004", "deprecated", "test"));
+    put("e.yaml", rule("ATR-2026-00005", "experimental", "experimental"));
+    put("not-a-rule.yaml", "title: no id here\n");
+
+    const counts = computeCounts(root);
+    rmSync(root, { recursive: true, force: true });
+
+    expect(counts.total).toBe(5);
+    expect(counts.effective).toBe(3);
+    expect(counts.inert).toBe(2);
+    expect(counts.byStatus).toEqual({ stable: 1, experimental: 2, draft: 1, deprecated: 1 });
+    // The draft rule claims maturity: stable but can never reach the enforce lane.
+    expect(counts.lanes).toEqual({ enforce: 1, alert: 2, hunt: 3 });
+  });
+
+  it("total always equals effective + inert", () => {
+    const counts = computeCounts(join(REPO_ROOT, "rules"));
+    expect(counts.effective + counts.inert).toBe(counts.total);
+    expect(counts.effective).toBeLessThanOrEqual(counts.total);
+  });
+});
+
+describe("setBlockNumber", () => {
+  const doc = ['{', '  "rules": {', '    "total": 10,', '    "categories": 3', "  }", "}"].join("\n");
+
+  it("replaces an existing field and keeps the file parseable", () => {
+    const out = setBlockNumber(doc, "rules", "total", 42);
+    expect(out.changed).toBe(true);
+    expect(out.before).toBe(10);
+    expect(JSON.parse(out.text).rules.total).toBe(42);
+  });
+
+  it("inserts a missing field after total", () => {
+    const out = setBlockNumber(doc, "rules", "effective", 8);
+    expect(out.changed).toBe(true);
+    expect(out.before).toBeNull();
+    const parsed = JSON.parse(out.text);
+    expect(parsed.rules.effective).toBe(8);
+    expect(parsed.rules.categories).toBe(3);
+  });
+
+  it("reports no change when the value already matches", () => {
+    const out = setBlockNumber(doc, "rules", "total", 10);
+    expect(out.changed).toBe(false);
+    expect(out.text).toBe(doc);
+  });
+
+  it("returns null for an absent block instead of silently doing nothing", () => {
+    expect(setBlockNumber(doc, "noSuchBlock", "total", 1)).toBeNull();
+  });
+
+  it("does not touch a same-named field in a different block", () => {
+    const two = ['{', '  "a": { "total": 1 },', '  "b": { "total": 2 }', "}"].join("\n");
+    const out = setBlockNumber(two, "b", "total", 99);
+    const parsed = JSON.parse(out.text);
+    expect(parsed.a.total).toBe(1);
+    expect(parsed.b.total).toBe(99);
+  });
+
+  it("is idempotent", () => {
+    const once = setBlockNumber(doc, "rules", "effective", 8).text;
+    const twice = setBlockNumber(once, "rules", "effective", 8);
+    expect(twice.changed).toBe(false);
+    expect(twice.text).toBe(once);
+  });
+});
+
+describe("surgical edit against the real stats files (read-only)", () => {
+  const cases = [
+    { path: "stats.json", block: "ruleCount" },
+    { path: "data/stats.json", block: "rules" },
+  ];
+
+  for (const { path, block } of cases) {
+    it(`inserts effective into ${path} without corrupting it`, () => {
+      const original = readFileSync(join(REPO_ROOT, path), "utf-8");
+      const out = setBlockNumber(original, block, "effective", 672);
+      expect(out).not.toBeNull();
+      const parsed = JSON.parse(out.text);
+      const before = JSON.parse(original);
+      expect(parsed[block].effective).toBe(672);
+      // Everything else survives byte-for-byte in meaning.
+      expect({ ...parsed[block], effective: undefined }).toEqual({
+        ...before[block],
+        effective: undefined,
+      });
+      expect(Object.keys(parsed)).toEqual(Object.keys(before));
+    });
+  }
+});


### PR DESCRIPTION
## What

Teaches the repo to report two rule numbers instead of one, and keeps both caches honest automatically.

- `scripts/reconcile-rule-count.mjs` — computes `total` (rule files on disk), `effective` (rules the engine loads AND that can fire in at least one lane), `inert = total - effective`, plus the per-lane ceilings. Writes total/effective/inert into `stats.json` (`ruleCount`) and `data/stats.json` (`rules`), and refreshes the status breakdown that sits beside them. New `--report` mode prints the numbers and writes nothing.
- `tests/reconcile-rule-count.test.ts` — 18 unit tests over the counting logic and the surgical JSON edit, including a read-only pass against the real `stats.json` / `data/stats.json`.
- `package.json` — `npm run count:rules` (the `--report` mode).
- `.github/workflows/reconcile-stats.yml` — the auto-reconcile commit message now carries both numbers: `(768 rule files, 670 effective)` instead of `(768 rules)`.
- `docs/QUALITY-GATE.md` — a "Counting rules honestly" section stating which number means what.

No rules and no engine code are touched.

## Why

`status: draft` does not mean "a weaker rule". It means the rule does not exist at runtime. `src/engine.ts` skips draft and deprecated rules in both evaluation paths — line 382 (sync) and line 533 (async) — before the lane gate and before any pattern is compiled. The header comment at `src/engine.ts:218` already says it outright: "Deprecated/draft rules are always skipped regardless of lane." So a draft rule fires in no lane, ever, including `hunt`.

Nothing published distinguished the two. `total` is the number that appears in the README, the docs, the MCP surface and the website, and on current main it overstates detection coverage by 98 rules.

The breakdown that would have exposed the gap had itself gone stale: `stats.json` recorded `draft: 37` while disk carries 96. That is what a hand-maintained number does, which is exactly the drift `reconcile-stats.yml` exists to close — it just was not closing this part of it.

## Evidence

Run against this branch's tree (768 rule files, i.e. main as of `0eeb99f`):

```
$ npm run count:rules
rule files on disk        : 768
effective (can ever fire) : 670
inert (never fires)       : 98   [status draft/deprecated, or maturity deprecated]
  by status               : stable=59 experimental=611 draft=96 deprecated=2
lane ceilings (effective) : enforce=105 alert=587 hunt=670
```

Unit tests:

```
$ npx vitest run tests/reconcile-rule-count.test.ts
 tests/reconcile-rule-count.test.ts (18 tests) 36ms
 Test Files  1 passed (1)
      Tests  18 passed (18)
```

Write path, executed on a throwaway copy of this tree, then re-checked for idempotency:

```
$ node scripts/reconcile-rule-count.mjs
[reconcile] stats.json: ruleCount.total=768 - in sync
[reconcile] stats.json: ruleCount.effective absent -> 670 (fixed)
[reconcile] stats.json: ruleCount.inert absent -> 98 (fixed)
[reconcile] stats.json: ruleCount.experimental 554 -> 611 (fixed)
[reconcile] stats.json: ruleCount.draft 37 -> 96 (fixed)
[reconcile] data/stats.json: rules.effective absent -> 670 (fixed)
[reconcile] data/stats.json: rules.inert absent -> 98 (fixed)

$ node scripts/reconcile-rule-count.mjs --check   # exit 0, every field in sync
```

Both files still parse, every pre-existing key survives with its value and position, and `stats.json`'s own invariant holds after the fix: 59 + 611 + 96 + 2 = 768.

## Risk

Low, and deliberately scoped so it can land first.

- No detection behavior change. `rules/` and `src/` are untouched; the engine loads exactly the same rules before and after.
- No publish trigger. This PR touches no rule file, so `publish-on-rules-merge.yml` does not fire and no npm version is cut.
- Existing consumers keep working. `effective` and `inert` are added fields; `total` keeps its meaning and its value, so `sync-stats.ts` and everything downstream of `ruleCount.total` / `rules.total` read the same number they read today.
- Expected side effect after merge: the next push to main that touches `rules/**` runs `reconcile-stats.yml`, which will commit the corrected numbers into `stats.json` and `data/stats.json` (`draft: 37 -> 96`, plus the new `effective` / `inert` fields). That commit is the point of the change, not a surprise from it.
- The one sharp edge is the formatting-preserving JSON edit, which is why it is exported and tested against the real files rather than a fixture: a missing block or missing anchor returns null and the script exits 2 instead of silently writing nothing.
