### PR TITLE
feat(ci): ratchet rule regexes against real RE2, verified by differential execution

### DIFF
--- a/.github/workflows/re2-portability.yml
+++ b/.github/workflows/re2-portability.yml
@@ -1,0 +1,149 @@
+name: RE2 portability
+
+# Downstream consumers compile ATR detection regexes with RE2-family engines
+# (Go `regexp`, Rust `regex`, and every Sigma backend built on them). RE2 is a
+# finite-automaton engine: it rejects lookaround, backreferences, atomic groups
+# and possessive quantifiers outright, spells \uXXXX as \x{XXXX}, and caps
+# repeat bounds at 1000. A rule using those constructs is silently dropped by
+# the consumer -- scripts/generate-sigma.py copies regexes through verbatim and
+# never compiles them, so a broken rule exports "successfully" and only fails
+# once someone downstream feeds it to a real RE2 backend.
+#
+# This gate is a RATCHET, not a hard gate. Part of the corpus predates the
+# requirement, and most of that debt needs a genuine refactor (lookaround has
+# no RE2 spelling). Failing every PR until the backlog clears would stop all
+# rule work, so -- exactly like maturity-fp-gate.yml -- this blocks NEW damage
+# and lets the existing backlog drain on its own schedule. The accepted
+# exceptions live in data/re2-portability-baseline.json.
+#
+# It runs on push to main as well as on PRs, and compares the WHOLE corpus
+# rather than a PR diff, because rules also land here through doors that never
+# open a pull request (the CVE collector and auto-crystallize commit straight
+# to main). A diff-scoped gate cannot see those.
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "rules/**"
+      - "data/re2-portability-baseline.json"
+      - "scripts/audit-re2-portability.ts"
+      - "scripts/gate-re2-portability.ts"
+      - "scripts/verify-re2-equivalence.ts"
+      - "data/re2-equivalence.json"
+      - ".github/workflows/re2-portability.yml"
+  push:
+    branches: [main]
+    paths:
+      - "rules/**"
+      - "data/re2-portability-baseline.json"
+      - "scripts/audit-re2-portability.ts"
+      - "scripts/gate-re2-portability.ts"
+      - "scripts/verify-re2-equivalence.ts"
+      - "data/re2-equivalence.json"
+
+permissions:
+  contents: read
+
+jobs:
+  re2-portability:
+    name: Rule regexes must stay RE2 portable
+    runs-on: ubuntu-latest
+    steps:
+      # No fetch-depth: 0 -- the gate compares against a committed baseline,
+      # not against a base ref, so a shallow checkout is enough.
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version: "22"
+
+      # Go ships preinstalled on ubuntu-latest, but pin it explicitly: the
+      # oracle below is the only thing that makes this gate trustworthy, and it
+      # should not depend on an undeclared property of the runner image.
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.25"
+          cache: false
+
+      - name: Install dependencies
+        run: npm ci
+
+      # --verify-re2 compiles every pattern with Go's regexp package, which IS
+      # RE2, so the verdict is measured rather than inferred from a hand-written
+      # scanner. That distinction is not academic: the scanner had two real
+      # blind spots that only this oracle caught.
+      - name: Audit rule regexes against RE2
+        run: npx tsx scripts/audit-re2-portability.ts --json --verify-re2 > re2-audit.json
+
+      # Fails when a rule outside the baseline is not RE2 portable, when a
+      # baselined rule gets worse, or when the scanner and real RE2 disagree.
+      # --require-oracle makes a missing Go toolchain an error rather than a
+      # silent downgrade to static analysis, so a PASS always means "real RE2
+      # compiled every pattern". Exit 1 means an author must act; exit 2 means
+      # the gate could not run.
+      - name: Portability ratchet
+        run: npx tsx scripts/gate-re2-portability.ts --audit re2-audit.json --require-oracle
+
+      # data/re2-equivalence.json records which mechanically-rewritten patterns
+      # actually reproduce their original match vector under RE2, and
+      # scripts/generate-sigma.py tags atr.portability.* from it. A stale file
+      # therefore mislabels a rule as runnable when it is not -- the exact
+      # silent failure this workflow exists to prevent -- so recompute it and
+      # require the committed copy to still describe the same rules.
+      #
+      # Compare the TAGGING VERDICT only: which rule, at which condition, for
+      # which cause. That is precisely what generate-sigma.py reads to choose
+      # between atr.portability.re2-ok and re2-blocked, so it is the only part
+      # whose staleness can mislabel a rule.
+      #
+      # Deliberately NOT compared: generatedAt, and the battery magnitudes
+      # (`inputs`, `mismatches`, the `examples` indices). The input battery is
+      # built from every test_cases entry in the WHOLE corpus
+      # (verify-re2-equivalence.ts loadCorpusTestInputs), so adding a single
+      # rule shifts those numbers on every entry while changing nothing about
+      # which rule is portable. Diffing them would red-flag every rule PR and
+      # every auto-crystallize push to main -- a gate that cries wolf on normal
+      # work gets ignored or removed, and then the real mislabel walks through.
+      - name: Equivalence artifact is current
+        run: |
+          npx tsx scripts/verify-re2-equivalence.ts \
+            --write-equivalence /tmp/re2-equivalence.fresh.json > /dev/null || true
+          python3 - <<'PY'
+          import json, sys
+          def load(p):
+              with open(p, encoding="utf-8") as fh:
+                  return json.load(fh)
+          def tagging_verdict(d):
+              return {
+                  rule_id: sorted(
+                      [entry.get("location", ""), sorted(entry.get("causes", []))]
+                      for entry in entries
+                  )
+                  for rule_id, entries in d.get("divergentRules", {}).items()
+              }
+          committed, fresh = load("data/re2-equivalence.json"), load("/tmp/re2-equivalence.fresh.json")
+          want, got = tagging_verdict(committed), tagging_verdict(fresh)
+          if want != got:
+              print("data/re2-equivalence.json is stale. Regenerate and commit:")
+              print("  npx tsx scripts/verify-re2-equivalence.ts --write-equivalence data/re2-equivalence.json")
+              for rule_id in sorted(set(want) | set(got)):
+                  if want.get(rule_id) != got.get(rule_id):
+                      print(f"  {rule_id}: committed={want.get(rule_id)} actual={got.get(rule_id)}")
+              sys.exit(1)
+          print(
+              "equivalence artifact current: "
+              f"{fresh.get('re2Equivalent')}/{fresh.get('patternsRewritten')} rewritten patterns "
+              f"verified portable, {len(got)} rule(s) measured divergent under RE2"
+          )
+          PY
+
+      # The full report, including every accepted exception, so a failing run
+      # can be diagnosed without re-running the audit locally.
+      - name: Upload audit report
+        if: always()
+        uses: actions/upload-artifact@v5
+        with:
+          name: re2-portability-audit
+          path: re2-audit.json
+          retention-days: 14

--- a/data/re2-equivalence.json
+++ b/data/re2-equivalence.json
@@ -1,0 +1,92 @@
+{
+  "generatedAt": "2026-07-31T07:35:10.519Z",
+  "note": "Patterns whose mechanical RE2 escape rewrite compiles under RE2 but does NOT reproduce the original JavaScript match vector. Produced by scripts/verify-re2-equivalence.ts (differential execution, not static analysis). Consumed by scripts/generate-sigma.py so a rule that would silently mis-detect on an RE2 backend is tagged, not shipped as clean.",
+  "patternsRewritten": 54,
+  "re2Equivalent": 48,
+  "re2Divergent": 6,
+  "divergentRules": {
+    "ATR-2026-00276": [
+      {
+        "location": "detection.conditions[0].value",
+        "mismatches": 11,
+        "inputs": 13611,
+        "causes": [
+          "any-character constructs count differently: JavaScript without the u flag counts UTF-16 code units (an astral character is two), RE2 counts runes (one), so bounded repeats disagree"
+        ],
+        "examples": [
+          "input#7738 \"\\u{200C}\\u{DC41}23\\u{1F600}^\\u{205F}\\u{1F600}\\u{1F600}c0x\\u{205F}\\u{2061}{b[\\u{200A}]^\\u{2060}\\u{200C}\" -> 0 vs 1",
+          "input#8068 \"[\\u{2060}}\\u{200B}?n)xxu\\u{E0041}?c^\\u{200A}uc )0}\\u{E0041}^\\u{A0}\\u{2060}0n\\u{E0041}0,?\\u{9}(\\u{2060}\\u{DB40}\\u{2003}^\\u{A}\\u{A}\" -> 0 vs 1"
+        ]
+      },
+      {
+        "location": "detection.conditions[1].value",
+        "mismatches": 8,
+        "inputs": 13611,
+        "causes": [
+          "any-character constructs count differently: JavaScript without the u flag counts UTF-16 code units (an astral character is two), RE2 counts runes (one), so bounded repeats disagree"
+        ],
+        "examples": [
+          "input#7730 \" \\u{2061}\\u{200B},^\\u{9}b)\\u{A}2,\\u{200C}\\u{E0041}{\\u{A0}{\\u{1F600}0uu:\\u{1F600},\\u{200D}{\\u{205F}?2\\u{200D}^\\u{200B}b \\u{200C}\" -> 0 vs 1",
+          "input#7789 \"[c\\u{200C}0\\u{200A}\\u{DB40}\\u{2061}\\u{1F600}\\u{9}u3\\u{1F600}{\\u{1F600}n2\\u{E0041}{[\\u{DB40} b\\u{200B}\\u{9}\\u{E0041}\\u{205F}x\\u{2060}6\\u{9}u:\" -> 0 vs 1"
+        ]
+      }
+    ],
+    "ATR-2026-00308": [
+      {
+        "location": "detection.conditions[1].value",
+        "mismatches": 57,
+        "inputs": 13934,
+        "causes": [
+          "\\s/\\S differ by dialect: JavaScript includes Unicode spaces (U+00A0, U+2003, U+3000, ...), RE2 restricts them to ASCII [\\t\\n\\f\\r ]",
+          "any-character constructs count differently: JavaScript without the u flag counts UTF-16 code units (an astral character is two), RE2 counts runes (one), so bounded repeats disagree"
+        ],
+        "examples": [
+          "input#7806 \"\\u{1AD7}6[\\u{FE2E}F\\u{36E}\\u{1AFF}}\\u{1AFE}\\u{36F}\\u{E0041} \\u{20E7}2\\u{1AFE}-8Eu}\\u{A}\" -> 0 vs 1",
+          "input#7877 \"1\\u{2FF}\\u{1AB0}\\u{36E}]\\u{20FF} \\u{1DFF}B\\u{1E00}\\u{20D0}B6\\u{DB40}]\\u{301}\\u{FE30}u\\u{36F}}\\u{1DFF}{]\\u{1AFE}\\u{300}\\u{1F600}[\\u{337}\\u{FE21}\\u{36E}\\u{DC41}\\u{FE2F},\\u{1DDF}(\" -> 0 vs 1"
+        ]
+      }
+    ],
+    "ATR-2026-00309": [
+      {
+        "location": "detection.conditions[1].value",
+        "mismatches": 28,
+        "inputs": 13653,
+        "causes": [
+          "\\s/\\S differ by dialect: JavaScript includes Unicode spaces (U+00A0, U+2003, U+3000, ...), RE2 restricts them to ASCII [\\t\\n\\f\\r ]"
+        ],
+        "examples": [
+          "input#7768 \"\\u{28FF}\\u{A} \\u{2801}\\u{2003}\\u{2800}\\u{28FE}\\u{287F}\\u{DB40}[[-\" -> 1 vs 0",
+          "input#8380 \"F{Fx\\u{28FE}+\\u{E0041},)\\u{2900}]}\\u{DC41}\\u{2800}\\u{A0}\\u{2801}\\u{2003}\\u{287F}\\u{A0}]\\u{2003}\\u{1F600}+8x\\u{2800}\\u{2900}([{\\u{27FF}\\u{A0}([0\\u{E0041}\\u{2003}\" -> 1 vs 0"
+        ]
+      }
+    ],
+    "ATR-2026-02010": [
+      {
+        "location": "detection.conditions[0].value",
+        "mismatches": 14,
+        "inputs": 14056,
+        "causes": [
+          "\\s/\\S differ by dialect: JavaScript includes Unicode spaces (U+00A0, U+2003, U+3000, ...), RE2 restricts them to ASCII [\\t\\n\\f\\r ]"
+        ],
+        "examples": [
+          "input#8497 \"\\u{A0}\" -> 1 vs 0",
+          "input#8828 \"\\u{A0}\\u{1F3FC}\" -> 1 vs 0"
+        ]
+      }
+    ],
+    "ATR-2026-00129": [
+      {
+        "location": "detection.conditions[0].value",
+        "mismatches": 30,
+        "inputs": 13643,
+        "causes": [
+          "pattern names UTF-16 surrogate codepoints (U+D800-U+DFFF); RE2 has no surrogates and folds them to U+FFFD, so the ported pattern compiles but can never match"
+        ],
+        "examples": [
+          "input#4358 \"Please summarize this: \\u{E0049}\\u{E006E}\\u{E0073}\\u{E0074}\\u{E0065}\\u{E0061}\\u{E0064}\\u{E002C}\\u{E0020}\\u{E0072}\\u{E0065}\\u{E0070}\\u{DB40}\" (+27 chars) -> 1 vs 0",
+          "input#4359 \"Normal visible text \\u{E0049}\\u{E0067}\\u{E006E}\\u{E006F}\\u{E0072}\\u{E0065}\\u{E0020}\\u{E0061}\\u{E006C}\\u{E006C} and mor\" (+14 chars) -> 1 vs 0"
+        ]
+      }
+    ]
+  }
+}

--- a/data/re2-portability-baseline.json
+++ b/data/re2-portability-baseline.json
@@ -1,0 +1,696 @@
+{
+  "generatedAt": "2026-07-28T07:46:55.390Z",
+  "note": "Rules whose detection regexes cannot be compiled by RE2 (Go regexp, Rust regex, Sigma backends built on them). Ratchet only -- new entries must be fixed, not added. See scripts/gate-re2-portability.ts.",
+  "corpus": {
+    "rules": 768,
+    "regexPatterns": 3254
+  },
+  "knownNotPortable": {
+    "ATR-2026-00001": {
+      "patterns": 5,
+      "classes": [
+        "lookaround",
+        "unicodeEscape"
+      ]
+    },
+    "ATR-2026-00002": {
+      "patterns": 2,
+      "classes": [
+        "unicodeEscape"
+      ]
+    },
+    "ATR-2026-00004": {
+      "patterns": 1,
+      "classes": [
+        "lookaround"
+      ]
+    },
+    "ATR-2026-00010": {
+      "patterns": 1,
+      "classes": [
+        "lookaround"
+      ]
+    },
+    "ATR-2026-00011": {
+      "patterns": 1,
+      "classes": [
+        "unicodeEscape"
+      ]
+    },
+    "ATR-2026-00012": {
+      "patterns": 1,
+      "classes": [
+        "lookaround"
+      ]
+    },
+    "ATR-2026-00030": {
+      "patterns": 4,
+      "classes": [
+        "lookaround"
+      ]
+    },
+    "ATR-2026-00040": {
+      "patterns": 1,
+      "classes": [
+        "lookaround"
+      ]
+    },
+    "ATR-2026-00051": {
+      "patterns": 1,
+      "classes": [
+        "lookaround"
+      ]
+    },
+    "ATR-2026-00052": {
+      "patterns": 1,
+      "classes": [
+        "lookaround"
+      ]
+    },
+    "ATR-2026-00060": {
+      "patterns": 1,
+      "classes": [
+        "lookaround"
+      ]
+    },
+    "ATR-2026-00063": {
+      "patterns": 2,
+      "classes": [
+        "lookaround"
+      ]
+    },
+    "ATR-2026-00066": {
+      "patterns": 1,
+      "classes": [
+        "lookaround"
+      ]
+    },
+    "ATR-2026-00070": {
+      "patterns": 1,
+      "classes": [
+        "lookaround"
+      ]
+    },
+    "ATR-2026-00080": {
+      "patterns": 1,
+      "classes": [
+        "unicodeEscape"
+      ]
+    },
+    "ATR-2026-00086": {
+      "patterns": 4,
+      "classes": [
+        "unicodeEscape"
+      ]
+    },
+    "ATR-2026-00093": {
+      "patterns": 1,
+      "classes": [
+        "lookaround"
+      ]
+    },
+    "ATR-2026-00098": {
+      "patterns": 1,
+      "classes": [
+        "lookaround"
+      ]
+    },
+    "ATR-2026-00099": {
+      "patterns": 2,
+      "classes": [
+        "lookaround"
+      ]
+    },
+    "ATR-2026-00111": {
+      "patterns": 1,
+      "classes": [
+        "lookaround"
+      ]
+    },
+    "ATR-2026-00114": {
+      "patterns": 1,
+      "classes": [
+        "lookaround"
+      ]
+    },
+    "ATR-2026-00115": {
+      "patterns": 1,
+      "classes": [
+        "lookaround"
+      ]
+    },
+    "ATR-2026-00120": {
+      "patterns": 3,
+      "classes": [
+        "lookaround",
+        "unicodeEscape"
+      ]
+    },
+    "ATR-2026-00123": {
+      "patterns": 2,
+      "classes": [
+        "lookaround"
+      ]
+    },
+    "ATR-2026-00129": {
+      "patterns": 2,
+      "classes": [
+        "unicodeEscape"
+      ]
+    },
+    "ATR-2026-00135": {
+      "patterns": 1,
+      "classes": [
+        "lookaround"
+      ]
+    },
+    "ATR-2026-00149": {
+      "patterns": 2,
+      "classes": [
+        "lookaround"
+      ]
+    },
+    "ATR-2026-00161": {
+      "patterns": 1,
+      "classes": [
+        "lookaround"
+      ]
+    },
+    "ATR-2026-00202": {
+      "patterns": 1,
+      "classes": [
+        "unicodeEscape"
+      ]
+    },
+    "ATR-2026-00258": {
+      "patterns": 4,
+      "classes": [
+        "unicodeEscape"
+      ]
+    },
+    "ATR-2026-00270": {
+      "patterns": 2,
+      "classes": [
+        "lookaround"
+      ]
+    },
+    "ATR-2026-00276": {
+      "patterns": 4,
+      "classes": [
+        "unicodeEscape"
+      ]
+    },
+    "ATR-2026-00284": {
+      "patterns": 1,
+      "classes": [
+        "lookaround"
+      ]
+    },
+    "ATR-2026-00286": {
+      "patterns": 1,
+      "classes": [
+        "other"
+      ]
+    },
+    "ATR-2026-00288": {
+      "patterns": 1,
+      "classes": [
+        "lookaround"
+      ]
+    },
+    "ATR-2026-00290": {
+      "patterns": 1,
+      "classes": [
+        "backreference"
+      ]
+    },
+    "ATR-2026-00301": {
+      "patterns": 1,
+      "classes": [
+        "lookaround"
+      ]
+    },
+    "ATR-2026-00308": {
+      "patterns": 2,
+      "classes": [
+        "unicodeEscape"
+      ]
+    },
+    "ATR-2026-00309": {
+      "patterns": 4,
+      "classes": [
+        "unicodeEscape"
+      ]
+    },
+    "ATR-2026-00310": {
+      "patterns": 3,
+      "classes": [
+        "unicodeEscape"
+      ]
+    },
+    "ATR-2026-00311": {
+      "patterns": 1,
+      "classes": [
+        "unicodeEscape"
+      ]
+    },
+    "ATR-2026-00312": {
+      "patterns": 2,
+      "classes": [
+        "unicodeEscape"
+      ]
+    },
+    "ATR-2026-00313": {
+      "patterns": 3,
+      "classes": [
+        "unicodeEscape"
+      ]
+    },
+    "ATR-2026-00367": {
+      "patterns": 2,
+      "classes": [
+        "unicodeEscape"
+      ]
+    },
+    "ATR-2026-00404": {
+      "patterns": 1,
+      "classes": [
+        "unicodeEscape"
+      ]
+    },
+    "ATR-2026-00411": {
+      "patterns": 1,
+      "classes": [
+        "lookaround"
+      ]
+    },
+    "ATR-2026-00420": {
+      "patterns": 1,
+      "classes": [
+        "lookaround"
+      ]
+    },
+    "ATR-2026-00423": {
+      "patterns": 1,
+      "classes": [
+        "other"
+      ]
+    },
+    "ATR-2026-00433": {
+      "patterns": 1,
+      "classes": [
+        "lookaround"
+      ]
+    },
+    "ATR-2026-00435": {
+      "patterns": 3,
+      "classes": [
+        "lookaround"
+      ]
+    },
+    "ATR-2026-00442": {
+      "patterns": 2,
+      "classes": [
+        "lookaround"
+      ]
+    },
+    "ATR-2026-00444": {
+      "patterns": 3,
+      "classes": [
+        "unicodeEscape"
+      ]
+    },
+    "ATR-2026-00448": {
+      "patterns": 1,
+      "classes": [
+        "lookaround"
+      ]
+    },
+    "ATR-2026-00451": {
+      "patterns": 1,
+      "classes": [
+        "lookaround"
+      ]
+    },
+    "ATR-2026-00452": {
+      "patterns": 1,
+      "classes": [
+        "unicodeEscape"
+      ]
+    },
+    "ATR-2026-00454": {
+      "patterns": 2,
+      "classes": [
+        "unicodeEscape"
+      ]
+    },
+    "ATR-2026-00502": {
+      "patterns": 1,
+      "classes": [
+        "backreference"
+      ]
+    },
+    "ATR-2026-00515": {
+      "patterns": 1,
+      "classes": [
+        "unicodeEscape"
+      ]
+    },
+    "ATR-2026-00524": {
+      "patterns": 5,
+      "classes": [
+        "lookaround"
+      ]
+    },
+    "ATR-2026-00526": {
+      "patterns": 1,
+      "classes": [
+        "lookaround"
+      ]
+    },
+    "ATR-2026-00527": {
+      "patterns": 1,
+      "classes": [
+        "lookaround"
+      ]
+    },
+    "ATR-2026-00528": {
+      "patterns": 2,
+      "classes": [
+        "lookaround"
+      ]
+    },
+    "ATR-2026-00529": {
+      "patterns": 1,
+      "classes": [
+        "lookaround"
+      ]
+    },
+    "ATR-2026-00530": {
+      "patterns": 2,
+      "classes": [
+        "lookaround"
+      ]
+    },
+    "ATR-2026-00531": {
+      "patterns": 3,
+      "classes": [
+        "lookaround"
+      ]
+    },
+    "ATR-2026-00532": {
+      "patterns": 1,
+      "classes": [
+        "lookaround"
+      ]
+    },
+    "ATR-2026-00533": {
+      "patterns": 2,
+      "classes": [
+        "lookaround"
+      ]
+    },
+    "ATR-2026-00534": {
+      "patterns": 2,
+      "classes": [
+        "lookaround"
+      ]
+    },
+    "ATR-2026-00536": {
+      "patterns": 3,
+      "classes": [
+        "lookaround"
+      ]
+    },
+    "ATR-2026-00537": {
+      "patterns": 1,
+      "classes": [
+        "lookaround"
+      ]
+    },
+    "ATR-2026-00538": {
+      "patterns": 1,
+      "classes": [
+        "lookaround"
+      ]
+    },
+    "ATR-2026-00539": {
+      "patterns": 1,
+      "classes": [
+        "lookaround"
+      ]
+    },
+    "ATR-2026-00565": {
+      "patterns": 1,
+      "classes": [
+        "lookaround"
+      ]
+    },
+    "ATR-2026-00580": {
+      "patterns": 2,
+      "classes": [
+        "lookaround"
+      ]
+    },
+    "ATR-2026-00702": {
+      "patterns": 1,
+      "classes": [
+        "lookaround"
+      ]
+    },
+    "ATR-2026-01007": {
+      "patterns": 2,
+      "classes": [
+        "backreference"
+      ]
+    },
+    "ATR-2026-01451": {
+      "patterns": 1,
+      "classes": [
+        "lookaround"
+      ]
+    },
+    "ATR-2026-01454": {
+      "patterns": 2,
+      "classes": [
+        "lookaround"
+      ]
+    },
+    "ATR-2026-01463": {
+      "patterns": 1,
+      "classes": [
+        "lookaround"
+      ]
+    },
+    "ATR-2026-01612": {
+      "patterns": 1,
+      "classes": [
+        "lookaround"
+      ]
+    },
+    "ATR-2026-01771": {
+      "patterns": 1,
+      "classes": [
+        "lookaround"
+      ]
+    },
+    "ATR-2026-01925": {
+      "patterns": 1,
+      "classes": [
+        "unicodeEscape"
+      ]
+    },
+    "ATR-2026-01957": {
+      "patterns": 1,
+      "classes": [
+        "lookaround"
+      ]
+    },
+    "ATR-2026-01983": {
+      "patterns": 1,
+      "classes": [
+        "lookaround"
+      ]
+    },
+    "ATR-2026-01994": {
+      "patterns": 1,
+      "classes": [
+        "lookaround"
+      ]
+    },
+    "ATR-2026-02004": {
+      "patterns": 1,
+      "classes": [
+        "unicodeEscape"
+      ]
+    },
+    "ATR-2026-02006": {
+      "patterns": 1,
+      "classes": [
+        "lookaround"
+      ]
+    },
+    "ATR-2026-02010": {
+      "patterns": 1,
+      "classes": [
+        "unicodeEscape"
+      ]
+    },
+    "ATR-2026-02015": {
+      "patterns": 1,
+      "classes": [
+        "unicodeEscape"
+      ]
+    },
+    "ATR-2026-02018": {
+      "patterns": 1,
+      "classes": [
+        "unicodeEscape"
+      ]
+    },
+    "ATR-2026-02040": {
+      "patterns": 2,
+      "classes": [
+        "lookaround"
+      ]
+    },
+    "ATR-2026-02041": {
+      "patterns": 3,
+      "classes": [
+        "lookaround"
+      ]
+    },
+    "ATR-2026-02100": {
+      "patterns": 4,
+      "classes": [
+        "lookaround"
+      ]
+    },
+    "ATR-2026-02105": {
+      "patterns": 1,
+      "classes": [
+        "lookaround"
+      ]
+    },
+    "ATR-2026-02106": {
+      "patterns": 2,
+      "classes": [
+        "lookaround"
+      ]
+    },
+    "ATR-2026-02107": {
+      "patterns": 1,
+      "classes": [
+        "lookaround"
+      ]
+    },
+    "ATR-2026-02123": {
+      "patterns": 2,
+      "classes": [
+        "lookaround"
+      ]
+    },
+    "ATR-2026-02141": {
+      "patterns": 1,
+      "classes": [
+        "lookaround"
+      ]
+    },
+    "ATR-2026-02142": {
+      "patterns": 1,
+      "classes": [
+        "lookaround"
+      ]
+    },
+    "ATR-2026-02190": {
+      "patterns": 1,
+      "classes": [
+        "lookaround"
+      ]
+    },
+    "ATR-2026-02211": {
+      "patterns": 4,
+      "classes": [
+        "lookaround"
+      ]
+    },
+    "ATR-2026-02231": {
+      "patterns": 2,
+      "classes": [
+        "lookaround"
+      ]
+    },
+    "ATR-2026-02232": {
+      "patterns": 2,
+      "classes": [
+        "lookaround"
+      ]
+    },
+    "ATR-2026-02233": {
+      "patterns": 1,
+      "classes": [
+        "lookaround"
+      ]
+    },
+    "ATR-2026-02260": {
+      "patterns": 3,
+      "classes": [
+        "lookaround"
+      ]
+    },
+    "ATR-2026-02261": {
+      "patterns": 1,
+      "classes": [
+        "backreference"
+      ]
+    },
+    "ATR-2026-02262": {
+      "patterns": 2,
+      "classes": [
+        "lookaround"
+      ]
+    },
+    "ATR-2026-02263": {
+      "patterns": 1,
+      "classes": [
+        "lookaround"
+      ]
+    },
+    "ATR-2026-02300": {
+      "patterns": 4,
+      "classes": [
+        "lookaround"
+      ]
+    },
+    "ATR-2026-02301": {
+      "patterns": 2,
+      "classes": [
+        "lookaround"
+      ]
+    },
+    "ATR-2026-02304": {
+      "patterns": 1,
+      "classes": [
+        "lookaround"
+      ]
+    },
+    "ATR-2026-02371": {
+      "patterns": 1,
+      "classes": [
+        "lookaround"
+      ]
+    },
+    "ATR-2026-02372": {
+      "patterns": 2,
+      "classes": [
+        "lookaround"
+      ]
+    },
+    "ATR-2026-02373": {
+      "patterns": 2,
+      "classes": [
+        "lookaround"
+      ]
+    }
+  }
+}

--- a/scripts/audit-re2-portability.ts
+++ b/scripts/audit-re2-portability.ts
@@ -1,0 +1,702 @@
+/**
+ * RE2 portability audit for the ATR rule corpus.
+ *
+ * Downstream consumers of ATR rules run RE2-family engines (Go `regexp`,
+ * Rust `regex`, and every Sigma backend that compiles to them). RE2 is a
+ * finite-automaton engine: it rejects constructs that need backtracking, and
+ * it spells some escapes differently from JavaScript. A rule whose regex uses
+ * those constructs cannot be exported faithfully, so this script finds them.
+ *
+ * WHAT IS SCANNED
+ *   Only strings the ATR engine actually compiles as regular expressions:
+ *     - array-format  `detection.conditions[].value`  where operator == regex
+ *     - named-format  `detection.conditions.<name>.patterns[]` where
+ *       match_type is regex (engine defaults an absent match_type to regex)
+ *     - sequence      `detection.conditions.<name>.steps[].patterns[]`
+ *   Prose fields (title / description / test_cases / false_positives) are
+ *   NEVER scanned. They contain regex-looking text that is not a regex, and
+ *   treating them as patterns is the main way this audit could produce
+ *   fiction.
+ *
+ * CLASSIFICATION
+ *   mechanically fixable  unicodeEscape   \uXXXX  -> \x{XXXX}   (equivalent)
+ *                         namedGroup      (?<n>)  -> (?P<n>)    (equivalent)
+ *   not fixable           lookaround      (?= (?! (?<= (?<!
+ *                         backreference   \1..\9, \k<name>
+ *                         atomicOrPossessive  (?>...)  a*+ a++ a?+ a{n,m}+
+ *   A rule is "mechanically fixable" only when every incompatibility it has
+ *   falls in the first group.
+ *
+ *   A sixth bucket, `other`, holds RE2 incompatibilities outside those five:
+ *   `\b` inside a character class (a JS backspace escape that RE2 rejects,
+ *   and almost always an authoring slip for a word boundary) and repeat
+ *   counts above RE2's hard limit of 1000. Both need a human decision, so
+ *   they count as incompatible and never as mechanically fixable.
+ *
+ * USAGE
+ *   npx tsx scripts/audit-re2-portability.ts
+ *   npx tsx scripts/audit-re2-portability.ts --json
+ *   npx tsx scripts/audit-re2-portability.ts --fail-on-notfixable   # CI gate
+ *   npx tsx scripts/audit-re2-portability.ts --verify-re2           # needs Go
+ *
+ * `--verify-re2` is the honesty check: it compiles every pattern (and every
+ * proposed rewrite) with Go's regexp package, which IS RE2, and reports any
+ * disagreement with the static verdict. Without it the verdict is a careful
+ * parse; with it the verdict is measured. Read-only; writes nothing.
+ */
+import { readFileSync, readdirSync, statSync, mkdtempSync, writeFileSync } from "node:fs";
+import { join, resolve, relative } from "node:path";
+import { tmpdir } from "node:os";
+import { execFileSync } from "node:child_process";
+import { load as yamlLoad } from "js-yaml";
+
+const RULES_DIR = resolve(process.cwd(), "rules");
+
+/** The five RE2 incompatibility classes this audit reports. */
+export type IncompatClass =
+  | "lookaround"
+  | "backreference"
+  | "atomicOrPossessive"
+  | "namedGroup"
+  | "unicodeEscape";
+
+/** Classes that a scripted rewrite can fix without changing semantics. */
+const FIXABLE_CLASSES: ReadonlySet<IncompatClass> = new Set<IncompatClass>([
+  "namedGroup",
+  "unicodeEscape",
+]);
+
+export interface Finding {
+  readonly cls: IncompatClass | "other";
+  readonly token: string;
+  readonly index: number;
+  readonly detail: string;
+}
+
+export interface PatternRef {
+  readonly file: string;
+  readonly ruleId: string;
+  readonly location: string;
+  readonly pattern: string;
+}
+
+export interface PatternAudit extends PatternRef {
+  readonly findings: readonly Finding[];
+}
+
+// ---------------------------------------------------------------------------
+// Corpus walking + pattern extraction
+// ---------------------------------------------------------------------------
+
+function collectRuleFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir).sort()) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) out.push(...collectRuleFiles(full));
+    else if (/\.ya?ml$/i.test(entry)) out.push(full);
+  }
+  return out;
+}
+
+function isRegexOperator(raw: unknown): boolean {
+  // Accept the documented operator plus the negated/quantified spellings that
+  // downstream forks use, so a renamed operator cannot silently skip the audit.
+  const op = String(raw ?? "regex").trim().toLowerCase();
+  return op === "regex" || op === "regex_all" || op === "regex_any" || op === "not_regex";
+}
+
+/** Pull regex strings out of one parsed rule document. Pure; allocates new. */
+function extractPatterns(doc: unknown, file: string): PatternRef[] {
+  const rule = (doc ?? {}) as Record<string, unknown>;
+  const ruleId = String(rule["id"] ?? "(no id)");
+  const detection = (rule["detection"] ?? {}) as Record<string, unknown>;
+  const conditions = detection["conditions"];
+  const push = (location: string, pattern: unknown): PatternRef[] =>
+    typeof pattern === "string" ? [{ file, ruleId, location, pattern }] : [];
+
+  if (Array.isArray(conditions)) {
+    return conditions.flatMap((cond, i) => {
+      const c = (cond ?? {}) as Record<string, unknown>;
+      if (!isRegexOperator(c["operator"])) return [];
+      return push(`detection.conditions[${i}].value`, c["value"]);
+    });
+  }
+  if (conditions && typeof conditions === "object") {
+    return Object.entries(conditions as Record<string, unknown>).flatMap(([name, def]) =>
+      extractNamedCondition(name, def, file, ruleId)
+    );
+  }
+  return [];
+}
+
+/** Named-map condition: {patterns, match_type} or {steps: [{patterns}]}. */
+function extractNamedCondition(
+  name: string,
+  def: unknown,
+  file: string,
+  ruleId: string
+): PatternRef[] {
+  const cond = (def ?? {}) as Record<string, unknown>;
+  const base = `detection.conditions.${name}`;
+  const out: PatternRef[] = [];
+  const take = (patterns: unknown, matchType: unknown, loc: string): void => {
+    if (!Array.isArray(patterns) || !isRegexOperator(matchType)) return;
+    patterns.forEach((p, i) => {
+      if (typeof p === "string") out.push({ file, ruleId, location: `${loc}[${i}]`, pattern: p });
+    });
+  };
+  take(cond["patterns"], cond["match_type"], `${base}.patterns`);
+  const steps = cond["steps"];
+  if (Array.isArray(steps)) {
+    steps.forEach((step, i) => {
+      const s = (step ?? {}) as Record<string, unknown>;
+      take(s["patterns"], s["match_type"], `${base}.steps[${i}].patterns`);
+    });
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Regex scanner
+// ---------------------------------------------------------------------------
+
+const HEX4 = /^[0-9a-fA-F]{4}$/;
+
+/** RE2's hard cap on a repeat bound (Go regexp/syntax maxRepeat). */
+const RE2_MAX_REPEAT = 1000;
+
+function scanEscape(rx: string, i: number, inClass: boolean): { findings: Finding[]; next: number } {
+  const c = rx[i + 1] ?? "";
+  if (c === "u") return scanUnicodeEscape(rx, i);
+  if (inClass && (c === "b" || c === "B")) {
+    return {
+      findings: [{ cls: "other", token: `\\${c}`, index: i, detail: `\\${c} inside a character class is a JS backspace escape; RE2 rejects it` }],
+      next: i + 2,
+    };
+  }
+  if (c === "k" && rx[i + 2] === "<") {
+    const end = rx.indexOf(">", i + 2);
+    const token = end === -1 ? rx.slice(i) : rx.slice(i, end + 1);
+    return {
+      findings: [{ cls: "backreference", token, index: i, detail: "named backreference \\k<name> is unsupported by RE2" }],
+      next: end === -1 ? rx.length : end + 1,
+    };
+  }
+  if (!inClass && c >= "1" && c <= "9") {
+    return {
+      findings: [{ cls: "backreference", token: `\\${c}`, index: i, detail: "numeric backreference requires backtracking; RE2 rejects it" }],
+      next: i + 2,
+    };
+  }
+  return { findings: [], next: i + 2 };
+}
+
+function scanUnicodeEscape(rx: string, i: number): { findings: Finding[]; next: number } {
+  if (rx[i + 2] === "{") {
+    const end = rx.indexOf("}", i + 2);
+    const token = end === -1 ? rx.slice(i) : rx.slice(i, end + 1);
+    return {
+      findings: [{ cls: "unicodeEscape", token, index: i, detail: "JS \\u{...} escape; RE2 spells it \\x{...}" }],
+      next: end === -1 ? rx.length : end + 1,
+    };
+  }
+  const digits = rx.slice(i + 2, i + 6);
+  if (HEX4.test(digits)) {
+    return {
+      findings: [{ cls: "unicodeEscape", token: `\\u${digits}`, index: i, detail: "JS \\uXXXX escape; RE2 spells it \\x{XXXX}" }],
+      next: i + 6,
+    };
+  }
+  return {
+    findings: [{ cls: "other", token: rx.slice(i, i + 2), index: i, detail: "bare \\u with no hex payload" }],
+    next: i + 2,
+  };
+}
+
+function scanGroupOpen(rx: string, i: number): { findings: Finding[]; next: number } {
+  const head3 = rx.slice(i, i + 3);
+  const head4 = rx.slice(i, i + 4);
+  if (head4 === "(?<=" || head4 === "(?<!") {
+    return { findings: [{ cls: "lookaround", token: head4, index: i, detail: "lookbehind requires backtracking; RE2 rejects it" }], next: i + 4 };
+  }
+  if (head3 === "(?=" || head3 === "(?!") {
+    return { findings: [{ cls: "lookaround", token: head3, index: i, detail: "lookahead requires backtracking; RE2 rejects it" }], next: i + 3 };
+  }
+  if (head3 === "(?>") {
+    return { findings: [{ cls: "atomicOrPossessive", token: head3, index: i, detail: "atomic group is not expressible in RE2" }], next: i + 3 };
+  }
+  if (rx.slice(i, i + 3) === "(?<") {
+    const end = rx.indexOf(">", i + 3);
+    const token = end === -1 ? rx.slice(i) : rx.slice(i, end + 1);
+    return {
+      findings: [{ cls: "namedGroup", token, index: i, detail: "JS named group (?<n>); RE2 spells it (?P<n>)" }],
+      next: end === -1 ? rx.length : end + 1,
+    };
+  }
+  return { findings: [], next: i + 1 };
+}
+
+/**
+ * Walk a regex tracking escape and character-class state, and report every
+ * RE2-incompatible construct. Character-class interiors are respected so that
+ * `[(?=]` or `[*+]` are read as literals, not as operators.
+ */
+export function scanPattern(rx: string): Finding[] {
+  const findings: Finding[] = [];
+  let i = 0;
+  let inClass = false;
+  let quantEnd = -1; // index just past the last quantifier consumed
+
+  while (i < rx.length) {
+    const ch = rx[i]!;
+    if (ch === "\\") {
+      const r = scanEscape(rx, i, inClass);
+      findings.push(...r.findings);
+      i = r.next;
+      continue;
+    }
+    if (inClass) {
+      if (ch === "]") inClass = false;
+      i += 1;
+      continue;
+    }
+    if (ch === "[") {
+      inClass = true;
+      i += 1;
+      continue;
+    }
+    if (ch === "(") {
+      const r = scanGroupOpen(rx, i);
+      findings.push(...r.findings);
+      i = r.next;
+      continue;
+    }
+    const quant = readQuantifier(rx, i);
+    if (quant !== null) {
+      findings.push(...scanQuantifier(rx, i, quant, quantEnd));
+      quantEnd = quant;
+      i = quant;
+      continue;
+    }
+    i += 1;
+  }
+  return findings;
+}
+
+/**
+ * Findings attached to a quantifier that spans [start, end): an out-of-range
+ * repeat bound, and a trailing `+` that makes it possessive. `prevEnd` guards
+ * against reading the second `+` of `a++` as a fresh quantifier.
+ */
+function scanQuantifier(rx: string, start: number, end: number, prevEnd: number): Finding[] {
+  const bounds = checkRepeatBounds(rx, start);
+  if (rx[end] !== "+" || end === prevEnd) return bounds;
+  return [
+    ...bounds,
+    {
+      cls: "atomicOrPossessive",
+      token: rx.slice(start, end + 1),
+      index: start,
+      detail: "possessive quantifier is not expressible in RE2",
+    },
+  ];
+}
+
+/** RE2 caps every repeat bound at 1000; JS has no such limit. */
+function checkRepeatBounds(rx: string, i: number): Finding[] {
+  const m = /^\{(\d+)(?:,(\d*))?\}/.exec(rx.slice(i));
+  if (!m) return [];
+  const bounds = [Number(m[1]), m[2] ? Number(m[2]) : 0];
+  if (bounds.every((n) => n <= RE2_MAX_REPEAT)) return [];
+  return [
+    {
+      cls: "other",
+      token: m[0],
+      index: i,
+      detail: `repeat bound exceeds RE2's limit of ${RE2_MAX_REPEAT}`,
+    },
+  ];
+}
+
+/**
+ * If a quantifier starts at `i`, return the index just past it, else null.
+ * `?` directly after `(` is a group-kind marker, not a quantifier, and is
+ * already consumed by scanGroupOpen.
+ */
+function readQuantifier(rx: string, i: number): number | null {
+  const ch = rx[i]!;
+  const prev = i > 0 ? rx[i - 1] : "";
+  if (ch === "*" || ch === "+" || ch === "?") {
+    if (i === 0 || prev === "(" || prev === "|") return null;
+    return rx[i + 1] === "?" ? i + 2 : i + 1; // absorb lazy marker
+  }
+  if (ch === "{") {
+    const m = /^\{\d+(,\d*)?\}/.exec(rx.slice(i));
+    if (!m) return null;
+    const end = i + m[0].length;
+    return rx[end] === "?" ? end + 1 : end;
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Mechanical rewrite
+// ---------------------------------------------------------------------------
+
+/**
+ * Rewrite the two mechanically-fixable classes into RE2 spelling. Returns the
+ * pattern unchanged when it has no fixable construct. Never mutates input.
+ */
+export function rewriteForRe2(rx: string): string {
+  return rx
+    .replace(/\\u\{([0-9a-fA-F]+)\}/g, (_m, hex: string) => `\\x{${hex}}`)
+    .replace(/\\u([0-9a-fA-F]{4})/g, (_m, hex: string) => `\\x{${hex}}`)
+    .replace(/\(\?<([A-Za-z_][A-Za-z0-9_]*)>/g, (_m, name: string) => `(?P<${name}>`);
+}
+
+// ---------------------------------------------------------------------------
+// Aggregation
+// ---------------------------------------------------------------------------
+
+interface RuleVerdict {
+  readonly file: string;
+  readonly ruleId: string;
+  readonly classes: readonly IncompatClass[];
+  readonly fixable: boolean;
+  readonly patterns: readonly PatternAudit[];
+}
+
+function buildVerdicts(audits: readonly PatternAudit[], files: readonly string[]): RuleVerdict[] {
+  const byFile = new Map<string, PatternAudit[]>();
+  for (const a of audits) {
+    if (a.findings.length === 0) continue;
+    byFile.set(a.file, [...(byFile.get(a.file) ?? []), a]);
+  }
+  return files
+    .filter((f) => byFile.has(f))
+    .map((file) => {
+      const patterns = byFile.get(file)!;
+      const classes = [
+        ...new Set(
+          patterns.flatMap((p) => p.findings.map((f) => f.cls)).filter((c): c is IncompatClass => c !== "other")
+        ),
+      ].sort();
+      return {
+        file,
+        ruleId: patterns[0]!.ruleId,
+        classes,
+        fixable: classes.length > 0 && classes.every((c) => FIXABLE_CLASSES.has(c)),
+        patterns,
+      };
+    });
+}
+
+function countByClass(verdicts: readonly RuleVerdict[]): Record<IncompatClass, number> {
+  const zero: Record<IncompatClass, number> = {
+    lookaround: 0,
+    backreference: 0,
+    atomicOrPossessive: 0,
+    namedGroup: 0,
+    unicodeEscape: 0,
+  };
+  return verdicts.reduce(
+    (acc, v) => v.classes.reduce((inner, c) => ({ ...inner, [c]: inner[c] + 1 }), acc),
+    zero
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Optional empirical verification against Go's regexp (which is RE2)
+// ---------------------------------------------------------------------------
+
+const GO_ORACLE = `package main
+
+import (
+	"encoding/json"
+	"os"
+	"regexp"
+)
+
+func main() {
+	var in []string
+	if err := json.NewDecoder(os.Stdin).Decode(&in); err != nil {
+		os.Exit(2)
+	}
+	out := make([]map[string]any, 0, len(in))
+	for _, p := range in {
+		entry := map[string]any{"ok": true, "error": ""}
+		if _, err := regexp.Compile(p); err != nil {
+			entry["ok"] = false
+			entry["error"] = err.Error()
+		}
+		out = append(out, entry)
+	}
+	json.NewEncoder(os.Stdout).Encode(out)
+}
+`;
+
+interface OracleResult {
+  readonly ok: boolean;
+  readonly error: string;
+}
+
+function compileWithGo(patterns: readonly string[]): OracleResult[] | null {
+  try {
+    const dir = mkdtempSync(join(tmpdir(), "atr-re2-"));
+    const src = join(dir, "main.go");
+    writeFileSync(src, GO_ORACLE, "utf8");
+    const stdout = execFileSync("go", ["run", src], {
+      input: JSON.stringify(patterns),
+      encoding: "utf8",
+      maxBuffer: 64 * 1024 * 1024,
+    });
+    return JSON.parse(stdout) as OracleResult[];
+  } catch {
+    return null;
+  }
+}
+
+interface OracleReport {
+  readonly available: boolean;
+  readonly rawFailures: number;
+  readonly rewrittenFailures: number;
+  /** Patterns the scanner called auto-fixable that the rewrite genuinely repaired. */
+  readonly fixableRepaired: number;
+  readonly fixableTotal: number;
+  readonly disagreements: readonly string[];
+  readonly failureSamples: readonly string[];
+}
+
+const EMPTY_ORACLE: OracleReport = {
+  available: false,
+  rawFailures: 0,
+  rewrittenFailures: 0,
+  fixableRepaired: 0,
+  fixableTotal: 0,
+  disagreements: [],
+  failureSamples: [],
+};
+
+function verifyWithRe2(audits: readonly PatternAudit[]): OracleReport {
+  const raw = compileWithGo(audits.map((a) => a.pattern));
+  const fixed = raw && compileWithGo(audits.map((a) => rewriteForRe2(a.pattern)));
+  if (!raw || !fixed) return EMPTY_ORACLE;
+  const disagreements: string[] = [];
+  const failureSamples: string[] = [];
+  audits.forEach((a, i) => {
+    const flagged = a.findings.length > 0;
+    const claimedFixable = flagged && a.findings.every((f) => f.cls !== "other" && FIXABLE_CLASSES.has(f.cls));
+    if (!raw[i]!.ok && !flagged) {
+      disagreements.push(`${a.ruleId} ${a.location}: RE2 rejects but scanner found nothing -- ${raw[i]!.error}`);
+    }
+    if (raw[i]!.ok && flagged) {
+      disagreements.push(`${a.ruleId} ${a.location}: scanner flagged but RE2 accepts it as written`);
+    }
+    // Only a broken promise if the scanner claimed this one was auto-fixable.
+    if (claimedFixable && !fixed[i]!.ok) {
+      disagreements.push(`${a.ruleId} ${a.location}: rewrite still rejected by RE2 -- ${fixed[i]!.error}`);
+    }
+    if (!raw[i]!.ok && failureSamples.length < 40) {
+      failureSamples.push(`${a.ruleId} ${a.location}: ${raw[i]!.error}`);
+    }
+  });
+  const fixableIdx = audits.map((a, i) => [a, i] as const).filter(([a]) => a.findings.length > 0 && a.findings.every((f) => f.cls !== "other" && FIXABLE_CLASSES.has(f.cls)));
+  return {
+    available: true,
+    rawFailures: raw.filter((r) => !r.ok).length,
+    rewrittenFailures: fixed.filter((r) => !r.ok).length,
+    fixableRepaired: fixableIdx.filter(([, i]) => !raw[i]!.ok && fixed[i]!.ok).length,
+    fixableTotal: fixableIdx.length,
+    disagreements,
+    failureSamples,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Output
+// ---------------------------------------------------------------------------
+
+interface Totals {
+  readonly rules: number;
+  readonly patterns: number;
+  readonly badPatterns: number;
+  readonly otherRules: number;
+}
+
+function renderOracle(oracle: OracleReport | null): string[] {
+  if (!oracle) return [];
+  if (!oracle.available) {
+    return ["RE2 oracle unavailable (Go toolchain not found); verdict is static analysis only", ""];
+  }
+  return [
+    "RE2 ORACLE (Go regexp -- the real engine, not a heuristic)",
+    `  patterns RE2 rejects as written   ${oracle.rawFailures}`,
+    `  patterns RE2 rejects after rewrite ${oracle.rewrittenFailures}`,
+    `  auto-fixable patterns repaired     ${oracle.fixableRepaired} / ${oracle.fixableTotal}`,
+    `  scanner/oracle disagreements       ${oracle.disagreements.length}`,
+    ...oracle.disagreements.slice(0, 20).map((d) => `    ${d}`),
+    "",
+  ];
+}
+
+// ---------------------------------------------------------------------------
+// Remediation coverage
+// ---------------------------------------------------------------------------
+//
+// "Mechanically fixable" above is a STATIC claim: the rule's only RE2 blocker
+// is a spelling this repo can rewrite. Whether the rewrite actually preserves
+// meaning is a separate, empirical question, answered by
+// scripts/verify-re2-equivalence.ts running both engines over a shared input
+// battery. That run records the patterns whose rewrite compiles under RE2 but
+// does NOT reproduce the original match vector, in data/re2-equivalence.json.
+//
+// Coverage reconciles the two so the static claim can never quietly overstate
+// what was really delivered: fixable-and-verified rules are genuinely portable
+// downstream, fixable-but-divergent rules are not, and every remaining rule is
+// carried as portability metadata instead of a silent downstream failure.
+
+const EQUIVALENCE_PATH = resolve(process.cwd(), "data/re2-equivalence.json");
+
+interface Coverage {
+  readonly incompatible: number;
+  readonly claimedFixable: number;
+  readonly verifiedPortable: number;
+  readonly divergentAfterRewrite: readonly string[];
+  readonly taggedForDownstream: number;
+  readonly equivalenceAvailable: boolean;
+}
+
+/** Rule ids whose rewrite was measured to diverge under RE2. */
+function loadDivergentRuleIds(path: string = EQUIVALENCE_PATH): string[] | null {
+  try {
+    const parsed = JSON.parse(readFileSync(path, "utf8")) as { divergentRules?: Record<string, unknown> };
+    return Object.keys(parsed.divergentRules ?? {});
+  } catch {
+    return null;
+  }
+}
+
+function computeCoverage(verdicts: readonly RuleVerdict[]): Coverage {
+  const divergent = loadDivergentRuleIds();
+  const claimed = verdicts.filter((v) => v.fixable);
+  const divergentSet = new Set(divergent ?? []);
+  const stillBroken = claimed.filter((v) => divergentSet.has(v.ruleId)).map((v) => v.ruleId);
+  return {
+    incompatible: verdicts.length,
+    claimedFixable: claimed.length,
+    verifiedPortable: divergent === null ? 0 : claimed.length - stillBroken.length,
+    divergentAfterRewrite: stillBroken,
+    taggedForDownstream: verdicts.length,
+    equivalenceAvailable: divergent !== null,
+  };
+}
+
+function renderCoverage(c: Coverage): string[] {
+  if (!c.equivalenceAvailable) {
+    return [
+      "REMEDIATION COVERAGE",
+      "  data/re2-equivalence.json missing -- run:",
+      "    npx tsx scripts/verify-re2-equivalence.ts --write-equivalence data/re2-equivalence.json",
+      "",
+    ];
+  }
+  const pct = (n: number): string => `${((n / Math.max(c.incompatible, 1)) * 100).toFixed(1)}%`;
+  return [
+    "REMEDIATION COVERAGE (static claim reconciled against the differential run)",
+    `  incompatible rules                      ${c.incompatible}`,
+    `  claimed mechanically fixable            ${c.claimedFixable}`,
+    `  VERIFIED portable after rewrite         ${c.verifiedPortable}  (${pct(c.verifiedPortable)} of incompatible)`,
+    `  rewrite compiles but DIVERGES           ${c.divergentAfterRewrite.length}  -> treated as not portable`,
+    ...c.divergentAfterRewrite.map((id) => `      ${id}`),
+    `  carried as portability metadata         ${c.taggedForDownstream}  (${pct(c.taggedForDownstream)} -- every incompatible rule is tagged)`,
+    "",
+    "  Downstream effect: RE2 backends read atr.portability.re2-blocked from the",
+    "  Sigma export and skip those rules instead of failing to compile mid-pipeline.",
+    "",
+  ];
+}
+
+function renderTable(verdicts: readonly RuleVerdict[], totals: Totals, oracle: OracleReport | null): string {
+  const byClass = countByClass(verdicts);
+  const fixable = verdicts.filter((v) => v.fixable);
+  const notFixable = verdicts.filter((v) => !v.fixable);
+  const detail = (v: RuleVerdict): string =>
+    `  ${v.ruleId.padEnd(18)} ${(v.classes.join(",") || "other").padEnd(26)} ${relative(process.cwd(), v.file)}`;
+  return [
+    "RE2 portability audit -- ATR rule corpus",
+    "=".repeat(72),
+    `rules scanned            ${totals.rules}`,
+    `regex patterns scanned   ${totals.patterns}`,
+    `patterns incompatible    ${totals.badPatterns}`,
+    `rules incompatible       ${verdicts.length}`,
+    "",
+    "by class (rules; a rule can appear in more than one row)",
+    ...(Object.keys(byClass) as IncompatClass[]).map(
+      (c) =>
+        `  ${c.padEnd(20)} ${String(byClass[c]).padStart(4)}  ${FIXABLE_CLASSES.has(c) ? "mechanically fixable" : "needs refactor"}`
+    ),
+    `  ${"other".padEnd(20)} ${String(totals.otherRules).padStart(4)}  needs refactor (outside the five classes)`,
+    "",
+    `mechanically fixable     ${fixable.length}`,
+    `not fixable              ${notFixable.length}`,
+    "",
+    ...renderCoverage(computeCoverage(verdicts)),
+    ...(fixable.length ? ["MECHANICALLY FIXABLE", ...fixable.map(detail), ""] : []),
+    ...(notFixable.length ? ["NOT FIXABLE (refactor or mark non-portable)", ...notFixable.map(detail), ""] : []),
+    ...renderOracle(oracle),
+  ].join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------------------
+
+function main(): void {
+  const argv = process.argv.slice(2);
+  const wantJson = argv.includes("--json");
+  const failOnNotFixable = argv.includes("--fail-on-notfixable");
+  const wantOracle = argv.includes("--verify-re2");
+
+  const files = collectRuleFiles(RULES_DIR);
+  const audits: PatternAudit[] = files.flatMap((file) => {
+    const doc = yamlLoad(readFileSync(file, "utf8"));
+    return extractPatterns(doc, file).map((ref) => ({ ...ref, findings: scanPattern(ref.pattern) }));
+  });
+  const verdicts = buildVerdicts(audits, files);
+  const oracle = wantOracle ? verifyWithRe2(audits) : null;
+  const notFixable = verdicts.filter((v) => !v.fixable);
+  const totals: Totals = {
+    rules: files.length,
+    patterns: audits.length,
+    badPatterns: audits.filter((a) => a.findings.length > 0).length,
+    otherRules: verdicts.filter((v) => v.patterns.some((p) => p.findings.some((f) => f.cls === "other"))).length,
+  };
+
+  if (wantJson) {
+    process.stdout.write(
+      JSON.stringify(
+        {
+          totalRules: totals.rules,
+          totalPatterns: totals.patterns,
+          incompatiblePatterns: totals.badPatterns,
+          incompatible: verdicts.length,
+          byClass: countByClass(verdicts),
+          otherRules: totals.otherRules,
+          mechanicallyFixable: verdicts.filter((v) => v.fixable).map((v) => relative(process.cwd(), v.file)),
+          notFixable: notFixable.map((v) => relative(process.cwd(), v.file)),
+          rules: verdicts.map((v) => ({ ...v, file: relative(process.cwd(), v.file) })),
+          coverage: computeCoverage(verdicts),
+          oracle,
+        },
+        null,
+        2
+      ) + "\n"
+    );
+  } else {
+    process.stdout.write(renderTable(verdicts, totals, oracle) + "\n");
+  }
+
+  if (failOnNotFixable && notFixable.length > 0) process.exit(1);
+}
+
+main();

--- a/scripts/fix-re2-escapes.ts
+++ b/scripts/fix-re2-escapes.ts
@@ -1,0 +1,362 @@
+/**
+ * Mechanical RE2-dialect rewrite for ATR rule patterns.
+ *
+ * Two constructs have an exactly equivalent RE2 spelling and can therefore be
+ * rewritten by a script rather than by a human:
+ *
+ *   JS `\uXXXX` / `\u{XXXXX}`  ->  RE2 `\x{XXXX}` / `\x{XXXXX}`
+ *   JS `(?<name>...)`          ->  RE2 `(?P<name>...)`
+ *
+ * Everything else that RE2 rejects (lookaround, backreference, atomic group,
+ * possessive quantifier, out-of-range repeat bounds) changes the matched
+ * language when removed, so this script never touches it.
+ *
+ * WHY A WALK AND NOT A REPLACE
+ *   `s.replace(/\\u([0-9a-fA-F]{4})/g, ...)` is wrong. In the pattern
+ *   `\\u0041` (an escaped backslash followed by a literal `u0041`, i.e. the
+ *   rule is looking for the seven characters `A` in the payload) that
+ *   regex matches starting at the SECOND backslash and produces `\\x{0041}`,
+ *   silently turning a search for the text `A` into a search for
+ *   `\` followed by `A`. ATR has rules that hunt exactly that text -- see
+ *   ATR-2026-00258 condition #3. So the rewriter walks the pattern tracking
+ *   backslash and character-class state, and only rewrites escapes that are
+ *   genuinely escape-initial.
+ *
+ * WHERE THE REWRITE IS SAFE TO APPLY
+ *   NOT in the rule YAML. ATR's own engine compiles these strings with
+ *   `new RegExp(source, flags)` and picks its flags with
+ *   `pattern.includes('\\u{') || pattern.includes('\\p{') ? 'iu' : 'i'`
+ *   (src/engine.ts). JavaScript has no `\x{...}` escape: without `u` it
+ *   degrades via Annex B to a literal `x` plus a brace quantifier, and with
+ *   `u` it is a SyntaxError. Rewriting the YAML therefore breaks detection in
+ *   the primary engine. `--apply` consequently refuses to write inside
+ *   `rules/` unless `--force-rules` is passed, and prints why.
+ *   The supported consumer of this module is the export path
+ *   (scripts/generate-sigma.py, scripts/compile-yara.ts), which emits for RE2
+ *   engines and where the rewrite is both safe and necessary.
+ *
+ * USAGE
+ *   npx tsx scripts/fix-re2-escapes.ts                  # dry run (default)
+ *   npx tsx scripts/fix-re2-escapes.ts --json
+ *   npx tsx scripts/fix-re2-escapes.ts --apply          # refuses on rules/
+ *   npx tsx scripts/fix-re2-escapes.ts --apply --force-rules
+ */
+import { readFileSync, readdirSync, statSync, writeFileSync } from "node:fs";
+import { join, resolve, relative } from "node:path";
+import { pathToFileURL } from "node:url";
+import { load as yamlLoad, dump as yamlDump } from "js-yaml";
+
+const RULES_DIR = resolve(process.cwd(), "rules");
+
+export type RewriteKind = "unicodeEscape" | "namedGroup";
+
+export interface Rewrite {
+  readonly kind: RewriteKind;
+  readonly index: number;
+  readonly token: string;
+  readonly replacement: string;
+}
+
+const HEX4 = /^[0-9a-fA-F]{4}$/;
+const BRACED_HEX = /^[0-9a-fA-F]{1,6}$/;
+const GROUP_NAME = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+// ---------------------------------------------------------------------------
+// Escape-aware planner
+// ---------------------------------------------------------------------------
+
+/** A `\u...` escape starting at `i`, or null when it is not a rewritable one. */
+function planUnicodeEscape(rx: string, i: number): Rewrite | null {
+  if (rx[i + 2] === "{") {
+    const end = rx.indexOf("}", i + 3);
+    if (end === -1) return null;
+    const hex = rx.slice(i + 3, end);
+    if (!BRACED_HEX.test(hex)) return null;
+    return { kind: "unicodeEscape", index: i, token: rx.slice(i, end + 1), replacement: `\\x{${hex}}` };
+  }
+  const hex = rx.slice(i + 2, i + 6);
+  if (!HEX4.test(hex)) return null;
+  return { kind: "unicodeEscape", index: i, token: `\\u${hex}`, replacement: `\\x{${hex}}` };
+}
+
+/** A JS named group `(?<name>` at `i`, or null (lookbehind is not one). */
+function planNamedGroup(rx: string, i: number): Rewrite | null {
+  if (rx.startsWith("(?<=", i) || rx.startsWith("(?<!", i)) return null;
+  if (!rx.startsWith("(?<", i)) return null;
+  const end = rx.indexOf(">", i + 3);
+  if (end === -1) return null;
+  const name = rx.slice(i + 3, end);
+  if (!GROUP_NAME.test(name)) return null;
+  return { kind: "namedGroup", index: i, token: rx.slice(i, end + 1), replacement: `(?P<${name}>` };
+}
+
+/** Index just past the construct at `i`, used to keep the walk in step. */
+function skipWidth(rx: string, i: number, inClass: boolean): number {
+  if (rx[i] === "\\") return i + 2;
+  if (inClass) return i + 1;
+  return i + 1;
+}
+
+/**
+ * Walk `rx` and return every mechanically rewritable construct, in source
+ * order. Pure: allocates a new array and never touches the input.
+ *
+ * The walk exists to distinguish an escape-initial backslash from an escaped
+ * one, and to keep `(?<` inside a character class (where it is four literals)
+ * from being read as a group opener.
+ */
+export function planRewrites(rx: string): readonly Rewrite[] {
+  const out: Rewrite[] = [];
+  let i = 0;
+  let inClass = false;
+  while (i < rx.length) {
+    const ch = rx[i]!;
+    if (ch === "\\") {
+      const planned = rx[i + 1] === "u" ? planUnicodeEscape(rx, i) : null;
+      if (planned) {
+        out.push(planned);
+        i += planned.token.length;
+        continue;
+      }
+      i = skipWidth(rx, i, inClass);
+      continue;
+    }
+    if (inClass) {
+      if (ch === "]") inClass = false;
+      i += 1;
+      continue;
+    }
+    if (ch === "[") {
+      inClass = true;
+      i += 1;
+      continue;
+    }
+    if (ch === "(") {
+      const planned = planNamedGroup(rx, i);
+      if (planned) {
+        out.push(planned);
+        i += planned.token.length;
+        continue;
+      }
+    }
+    i += 1;
+  }
+  return out;
+}
+
+/** Apply a plan right-to-left so earlier indices stay valid. Never mutates. */
+export function applyRewrites(rx: string, plan: readonly Rewrite[]): string {
+  return [...plan]
+    .sort((a, b) => b.index - a.index)
+    .reduce((acc, r) => acc.slice(0, r.index) + r.replacement + acc.slice(r.index + r.token.length), rx);
+}
+
+/** Convenience: plan + apply in one call. */
+export function rewriteForRe2(rx: string): { readonly source: string; readonly plan: readonly Rewrite[] } {
+  const plan = planRewrites(rx);
+  return { source: plan.length === 0 ? rx : applyRewrites(rx, plan), plan };
+}
+
+// ---------------------------------------------------------------------------
+// Rule corpus access
+// ---------------------------------------------------------------------------
+
+export interface PatternRef {
+  readonly file: string;
+  readonly ruleId: string;
+  readonly index: number;
+  readonly field: string;
+  readonly pattern: string;
+}
+
+export function collectRuleFiles(dir: string = RULES_DIR): string[] {
+  return readdirSync(dir)
+    .sort()
+    .flatMap((entry) => {
+      const full = join(dir, entry);
+      if (statSync(full).isDirectory()) return collectRuleFiles(full);
+      return /\.ya?ml$/i.test(entry) ? [full] : [];
+    });
+}
+
+function isRegexOperator(raw: unknown): boolean {
+  const op = String(raw ?? "regex").trim().toLowerCase();
+  return op === "regex" || op === "regex_all" || op === "regex_any" || op === "not_regex";
+}
+
+/** Regex strings the ATR engine compiles from one rule document. */
+export function extractPatterns(doc: unknown, file: string): PatternRef[] {
+  const rule = (doc ?? {}) as Record<string, unknown>;
+  const ruleId = String(rule["id"] ?? "(no id)");
+  const detection = (rule["detection"] ?? {}) as Record<string, unknown>;
+  const conditions = detection["conditions"];
+  if (!Array.isArray(conditions)) return [];
+  return conditions.flatMap((cond, index) => {
+    const c = (cond ?? {}) as Record<string, unknown>;
+    if (!isRegexOperator(c["operator"])) return [];
+    const pattern = c["value"];
+    if (typeof pattern !== "string") return [];
+    return [{ file, ruleId, index, field: String(c["field"] ?? "content"), pattern }];
+  });
+}
+
+export function loadCorpus(dir: string = RULES_DIR): PatternRef[] {
+  return collectRuleFiles(dir).flatMap((file) => extractPatterns(yamlLoad(readFileSync(file, "utf8")), file));
+}
+
+// ---------------------------------------------------------------------------
+// YAML surgical edit
+// ---------------------------------------------------------------------------
+
+const VALUE_LINE = /^(\s*(?:-\s+)?value:[ \t]+)(\S.*)$/;
+
+/** Parse one YAML scalar fragment back to its string, or null if it is not one. */
+function parseScalar(raw: string): string | null {
+  try {
+    const parsed = yamlLoad(raw);
+    return typeof parsed === "string" ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function renderScalar(value: string): string {
+  return yamlDump(value, { quotingType: '"', forceQuotes: true, lineWidth: -1 }).replace(/\n$/, "");
+}
+
+export interface FileEdit {
+  readonly file: string;
+  readonly linesChanged: number;
+  readonly patternsChanged: number;
+  readonly text: string;
+  readonly unmatched: readonly string[];
+}
+
+/**
+ * Rewrite every `value:` scalar in `text` whose parsed content appears in
+ * `targets`. Returns new text; the original string is never mutated.
+ */
+export function rewriteYamlText(text: string, targets: ReadonlySet<string>): Omit<FileEdit, "file"> {
+  const seen = new Set<string>();
+  let linesChanged = 0;
+  const out = text.split("\n").map((line) => {
+    const m = VALUE_LINE.exec(line);
+    if (!m) return line;
+    const parsed = parseScalar(m[2]!);
+    if (parsed === null || !targets.has(parsed)) return line;
+    const { source, plan } = rewriteForRe2(parsed);
+    if (plan.length === 0) return line;
+    seen.add(parsed);
+    linesChanged += 1;
+    return `${m[1]}${renderScalar(source)}`;
+  });
+  return {
+    linesChanged,
+    patternsChanged: seen.size,
+    text: out.join("\n"),
+    unmatched: [...targets].filter((t) => !seen.has(t)),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+
+interface PlannedPattern extends PatternRef {
+  readonly rewritten: string;
+  readonly plan: readonly Rewrite[];
+}
+
+function planCorpus(refs: readonly PatternRef[]): PlannedPattern[] {
+  return refs.flatMap((ref) => {
+    const { source, plan } = rewriteForRe2(ref.pattern);
+    return plan.length === 0 ? [] : [{ ...ref, rewritten: source, plan }];
+  });
+}
+
+function renderPlan(planned: readonly PlannedPattern[], applied: boolean): string {
+  const files = [...new Set(planned.map((p) => p.file))];
+  const byKind = planned.flatMap((p) => p.plan).reduce<Record<string, number>>((acc, r) => ({ ...acc, [r.kind]: (acc[r.kind] ?? 0) + 1 }), {});
+  return [
+    `RE2 mechanical escape rewrite -- ${applied ? "APPLIED" : "DRY RUN (default; pass --apply to write)"}`,
+    "=".repeat(72),
+    `rule files touched   ${files.length}`,
+    `patterns rewritten   ${planned.length}`,
+    `tokens rewritten     ${Object.entries(byKind).map(([k, n]) => `${k}=${n}`).join(" ") || "0"}`,
+    "",
+    ...planned.flatMap((p) => [
+      `  ${p.ruleId} detection.conditions[${p.index}].value (${p.field})`,
+      `    -  ${p.pattern}`,
+      `    +  ${p.rewritten}`,
+    ]),
+  ].join("\n");
+}
+
+function writeEdits(planned: readonly PlannedPattern[]): number {
+  const byFile = planned.reduce<Map<string, Set<string>>>((acc, p) => {
+    const next = acc.get(p.file) ?? new Set<string>();
+    next.add(p.pattern);
+    return new Map(acc).set(p.file, next);
+  }, new Map());
+  let written = 0;
+  for (const [file, targets] of byFile) {
+    const before = readFileSync(file, "utf8");
+    const edit = rewriteYamlText(before, targets);
+    if (edit.unmatched.length > 0) {
+      console.error(`[fix-re2] ${relative(process.cwd(), file)}: ${edit.unmatched.length} pattern(s) not found on a value: line; skipped`);
+    }
+    if (edit.text === before) continue;
+    writeFileSync(file, edit.text, "utf8");
+    written += 1;
+  }
+  return written;
+}
+
+const RULES_GUARD = [
+  "REFUSING to rewrite rules/ .",
+  "ATR's engine compiles these patterns with JavaScript's RegExp, which has no",
+  "\\x{...} escape: without the u flag it degrades to a literal x plus a brace",
+  "quantifier, and with the u flag it is a SyntaxError. Rewriting the rule YAML",
+  "silently destroys detection in the primary engine. Apply this rewrite in the",
+  "RE2-targeting exporters instead. Pass --force-rules to override.",
+].join("\n");
+
+function main(): void {
+  const argv = process.argv.slice(2);
+  const apply = argv.includes("--apply");
+  const force = argv.includes("--force-rules");
+  const planned = planCorpus(loadCorpus());
+
+  if (argv.includes("--json")) {
+    process.stdout.write(
+      JSON.stringify(
+        {
+          applied: apply && force,
+          files: [...new Set(planned.map((p) => relative(process.cwd(), p.file)))],
+          patterns: planned.map((p) => ({
+            ruleId: p.ruleId,
+            file: relative(process.cwd(), p.file),
+            location: `detection.conditions[${p.index}].value`,
+            before: p.pattern,
+            after: p.rewritten,
+            tokens: p.plan.map((r) => ({ kind: r.kind, token: r.token, replacement: r.replacement })),
+          })),
+        },
+        null,
+        2
+      ) + "\n"
+    );
+  } else {
+    process.stdout.write(renderPlan(planned, apply && force) + "\n");
+  }
+
+  if (!apply) return;
+  if (!force) {
+    console.error(`\n${RULES_GUARD}`);
+    process.exit(2);
+  }
+  const written = writeEdits(planned);
+  console.error(`\n[fix-re2] wrote ${written} file(s).`);
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) main();

--- a/scripts/gate-re2-portability.ts
+++ b/scripts/gate-re2-portability.ts
@@ -1,0 +1,444 @@
+/**
+ * RE2 portability ratchet -- CI gate over the whole ATR rule corpus.
+ *
+ * WHY A RATCHET INSTEAD OF A HARD GATE
+ *   Downstream consumers compile ATR regexes with RE2-family engines (Go
+ *   `regexp`, Rust `regex`, and every Sigma backend built on them). A large
+ *   part of the corpus predates that requirement, and most of that debt needs
+ *   a genuine refactor rather than a mechanical rewrite -- lookarounds and
+ *   backreferences have no RE2 spelling. Failing every PR until the backlog is
+ *   cleared would stop all rule work. So this gate does what the maturity-FP
+ *   gate and the generalization gate do: it blocks NEW damage and lets the
+ *   existing backlog drain on its own schedule.
+ *
+ * WHY FULL-SET AND NOT PR-DIFF SCOPED
+ *   Rules land here by paths that never open a pull request -- the CVE
+ *   collector and auto-crystallize commit straight to main. A gate that only
+ *   inspects a PR diff cannot see those. Comparing the whole corpus against a
+ *   baseline catches a new incompatibility no matter which door it came in
+ *   through, and needs no git history (so a shallow checkout is enough).
+ *
+ * WHAT FAILS THE BUILD
+ *   - A rule absent from the baseline has an RE2-incompatible regex. That is
+ *     every newly authored rule, and every previously clean rule that a change
+ *     made incompatible.
+ *   - A baselined rule got worse: more incompatible patterns than the baseline
+ *     records, or an incompatibility class it did not have before.
+ *   - The static scanner disagrees with real RE2. Only checked when the audit
+ *     ran with --verify-re2 and a Go toolchain was present; otherwise skipped,
+ *     never guessed.
+ *
+ * WHAT DOES NOT FAIL THE BUILD
+ *   - A baselined rule that improved or was fixed. It is reported so the
+ *     baseline can be tightened with --write-baseline, matching the behaviour
+ *     of scripts/eval-generalization.ts --gate.
+ *
+ * KNOWN GAP (deliberate)
+ *   Baseline entries record a pattern count and a class set, not the pattern
+ *   text. Editing an already-incompatible regex in place, without adding a new
+ *   incompatibility, stays green. Recording pattern text would catch that, but
+ *   would churn the baseline on every cosmetic regex edit. The inflow this
+ *   gate exists to stop is newly generated rules, and the not-in-baseline
+ *   check covers those completely.
+ *
+ * USAGE
+ *   npx tsx scripts/gate-re2-portability.ts                      # audit + gate
+ *   npx tsx scripts/gate-re2-portability.ts --audit report.json  # reuse a report
+ *   npx tsx scripts/gate-re2-portability.ts --require-oracle     # CI: refuse to run without real RE2
+ *   npx tsx scripts/gate-re2-portability.ts --write-baseline
+ */
+import { execFileSync } from "node:child_process";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const BASELINE_PATH = resolve(process.cwd(), "data/re2-portability-baseline.json");
+const AUDIT_SCRIPT = resolve(process.cwd(), "scripts/audit-re2-portability.ts");
+
+const BASELINE_NOTE =
+  "Rules whose detection regexes cannot be compiled by RE2 (Go regexp, Rust regex, " +
+  "Sigma backends built on them). Ratchet only -- new entries must be fixed, not added. " +
+  "See scripts/gate-re2-portability.ts.";
+
+/** Findings the audit reports outside the five named classes need a human. */
+const NEEDS_HUMAN_CLASS = "other";
+
+// ---------------------------------------------------------------------------
+// Shapes emitted by scripts/audit-re2-portability.ts --json
+// ---------------------------------------------------------------------------
+
+interface AuditFinding {
+  readonly cls: string;
+  readonly token: string;
+  /** Character offset of the construct inside the pattern string. */
+  readonly index: number;
+  readonly detail: string;
+}
+
+interface AuditPattern {
+  readonly location: string;
+  readonly pattern: string;
+  readonly findings: readonly AuditFinding[];
+}
+
+interface AuditRule {
+  readonly file: string;
+  readonly ruleId: string;
+  readonly patterns: readonly AuditPattern[];
+}
+
+interface AuditOracle {
+  readonly available: boolean;
+  readonly disagreements: readonly string[];
+}
+
+interface AuditReport {
+  readonly totalRules: number;
+  readonly totalPatterns: number;
+  readonly incompatiblePatterns: number;
+  readonly rules: readonly AuditRule[];
+  readonly oracle: AuditOracle | null;
+}
+
+// ---------------------------------------------------------------------------
+// Baseline
+// ---------------------------------------------------------------------------
+
+interface BaselineEntry {
+  /** How many distinct regex patterns in this rule RE2 cannot compile. */
+  readonly patterns: number;
+  /** Incompatibility classes present, sorted. "other" means a human must look. */
+  readonly classes: readonly string[];
+}
+
+interface Baseline {
+  readonly generatedAt: string;
+  readonly note: string;
+  readonly corpus: { readonly rules: number; readonly regexPatterns: number };
+  readonly knownNotPortable: Readonly<Record<string, BaselineEntry>>;
+}
+
+const EMPTY_BASELINE: Baseline = {
+  generatedAt: "",
+  note: BASELINE_NOTE,
+  corpus: { rules: 0, regexPatterns: 0 },
+  knownNotPortable: {},
+};
+
+/** Parse and validate a baseline file. Never trusts the shape on disk. */
+function loadBaseline(): Baseline {
+  if (!existsSync(BASELINE_PATH)) return EMPTY_BASELINE;
+  const doc = readJson(BASELINE_PATH) as Partial<Baseline>;
+  const known = doc.knownNotPortable;
+  // An array here would pass a bare typeof check and then read as an EMPTY
+  // baseline, turning a corrupt file into "every rule is a new regression".
+  if (known === null || typeof known !== "object" || Array.isArray(known)) {
+    throw new Error(`${BASELINE_PATH}: "knownNotPortable" must be an object of ruleId -> entry`);
+  }
+  for (const [id, entry] of Object.entries(known)) {
+    const ok = entry && typeof entry.patterns === "number" && Array.isArray(entry.classes);
+    if (!ok) throw new Error(`${BASELINE_PATH}: entry "${id}" needs {patterns:number, classes:string[]}`);
+  }
+  return { ...EMPTY_BASELINE, ...doc, knownNotPortable: known as Record<string, BaselineEntry> };
+}
+
+function readJson(path: string): unknown {
+  try {
+    return JSON.parse(readFileSync(path, "utf8"));
+  } catch (err) {
+    throw new Error(`${path}: not readable as JSON -- ${(err as Error).message}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Audit acquisition
+// ---------------------------------------------------------------------------
+
+function parseAudit(raw: string, source: string): AuditReport {
+  let doc: Partial<AuditReport>;
+  try {
+    doc = JSON.parse(raw) as Partial<AuditReport>;
+  } catch (err) {
+    throw new Error(`${source}: not valid JSON -- ${(err as Error).message}`);
+  }
+  if (typeof doc.totalRules !== "number" || !Array.isArray(doc.rules)) {
+    throw new Error(`${source}: not an audit report (expected totalRules + rules[]). Produce it with: npx tsx scripts/audit-re2-portability.ts --json`);
+  }
+  return doc as AuditReport;
+}
+
+/**
+ * Run the audit in-process-adjacent. Uses the same node binary with tsx
+ * preloaded so no npx lookup or global install is involved. --verify-re2 is
+ * best effort: with a Go toolchain the verdict is measured against real RE2,
+ * without one the audit silently reports the oracle as unavailable.
+ */
+function spawnAudit(): AuditReport {
+  const stdout = execFileSync(
+    process.execPath,
+    ["--import", "tsx", AUDIT_SCRIPT, "--json", "--verify-re2"],
+    { encoding: "utf8", maxBuffer: 128 * 1024 * 1024 }
+  );
+  return parseAudit(stdout, "audit subprocess");
+}
+
+function acquireAudit(auditPath: string): AuditReport {
+  if (!auditPath) return spawnAudit();
+  if (!existsSync(auditPath)) throw new Error(`--audit ${auditPath}: file not found`);
+  return parseAudit(readFileSync(auditPath, "utf8"), auditPath);
+}
+
+// ---------------------------------------------------------------------------
+// Current state
+// ---------------------------------------------------------------------------
+
+interface Observed extends BaselineEntry {
+  readonly ruleId: string;
+  readonly file: string;
+  readonly detail: readonly AuditPattern[];
+}
+
+/**
+ * Collapse the audit report into one entry per incompatible rule. Classes are
+ * read off the findings rather than the audit's own `classes` field so that
+ * "other" findings are represented instead of vanishing.
+ */
+function observe(report: AuditReport): ReadonlyMap<string, Observed> {
+  const withFindings = report.rules.filter((r) => r.patterns.some((p) => p.findings.length > 0));
+  return new Map(
+    withFindings.map((rule) => {
+      const bad = rule.patterns.filter((p) => p.findings.length > 0);
+      const classes = [...new Set(bad.flatMap((p) => p.findings.map((f) => f.cls)))].sort();
+      return [rule.ruleId, { ruleId: rule.ruleId, file: rule.file, patterns: bad.length, classes, detail: bad }];
+    })
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Comparison
+// ---------------------------------------------------------------------------
+
+interface Regression {
+  readonly rule: Observed;
+  readonly reason: string;
+  /**
+   * Classes this rule did not have in the baseline. When non-empty the report
+   * shows only these findings, so a rule with pre-existing debt does not bury
+   * the actual regression under dozens of already-accepted lines.
+   */
+  readonly gained: readonly string[];
+}
+
+interface Comparison {
+  readonly added: readonly Observed[];
+  readonly worsened: readonly Regression[];
+  readonly improved: readonly string[];
+  readonly resolved: readonly string[];
+}
+
+function worseThan(current: Observed, base: BaselineEntry): Omit<Regression, "rule"> | null {
+  const gained = current.classes.filter((c) => !base.classes.includes(c));
+  if (gained.length > 0) return { reason: `new incompatibility class: ${gained.join(", ")}`, gained };
+  if (current.patterns > base.patterns) {
+    return { reason: `incompatible patterns rose ${base.patterns} -> ${current.patterns}`, gained: [] };
+  }
+  return null;
+}
+
+function betterThan(current: Observed | undefined, base: BaselineEntry): boolean {
+  if (!current) return false;
+  const dropped = base.classes.filter((c) => !current.classes.includes(c));
+  return current.patterns < base.patterns || dropped.length > 0;
+}
+
+function compare(current: ReadonlyMap<string, Observed>, base: Baseline): Comparison {
+  const known = base.knownNotPortable;
+  const added = [...current.values()].filter((o) => !(o.ruleId in known));
+  const worsened = [...current.values()].flatMap((o) => {
+    const entry = known[o.ruleId];
+    if (!entry) return [];
+    const verdict = worseThan(o, entry);
+    return verdict ? [{ rule: o, ...verdict }] : [];
+  });
+  const baselineIds = Object.keys(known).sort();
+  return {
+    added,
+    worsened,
+    improved: baselineIds.filter((id) => betterThan(current.get(id), known[id]!)),
+    resolved: baselineIds.filter((id) => !current.has(id)),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Reporting
+// ---------------------------------------------------------------------------
+
+/** Keep one rule's block short enough that a CI log stays readable. */
+const MAX_DETAIL_LINES = 12;
+
+/**
+ * One indented block per offending rule: where it is and what RE2 chokes on.
+ * `focus`, when non-empty, limits the findings to the classes that actually
+ * regressed, so pre-existing accepted debt in the same rule stays out of the way.
+ */
+function renderRule(rule: Observed, reason: string, focus: readonly string[] = []): string[] {
+  const keep = (f: AuditFinding): boolean => focus.length === 0 || focus.includes(f.cls);
+  const body = rule.detail.flatMap((p) =>
+    p.findings.filter(keep).map((f) => `      ${p.location} @${f.index}  [${f.cls}] ${f.token}  ${f.detail}`)
+  );
+  const shown = body.slice(0, MAX_DETAIL_LINES);
+  const rest = body.length - shown.length;
+  return [
+    `  - ${rule.ruleId}  ${reason}`,
+    `      ${rule.file}`,
+    ...shown,
+    ...(rest > 0 ? [`      ... and ${rest} more (run: npx tsx scripts/audit-re2-portability.ts)`] : []),
+  ];
+}
+
+function fixHint(rules: readonly Observed[]): string[] {
+  const classes = new Set(rules.flatMap((r) => r.classes));
+  const lines: string[] = [];
+  if (classes.has("unicodeEscape")) {
+    lines.push("  unicodeEscape  rewrite \\uXXXX as \\x{XXXX} -- but the rewrite is NOT always");
+    lines.push("                 equivalent, so confirm with scripts/verify-re2-equivalence.ts.");
+    lines.push("                 It compiles under RE2 and silently changes meaning when the");
+    lines.push("                 pattern names a UTF-16 surrogate (\\uD800-\\uDFFF is half of a pair");
+    lines.push("                 standing for one astral code point -- write [\\x{E0000}-\\x{E007F}],");
+    lines.push("                 not two halves), or leans on \\s/\\S (JS includes Unicode spaces,");
+    lines.push("                 RE2 restricts them to ASCII), or counts with . and bounded repeats");
+    lines.push("                 (JS counts UTF-16 code units, RE2 counts runes).");
+  }
+  if (classes.has("namedGroup")) lines.push("  namedGroup     rewrite (?<name>...) as (?P<name>...)");
+  if (classes.has("lookaround")) lines.push("  lookaround     RE2 has no lookahead/lookbehind. Restructure the pattern, or split the condition.");
+  if (classes.has("backreference")) lines.push("  backreference  RE2 cannot backtrack. Spell the repetition out.");
+  if (classes.has("atomicOrPossessive")) lines.push("  atomic/possessive  drop it; RE2 is linear-time and needs no catastrophic-backtracking guard.");
+  if (classes.has(NEEDS_HUMAN_CLASS)) lines.push("  other          repeat bound over 1000, or \\b inside a character class. Both need a human decision.");
+  return lines.length ? ["", "How to fix:", ...lines] : [];
+}
+
+function renderOracle(oracle: AuditOracle | null): string[] {
+  if (!oracle || !oracle.available) {
+    return ["oracle: not run (no Go toolchain, or audit ran without --verify-re2); verdict is static analysis"];
+  }
+  const n = oracle.disagreements.length;
+  return n === 0
+    ? ["oracle: real RE2 (Go regexp) agrees with the scanner on every pattern"]
+    : [`oracle: real RE2 disagrees with the scanner on ${n} pattern(s)`, ...oracle.disagreements.slice(0, 20).map((d) => `  ${d}`)];
+}
+
+// ---------------------------------------------------------------------------
+// Gate
+// ---------------------------------------------------------------------------
+
+/**
+ * CI runs with --require-oracle so the verdict is always measured against real
+ * RE2 rather than inferred. This matters more than it looks: the hand-written
+ * scanner had two genuine blind spots that only surfaced when every pattern was
+ * fed to Go's regexp. Silently degrading to static analysis because a runner
+ * image dropped its Go toolchain would leave a gate that still reports PASS
+ * while no longer checking what it claims to check.
+ */
+function requireOracle(oracle: AuditOracle | null): void {
+  if (oracle?.available) return;
+  throw new Error(
+    "--require-oracle was set but the RE2 oracle did not run. Install a Go toolchain " +
+      "and pass --verify-re2 to scripts/audit-re2-portability.ts. Refusing to report a " +
+      "verdict from static analysis alone."
+  );
+}
+
+function runGate(report: AuditReport, current: ReadonlyMap<string, Observed>, base: Baseline): never {
+  const { added, worsened, improved, resolved } = compare(current, base);
+  const oracle = report.oracle;
+  const oracleBroken = Boolean(oracle?.available) && (oracle?.disagreements.length ?? 0) > 0;
+  const out: string[] = [
+    "",
+    "=== ATR RE2 Portability GATE ===",
+    `corpus: ${report.totalRules} rules, ${report.totalPatterns} regex patterns`,
+    `not portable: ${current.size} rules / ${report.incompatiblePatterns} patterns (baseline ${Object.keys(base.knownNotPortable).length} rules)`,
+    ...renderOracle(oracle),
+  ];
+
+  if (improved.length || resolved.length) {
+    out.push("", "RATCHET -- these improved and should be tightened in the baseline:");
+    out.push(...resolved.map((id) => `  + ${id}: now fully RE2 portable`));
+    out.push(...improved.map((id) => `  + ${id}: fewer incompatibilities than the baseline records`));
+    out.push("  (run --write-baseline to tighten)");
+  }
+
+  if (added.length === 0 && worsened.length === 0 && !oracleBroken) {
+    out.push("", "GATE PASS -- no new RE2 incompatibility.", "");
+    process.stdout.write(out.join("\n"));
+    process.exit(0);
+  }
+
+  // The oracle can fail on its own, with every rule still inside the baseline.
+  // Announcing "new incompatibility introduced" and then listing nothing sends
+  // an author hunting for a rule change that does not exist.
+  const regressed = added.length > 0 || worsened.length > 0;
+  if (regressed) {
+    out.push("", "GATE FAIL -- new RE2 incompatibility introduced:");
+    out.push(...added.flatMap((r) => renderRule(r, "(not in baseline)")));
+    out.push(...worsened.flatMap((w) => renderRule(w.rule, `(${w.reason})`, w.gained)));
+    out.push(...fixHint([...added, ...worsened.map((w) => w.rule)]));
+    out.push("", "Downstream consumers compile these with RE2 and will drop the rule outright.", "Do NOT widen the baseline to silence this.");
+  }
+  if (oracleBroken) {
+    out.push(
+      "",
+      "GATE FAIL -- the static scanner no longer matches real RE2.",
+      "  Every pattern above was classified by scripts/audit-re2-portability.ts, and real",
+      "  RE2 came to a different verdict on the patterns listed under `oracle:`. Fix the",
+      "  scanner before trusting this gate; the baseline is meaningless while they disagree."
+    );
+  }
+  out.push("");
+  process.stdout.write(out.join("\n"));
+  process.exit(1);
+}
+
+function writeBaseline(report: AuditReport, current: ReadonlyMap<string, Observed>): void {
+  const ids = [...current.keys()].sort();
+  const baseline: Baseline = {
+    generatedAt: new Date().toISOString(),
+    note: BASELINE_NOTE,
+    corpus: { rules: report.totalRules, regexPatterns: report.totalPatterns },
+    knownNotPortable: Object.fromEntries(
+      ids.map((id) => {
+        const o = current.get(id)!;
+        return [id, { patterns: o.patterns, classes: o.classes }];
+      })
+    ),
+  };
+  writeFileSync(BASELINE_PATH, JSON.stringify(baseline, null, 2) + "\n");
+  process.stdout.write(`wrote baseline: ${ids.length} not-portable rules -> ${BASELINE_PATH}\n`);
+}
+
+function main(): void {
+  const argv = process.argv.slice(2);
+  const auditIdx = argv.indexOf("--audit");
+  const auditPath = auditIdx === -1 ? "" : (argv[auditIdx + 1] ?? "");
+  if (auditIdx !== -1 && !auditPath) throw new Error("--audit needs a path to an audit --json report");
+
+  const report = acquireAudit(auditPath);
+  const current = observe(report);
+
+  if (argv.includes("--write-baseline")) {
+    writeBaseline(report, current);
+    return;
+  }
+  if (argv.includes("--require-oracle")) requireOracle(report.oracle);
+  runGate(report, current, loadBaseline());
+}
+
+/**
+ * Exit codes are distinct on purpose: 1 means rules regressed and an author
+ * must act, 2 means the gate itself could not run. A CI log that conflates the
+ * two teaches people to ignore the gate.
+ */
+try {
+  main();
+} catch (err) {
+  process.stderr.write(`\nRE2 portability gate could not run: ${(err as Error).message}\n\n`);
+  process.exit(2);
+}

--- a/scripts/generate-sigma.py
+++ b/scripts/generate-sigma.py
@@ -45,6 +45,7 @@ from __future__ import annotations
 
 import argparse
 import glob
+import json
 import os
 import re
 import sys
@@ -196,7 +197,211 @@ def strip_leading_i_flag(pattern: str) -> tuple[str, bool]:
     return body, True
 
 
-def convert_conditions(atr_detection: dict) -> tuple[dict, str, list[str]]:
+# ---------------------------------------------------------------------------
+# RE2 portability
+# ---------------------------------------------------------------------------
+#
+# Sigma is a source format; each backend compiles the `re` modifier to its own
+# engine. Two engine families matter here and they disagree:
+#
+#   PCRE / Python re  -- understands \\uXXXX, lookaround, backreferences.
+#   RE2 (Go, Rust)    -- spells the escape \\x{XXXX} and, being a finite
+#                        automaton, cannot run lookaround or backreferences
+#                        at all.
+#
+# So there is no single spelling that satisfies both, and silently picking one
+# breaks the other. This emitter therefore keeps the source dialect by default
+# and offers --regex-dialect re2 for RE2 backends, while ALWAYS recording what
+# a RE2 backend cannot run. Reported via the existing conversion-warning
+# mechanism plus an `atr.portability.*` tag, so a consumer learns a rule is
+# unrunnable from the rule itself instead of from a compile error.
+
+RE2_MAX_REPEAT = 1000
+_HEX4_RE = re.compile(r"[0-9a-fA-F]{4}")
+_BRACED_HEX_RE = re.compile(r"\{([0-9a-fA-F]{1,6})\}")
+_GROUP_NAME_RE = re.compile(r"([A-Za-z_][A-Za-z0-9_]*)>")
+_REPEAT_RE = re.compile(r"\{(\d+)(?:,(\d*))?\}")
+
+
+def _scan_escape(rx: str, i: int, in_class: bool) -> tuple[tuple | None, str | None, int]:
+    """Classify the escape starting at `rx[i]`. Returns (rewrite, blocker, next)."""
+    nxt = rx[i + 1] if i + 1 < len(rx) else ""
+    if nxt == "u":
+        m = _BRACED_HEX_RE.match(rx, i + 2) or _HEX4_RE.match(rx, i + 2)
+        if m:
+            hexits = m.group(1) if m.re is _BRACED_HEX_RE else m.group(0)
+            cp = int(hexits, 16)
+            blocker = (
+                f"\\u{hexits} is a UTF-16 surrogate; RE2 folds it to U+FFFD, so the "
+                f"rewritten pattern compiles but can never match"
+                if 0xD800 <= cp <= 0xDFFF
+                else None
+            )
+            return (i, m.end(), "\\x{%s}" % hexits), blocker, m.end()
+    if in_class and nxt in ("b", "B"):
+        return None, f"\\{nxt} inside a character class is a backspace escape; RE2 rejects it", i + 2
+    if nxt == "k" and rx[i + 2 : i + 3] == "<":
+        return None, "named backreference \\k<name> requires backtracking; RE2 rejects it", i + 2
+    if not in_class and nxt.isdigit() and nxt != "0":
+        return None, f"backreference \\{nxt} requires backtracking; RE2 rejects it", i + 2
+    return None, None, i + 2
+
+
+def _scan_group(rx: str, i: int) -> tuple[tuple | None, str | None, int]:
+    """Classify the group opener at `rx[i]`. Returns (rewrite, blocker, next)."""
+    if rx[i : i + 4] in ("(?<=", "(?<!"):
+        return None, "lookbehind requires backtracking; RE2 rejects it", i + 4
+    if rx[i : i + 3] in ("(?=", "(?!"):
+        return None, "lookahead requires backtracking; RE2 rejects it", i + 3
+    if rx[i : i + 3] == "(?>":
+        return None, "atomic group is not expressible in RE2", i + 3
+    if rx[i : i + 3] == "(?<":
+        m = _GROUP_NAME_RE.match(rx, i + 3)
+        if m:
+            return (i, m.end(), "(?P<%s>" % m.group(1)), None, m.end()
+    return None, None, i + 1
+
+
+def _scan_repeat(rx: str, i: int) -> tuple[str | None, int]:
+    """Flag a `{n,m}` bound above RE2's hard cap. Returns (blocker, next)."""
+    m = _REPEAT_RE.match(rx, i)
+    if not m:
+        return None, i + 1
+    bounds = [int(m.group(1))] + ([int(m.group(2))] if m.group(2) else [])
+    if any(b > RE2_MAX_REPEAT for b in bounds):
+        return f"repeat bound {m.group(0)} exceeds RE2's limit of {RE2_MAX_REPEAT}", m.end()
+    if rx[m.end() : m.end() + 1] == "+":
+        return "possessive quantifier is not expressible in RE2", m.end() + 1
+    return None, m.end()
+
+
+def walk_regex(rx: str) -> tuple[list[tuple], list[str]]:
+    """One escape/character-class-aware pass over `rx`.
+
+    Returns the mechanically rewritable spans and the constructs RE2 cannot
+    run. The walk (rather than a bare re.sub) is what keeps an ESCAPED
+    backslash -- `\\\\u0041`, a rule hunting the literal text `\\u0041` -- from
+    being mistaken for a unicode escape and silently corrupted.
+    """
+    rewrites: list[tuple] = []
+    blockers: list[str] = []
+    i, in_class = 0, False
+    while i < len(rx):
+        ch = rx[i]
+        if ch == "\\":
+            rw, bl, i = _scan_escape(rx, i, in_class)
+            if rw:
+                rewrites.append(rw)
+            if bl:
+                blockers.append(bl)
+            continue
+        if in_class:
+            in_class = ch != "]"
+            i += 1
+            continue
+        if ch == "[":
+            in_class, i = True, i + 1
+            continue
+        if ch == "(":
+            rw, bl, i = _scan_group(rx, i)
+            if rw:
+                rewrites.append(rw)
+            if bl:
+                blockers.append(bl)
+            continue
+        if ch == "{":
+            bl, i = _scan_repeat(rx, i)
+            if bl:
+                blockers.append(bl)
+            continue
+        i += 1
+    return rewrites, blockers
+
+
+def rewrite_re2_escapes(pattern: str) -> str:
+    """Apply the RE2 spelling of the two exactly-equivalent escape forms.
+
+    Verified by scripts/verify-re2-equivalence.ts, which compares the original
+    under JavaScript against the rewrite under Go's regexp over a per-pattern
+    input battery. Never mutates the input.
+    """
+    rewrites, _ = walk_regex(pattern)
+    out = pattern
+    for start, end, replacement in reversed(rewrites):
+        out = out[:start] + replacement + out[end:]
+    return out
+
+
+def re2_blockers(pattern: str) -> list[str]:
+    """Constructs in `pattern` that no RE2 backend can run."""
+    return walk_regex(pattern)[1]
+
+
+# The static walk above catches what RE2 REFUSES TO COMPILE. It cannot catch
+# the second, quieter failure mode: a pattern that compiles fine under RE2 but
+# does not mean the same thing, because JavaScript and RE2 disagree about \s
+# (Unicode vs ASCII), about UTF-16 surrogates, and about whether a bounded
+# repeat counts code units or runes. Those only surface by running both engines
+# over the same inputs, which is what scripts/verify-re2-equivalence.ts does.
+# Its measured verdict is checked in here and consulted below, so a rule that
+# would silently mis-detect downstream is tagged rather than shipped as clean.
+
+EQUIVALENCE_PATH = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    "data",
+    "re2-equivalence.json",
+)
+
+
+def load_equivalence_divergences(path: str = EQUIVALENCE_PATH) -> dict:
+    """Map rule id -> list of measured RE2 divergences. Absent file = empty."""
+    try:
+        with open(path, encoding="utf-8") as fh:
+            return dict(json.load(fh).get("divergentRules", {}))
+    except (OSError, ValueError):
+        return {}
+
+
+def measured_divergence_warnings(atr_id: str, divergences: dict) -> list[str]:
+    """Warnings for conditions the differential run caught diverging under RE2."""
+    return [
+        "condition {loc} RE2-INCOMPATIBLE: {cause} (measured: {n}/{total} inputs "
+        "disagree between JavaScript and RE2)".format(
+            loc=entry.get("location", "?"),
+            cause=cause,
+            n=entry.get("mismatches", "?"),
+            total=entry.get("inputs", "?"),
+        )
+        for entry in divergences.get(str(atr_id), [])
+        for cause in entry.get("causes", [])
+    ]
+
+
+def emit_for_dialect(pattern: str, regex_dialect: str) -> tuple[str, list[str]]:
+    """Return the pattern to emit plus what RE2 still cannot run afterwards.
+
+    The portability verdict has to describe the pattern as EMITTED, not the
+    source. Under --regex-dialect pcre a `\\uXXXX` escape is left alone, which
+    is correct for PCRE/Python-re backends and still unreadable to RE2 -- so it
+    counts as a blocker there and not under --regex-dialect re2. Tagging a rule
+    re2-ok because its blocker happened to be fixable, without having fixed it,
+    would be exactly the silent-failure this metadata exists to prevent.
+    """
+    rewrites, blockers = walk_regex(pattern)
+    if regex_dialect == "re2":
+        out = pattern
+        for start, end, replacement in reversed(rewrites):
+            out = out[:start] + replacement + out[end:]
+        return out, blockers
+    if rewrites:
+        blockers = blockers + [
+            "JS-style \\uXXXX / (?<name> spelling; RE2 needs \\x{XXXX} / (?P<name> "
+            "(re-run with --regex-dialect re2)"
+        ]
+    return pattern, blockers
+
+
+def convert_conditions(atr_detection: dict, regex_dialect: str = "pcre") -> tuple[dict, str, list[str]]:
     """Turn ATR detection.conditions into Sigma selections + a condition string.
 
     Returns (selections_map, condition_expr, warnings).
@@ -224,6 +429,9 @@ def convert_conditions(atr_detection: dict) -> tuple[dict, str, list[str]]:
                 warnings.append(f"condition #{idx} has no value; skipped")
                 continue
             pattern, use_i = strip_leading_i_flag(str(value))
+            pattern, blockers = emit_for_dialect(pattern, regex_dialect)
+            for blocker in blockers:
+                warnings.append(f"condition #{idx} RE2-INCOMPATIBLE: {blocker}")
             modifier = "re|i" if use_i else "re"
             selections[sel_name] = {f"{field}|{modifier}": pattern}
         elif operator in ("gt", "lt", "gte", "lte", "eq"):
@@ -260,7 +468,12 @@ def convert_conditions(atr_detection: dict) -> tuple[dict, str, list[str]]:
     return selections, condition_expr, warnings
 
 
-def convert_rule(doc: dict, source_path: str) -> tuple[dict, list[str]]:
+def convert_rule(
+    doc: dict,
+    source_path: str,
+    regex_dialect: str = "pcre",
+    divergences: dict | None = None,
+) -> tuple[dict, list[str]]:
     """Convert one parsed ATR rule dict into a Sigma rule dict (+ warnings)."""
     warnings: list[str] = []
     atr_id = doc.get("id", "")
@@ -274,8 +487,16 @@ def convert_rule(doc: dict, source_path: str) -> tuple[dict, list[str]]:
     if not isinstance(atr_detection, dict):
         atr_detection = {}
 
-    selections, condition_expr, cond_warnings = convert_conditions(atr_detection)
+    selections, condition_expr, cond_warnings = convert_conditions(atr_detection, regex_dialect)
+    # The measured verdict describes the REWRITTEN spelling running on RE2, so
+    # it applies to the re2 emission. Under pcre the same conditions are already
+    # blocked for the earlier reason that RE2 cannot even parse \uXXXX.
+    if regex_dialect == "re2":
+        cond_warnings = cond_warnings + measured_divergence_warnings(
+            atr_id, divergences if divergences is not None else load_equivalence_divergences()
+        )
     warnings.extend(cond_warnings)
+    re2_blocked = [w for w in cond_warnings if "RE2-INCOMPATIBLE" in w]
 
     severity = str(doc.get("severity", "medium")).strip().lower()
     level = SEVERITY_TO_LEVEL.get(severity)
@@ -311,6 +532,12 @@ def convert_rule(doc: dict, source_path: str) -> tuple[dict, list[str]]:
         sigma_tags.append(f"atr.category.{str(atr_category).replace('_', '-')}")
     if atr_id:
         sigma_tags.append(f"atr.rule.{str(atr_id).lower()}")
+    # Portability is metadata, not a silent failure: a backend that compiles to
+    # RE2 (Go/Rust, i.e. most SIEM backends) can read this tag and skip the rule
+    # instead of erroring out mid-pipeline on a pattern it can never run.
+    sigma_tags.append(
+        "atr.portability.re2-blocked" if re2_blocked else "atr.portability.re2-ok"
+    )
 
     # Assemble description, honestly noting any approximation.
     desc = str(doc.get("description", "")).strip()
@@ -325,6 +552,27 @@ def convert_rule(doc: dict, source_path: str) -> tuple[dict, list[str]]:
             " NOTE: this rule contains at least one condition that could not be "
             "translated 1:1 to Sigma (see conversion warnings); treat as "
             "approximate."
+        )
+    if re2_blocked:
+        # Two distinct failure modes, and conflating them would mislead: a
+        # construct RE2 REFUSES TO COMPILE fails loudly, whereas a measured
+        # dialect divergence compiles happily and quietly matches the wrong
+        # set of inputs. The second is the dangerous one, so name it as such.
+        reasons = sorted({w.split("RE2-INCOMPATIBLE: ", 1)[-1] for w in re2_blocked})
+        measured = [r for r in reasons if "measured:" in r]
+        uncompilable = [r for r in reasons if "measured:" not in r]
+        provenance += " PORTABILITY: this rule is not safe to run on RE2-family backends (Go, Rust, and the Sigma backends built on them)."
+        if uncompilable:
+            provenance += " Cannot compile under RE2: " + "; ".join(uncompilable) + "."
+        if measured:
+            provenance += (
+                " Compiles under RE2 but does NOT reproduce the original match "
+                "behaviour, as measured by differential execution against the "
+                "reference engine: " + "; ".join(measured) + "."
+            )
+        provenance += (
+            " Such backends should skip this rule rather than emit a partial or "
+            "silently incorrect detection; PCRE/Python-re backends are unaffected."
         )
     full_desc = f"{desc}\n\n{provenance}" if desc else provenance
 
@@ -426,6 +674,21 @@ def main() -> int:
     parser.add_argument("--out", help="output directory for one .sigma.yml per rule")
     parser.add_argument("--stdout", action="store_true", help="print all Sigma docs to stdout, --- separated")
     parser.add_argument("--quiet", action="store_true", help="suppress per-rule conversion warnings")
+    parser.add_argument(
+        "--regex-dialect",
+        choices=("pcre", "re2"),
+        default="pcre",
+        help=(
+            "regex spelling to emit. pcre (default) keeps ATR's source dialect, which "
+            "PCRE/Python-re backends understand. re2 rewrites \\uXXXX to \\x{XXXX} and "
+            "(?<n> to (?P<n> for Go/Rust backends. Neither dialect can express "
+            "lookaround or backreferences in RE2 -- those rules are tagged, not faked."
+        ),
+    )
+    parser.add_argument(
+        "--portability-report",
+        help="write a JSON summary of RE2 portability across the converted rules",
+    )
     args = parser.parse_args()
 
     paths = iter_rule_paths(args.rule or None, args.all)
@@ -438,15 +701,20 @@ def main() -> int:
     converted = 0
     total_warnings = 0
     stdout_chunks: list[str] = []
+    blocked_rules: list[dict] = []
+    divergences = load_equivalence_divergences()
 
     for path in paths:
         doc = load_yaml(path)
         if doc is None:
             continue
-        sigma, warnings = convert_rule(doc, path)
+        sigma, warnings = convert_rule(doc, path, args.regex_dialect, divergences)
         text = dump_sigma(sigma)
         converted += 1
         total_warnings += len(warnings)
+        reasons = sorted({w.split("RE2-INCOMPATIBLE: ", 1)[-1] for w in warnings if "RE2-INCOMPATIBLE" in w})
+        if reasons:
+            blocked_rules.append({"id": str(doc.get("id", "")), "path": path, "reasons": reasons})
 
         if not args.quiet and warnings:
             for w in warnings:
@@ -462,10 +730,33 @@ def main() -> int:
     if stdout_chunks and (args.stdout or not args.out):
         print("\n---\n".join(stdout_chunks))
 
+    portable = converted - len(blocked_rules)
+    coverage = (portable / converted * 100.0) if converted else 0.0
+    if args.portability_report:
+        with open(args.portability_report, "w") as fh:
+            json.dump(
+                {
+                    "regex_dialect": args.regex_dialect,
+                    "rules_converted": converted,
+                    "re2_portable": portable,
+                    "re2_blocked": len(blocked_rules),
+                    "re2_coverage_pct": round(coverage, 2),
+                    "blocked": blocked_rules,
+                },
+                fh,
+                indent=2,
+            )
+            fh.write("\n")
+
     print(
         f"Converted {converted} ATR rule(s) to Sigma"
         + (f" -> {args.out}" if args.out else "")
         + f" ({total_warnings} conversion warning(s)).",
+        file=sys.stderr,
+    )
+    print(
+        f"RE2 portability: {portable}/{converted} rules runnable on RE2 backends "
+        f"({coverage:.1f}%); {len(blocked_rules)} tagged atr.portability.re2-blocked.",
         file=sys.stderr,
     )
     return 0

--- a/scripts/test_generate_sigma.py
+++ b/scripts/test_generate_sigma.py
@@ -20,9 +20,13 @@ from __future__ import annotations
 
 import glob
 import importlib.util
+import json
 import os
 import re
+import shutil
+import subprocess
 import sys
+import tempfile
 
 import yaml
 
@@ -236,6 +240,82 @@ def test_whole_corpus_converts_without_crashing():
         except Exception as exc:  # noqa: BLE001
             failures.append(f"{path}: raised {exc!r}")
     assert not failures, "corpus conversion failures:\n" + "\n".join(failures[:20])
+
+
+def _re2_regexes(rel: str, dialect: str) -> tuple[list[str], bool]:
+    """Emitted regex patterns for one rule, plus whether it is tagged blocked."""
+    doc = _load_atr(rel)
+    sigma, _ = CONV.convert_rule(doc, _abs(rel), dialect)
+    blocked = "atr.portability.re2-blocked" in (sigma.get("tags") or [])
+    patterns = [
+        val
+        for key, sel in sigma["detection"].items()
+        if key != "condition" and isinstance(sel, dict)
+        for field, val in sel.items()
+        if "|re" in field and isinstance(val, str)
+    ]
+    return patterns, blocked
+
+
+def test_every_rule_carries_a_portability_tag():
+    """A consumer must be able to tell RE2-runnable from not, per rule."""
+    for rel in SAMPLE_RULES:
+        _, s, _, _, _ = _convert(rel)
+        marks = [t for t in s["tags"] if t.startswith("atr.portability.re2-")]
+        assert len(marks) == 1, f"{rel}: expected exactly one portability tag, got {marks}"
+
+
+def test_re2_dialect_rewrites_unicode_escapes():
+    """--regex-dialect re2 emits RE2's escape spelling; pcre leaves it alone."""
+    rel = "rules/prompt-injection/ATR-2026-00258-unicode-tag-injection.yaml"
+    pcre_pats, _ = _re2_regexes(rel, "pcre")
+    re2_pats, _ = _re2_regexes(rel, "re2")
+    assert any("\\u{E0000}" in p for p in pcre_pats), "pcre dialect should keep \\u{...}"
+    assert any("\\x{E0000}" in p for p in re2_pats), "re2 dialect should emit \\x{...}"
+    assert not any("\\u{" in p for p in re2_pats), "re2 dialect must not leave \\u{...} behind"
+
+
+def test_no_untagged_rule_fails_re2_compilation():
+    """The load-bearing guarantee: an RE2 backend that honours the
+    `atr.portability.re2-blocked` tag never hits a pattern it cannot compile.
+
+    A rule that fails to compile while advertising itself as runnable is the
+    exact silent failure this metadata exists to prevent, so it is asserted
+    against the real engine rather than against our own classifier.
+    """
+    if shutil.which("go") is None:
+        print("   (skipped: no Go toolchain for the RE2 oracle)", file=sys.stderr)
+        return
+    go_src = (
+        "package main\n"
+        'import ("encoding/json";"os";"regexp")\n'
+        "func main(){var in []string\n"
+        " if err:=json.NewDecoder(os.Stdin).Decode(&in);err!=nil{os.Exit(2)}\n"
+        " out:=make([]bool,0,len(in))\n"
+        " for _,p:=range in{_,err:=regexp.Compile(p);out=append(out,err==nil)}\n"
+        " json.NewEncoder(os.Stdout).Encode(out)}\n"
+    )
+    paths = sorted(glob.glob(os.path.join(REPO, "rules", "**", "*.yaml"), recursive=True))
+    flat: list[str] = []
+    owners: list[tuple[str, bool]] = []
+    for path in paths:
+        pats, blocked = _re2_regexes(os.path.relpath(path, REPO), "re2")
+        flat.extend(pats)
+        owners.extend((os.path.basename(path), blocked) for _ in pats)
+    with tempfile.TemporaryDirectory() as tmp:
+        src = os.path.join(tmp, "main.go")
+        with open(src, "w") as fh:
+            fh.write(go_src)
+        proc = subprocess.run(
+            ["go", "run", src], input=json.dumps(flat), capture_output=True, text=True
+        )
+        assert proc.returncode == 0, f"RE2 oracle failed: {proc.stderr[:300]}"
+        ok = json.loads(proc.stdout)
+    untagged = [owners[i][0] for i, good in enumerate(ok) if not good and not owners[i][1]]
+    assert not untagged, (
+        f"{len(untagged)} pattern(s) are rejected by RE2 on rules NOT tagged "
+        f"re2-blocked (silent failure): {sorted(set(untagged))[:10]}"
+    )
 
 
 def _run_standalone() -> int:

--- a/scripts/verify-re2-equivalence.ts
+++ b/scripts/verify-re2-equivalence.ts
@@ -1,0 +1,634 @@
+/**
+ * Differential equivalence proof for the mechanical RE2 escape rewrite.
+ *
+ * scripts/fix-re2-escapes.ts claims that `\uXXXX -> \x{XXXX}` and
+ * `(?<n> -> (?P<n>` preserve meaning. A claim about regex semantics is only
+ * worth what an execution proves, so this script does not reason about it: it
+ * runs both spellings over a large shared input battery in every engine that
+ * matters and compares the match vectors position by position.
+ *
+ * THREE ARMS
+ *   JS(original)    ATR's own engine path: normalizeRegex() then
+ *                   new RegExp(src, src.includes('\\u{')||'\\p{' ? 'iu':'i').
+ *                   This is the reference behaviour -- what ATR detects today.
+ *   JS(rewritten)   Same compile path applied to the rewritten spelling.
+ *                   Equal vectors here mean the rewrite is safe to write into
+ *                   the rule YAML. Unequal means writing it breaks detection.
+ *   RE2(rewritten)  Go's regexp package (which IS RE2), the engine every
+ *                   downstream Sigma/YARA-adjacent consumer compiles to.
+ *                   Equal vectors mean the rewrite is a faithful port.
+ *
+ * A fourth control arm compiles the ORIGINAL under RE2 to confirm that the
+ * pattern really is the broken one and the audit is not inventing a problem.
+ *
+ * INPUT BATTERY (per pattern)
+ *   1. every test_cases / evasion_tests input in the whole rule corpus
+ *   2. a sample of the benign skill corpus (real-world negative text)
+ *   3. codepoint boundary probes built from the pattern's own escapes:
+ *      each referenced codepoint and its two neighbours, range endpoints and
+ *      midpoints, each alone / repeated / embedded in carrier text
+ *   4. seeded pseudo-random fuzz over an alphabet made of those codepoints
+ *      plus the pattern's own ASCII literals
+ *
+ * A single position where two arms disagree disqualifies the rewrite for that
+ * pattern; the script reports it rather than averaging it away.
+ *
+ * USAGE
+ *   npx tsx scripts/verify-re2-equivalence.ts
+ *   npx tsx scripts/verify-re2-equivalence.ts --json
+ *   npx tsx scripts/verify-re2-equivalence.ts --samples 4000
+ */
+import { readFileSync, readdirSync, mkdtempSync, writeFileSync, existsSync } from "node:fs";
+import { join, resolve, relative } from "node:path";
+import { tmpdir } from "node:os";
+import { execFileSync } from "node:child_process";
+import { load as yamlLoad } from "js-yaml";
+import { loadCorpus, collectRuleFiles, rewriteForRe2, type PatternRef } from "./fix-re2-escapes.js";
+
+const BENIGN_DIR = resolve(process.cwd(), "data/skill-benchmark/benign");
+const BENIGN_SAMPLE = 30;
+const BENIGN_CHARS = 1500;
+const DEFAULT_FUZZ = 6000;
+const MAX_FUZZ_LEN = 40;
+
+// ---------------------------------------------------------------------------
+// ATR engine compile path (mirrors src/engine.ts compilePatterns)
+// ---------------------------------------------------------------------------
+
+function normalizeRegex(pattern: string): string {
+  return pattern.replace(/^\(\?[imsx]+\)/, "");
+}
+
+export function engineCompile(value: string): RegExp | null {
+  const normalized = normalizeRegex(value);
+  const flags = normalized.includes("\\u{") || normalized.includes("\\p{") ? "iu" : "i";
+  try {
+    return new RegExp(normalized, flags);
+  } catch {
+    return null;
+  }
+}
+
+function jsVector(value: string, inputs: readonly string[]): string | null {
+  const re = engineCompile(value);
+  if (re === null) return null;
+  return inputs.map((s) => (re.test(s) ? "1" : "0")).join("");
+}
+
+// ---------------------------------------------------------------------------
+// Input battery
+// ---------------------------------------------------------------------------
+
+/** Every `input:` string under test_cases / evasion_tests in one rule doc. */
+function testCaseInputs(doc: unknown): string[] {
+  const rule = (doc ?? {}) as Record<string, unknown>;
+  const tc = (rule["test_cases"] ?? {}) as Record<string, unknown>;
+  const groups = [tc["true_positives"], tc["true_negatives"], rule["evasion_tests"]];
+  return groups.flatMap((g) =>
+    (Array.isArray(g) ? g : []).flatMap((entry) => {
+      const value = ((entry ?? {}) as Record<string, unknown>)["input"];
+      return typeof value === "string" ? [value] : [];
+    })
+  );
+}
+
+function loadCorpusTestInputs(): string[] {
+  return collectRuleFiles().flatMap((f) => testCaseInputs(yamlLoad(readFileSync(f, "utf8"))));
+}
+
+function loadBenignSample(): string[] {
+  if (!existsSync(BENIGN_DIR)) return [];
+  return readdirSync(BENIGN_DIR, { withFileTypes: true })
+    .filter((e) => e.isFile())
+    .map((e) => e.name)
+    .sort()
+    .slice(0, BENIGN_SAMPLE)
+    .map((f) => readFileSync(join(BENIGN_DIR, f), "utf8").slice(0, BENIGN_CHARS));
+}
+
+/** Codepoints named by the pattern's own \u escapes, plus range interiors. */
+function referencedCodepoints(pattern: string): number[] {
+  const plan = rewriteForRe2(pattern).plan.filter((r) => r.kind === "unicodeEscape");
+  const cps = plan.map((r) => parseInt(r.replacement.slice(3, -1), 16));
+  const ranges = plan.flatMap((r, i) => {
+    const next = plan[i + 1];
+    if (!next || pattern[r.index + r.token.length] !== "-") return [];
+    if (next.index !== r.index + r.token.length + 1) return [];
+    const lo = parseInt(r.replacement.slice(3, -1), 16);
+    const hi = parseInt(next.replacement.slice(3, -1), 16);
+    return [Math.floor((lo + hi) / 2), lo + 1, hi - 1];
+  });
+  const neighbours = cps.flatMap((cp) => [cp - 1, cp, cp + 1]);
+  return [...new Set([...neighbours, ...ranges])].filter((cp) => cp >= 0 && cp <= 0x10ffff).sort((a, b) => a - b);
+}
+
+/** ASCII literal words in the pattern -- the carrier text a real payload has. */
+function carrierWords(pattern: string): string[] {
+  return [...new Set(pattern.match(/[A-Za-z]{4,}/g) ?? [])]
+    .filter((w) => !/^(?:u|x|s|d|w|b|n|r|t)$/.test(w))
+    .slice(0, 8);
+}
+
+function boundaryProbes(pattern: string): string[] {
+  const cps = referencedCodepoints(pattern);
+  const words = carrierWords(pattern);
+  const chars = cps.map((cp) => String.fromCodePoint(cp));
+  return chars.flatMap((ch) => [
+    ch,
+    ch.repeat(3),
+    ch.repeat(8),
+    ch.repeat(16),
+    `abc${ch}def`,
+    `abc${ch.repeat(5)}def`,
+    `${ch} ${ch} ${ch}`,
+    `Encoded: ${ch.repeat(10)}`,
+    ...words.slice(0, 3).flatMap((w) => [`${w} ${ch.repeat(4)}`, `${ch.repeat(4)} ${w}`, `${w}${ch}`]),
+  ]);
+}
+
+/**
+ * Probes aimed at what the REWRITE means to a reader that does not know
+ * `\x{...}`. JavaScript without the `u` flag resolves `\x{0041}` via Annex B
+ * to a literal `x` followed by the brace quantifier `{0041}` -- i.e. "the
+ * letter x, 41 times". Unless the battery contains such strings, a rewritten
+ * pattern can look equivalent purely because nothing ever exercised the
+ * degraded reading. These probes make that reading observable.
+ */
+function rewriteArtifactProbes(after: string): string[] {
+  const braces = [...new Set(after.match(/x\{[0-9a-fA-F]+\}/g) ?? [])];
+  const counts = [...new Set(braces.map((b) => Number(b.slice(2, -1).replace(/[a-fA-F]/g, ""))))]
+    .filter((n) => Number.isFinite(n) && n > 0 && n <= 400);
+  return [
+    ...braces,
+    ...braces.map((b) => `abc${b}def`),
+    ...braces.map((b) => `${b}${b}${b}`),
+    ...counts.map((n) => "x".repeat(n)),
+    ...counts.map((n) => `abc${"x".repeat(n)}def`),
+    ...[1, 2, 3, 4, 5, 8, 16, 32, 41, 64, 96, 127, 255].map((n) => "x".repeat(n)),
+    "x{",
+    "}",
+    "x{0041}",
+    "\\x{200B}",
+  ];
+}
+
+/**
+ * Structured probes. Random fuzz cannot build "ixgnore" out of
+ * "i<ZWSP>gnore": that needs seven specific characters in order. But the
+ * degraded JS reading of `[\x{200B}...]` admits exactly the literals `x`, `{`,
+ * `}` and hex digits, so the divergence is reachable only by CONSTRUCTING it.
+ * Given an input that one arm already matches, swap the codepoints the pattern
+ * names for the characters the rewrite accidentally admits, and vice versa.
+ */
+function mutationProbes(pattern: string, after: string, matched: readonly string[]): string[] {
+  const cps = referencedCodepoints(pattern).map((cp) => String.fromCodePoint(cp));
+  const vocab = [...new Set(after.match(/[\x20-\x7e]/g) ?? [])].slice(0, 12);
+  const present = cps.filter((c) => matched.some((s) => s.includes(c)));
+  const swapOut = matched
+    .slice(0, 12)
+    .flatMap((s) => [
+      ...vocab.map((v) => present.reduce((acc, c) => acc.split(c).join(v), s)),
+      present.reduce((acc, c) => acc.split(c).join(""), s),
+    ]);
+  const swapIn = matched
+    .slice(0, 12)
+    .flatMap((s) => cps.slice(0, 6).map((c) => vocab.reduce((acc, v) => acc.split(v).join(c), s)));
+  return [...new Set([...swapOut, ...swapIn])].filter((s) => s.length > 0 && s.length < 4000);
+}
+
+/** Deterministic 32-bit LCG so a failure is always reproducible. */
+function makeRng(seed: number): () => number {
+  let state = seed >>> 0;
+  return () => {
+    state = (Math.imul(state, 1664525) + 1013904223) >>> 0;
+    return state / 0x100000000;
+  };
+}
+
+/**
+ * The fuzz alphabet must carry BOTH dialects' vocabulary: the codepoints the
+ * original names, and the characters the rewrite introduces (`x`, braces, hex
+ * digits). Omitting the latter is how a differential test lies by omission --
+ * the degraded JS reading of `\\x{0041}` can never be exercised if no input
+ * can contain an `x` or a brace.
+ */
+function fuzzAlphabet(pattern: string, after: string): string[] {
+  const cps = referencedCodepoints(pattern).map((cp) => String.fromCodePoint(cp));
+  const literals = [...new Set(pattern.match(/[\x20-\x7e]/g) ?? [])];
+  const rewriteVocab = [...new Set(after.match(/[\x20-\x7e]/g) ?? [])];
+  const spaces = ["\u0020", "\u00a0", "\u2003", "\n", "\t"];
+  const wide = ["\u{1F600}", "\u{E0041}", "\uDB40", "\uDC41"];
+  return [...new Set([...cps, ...literals, ...rewriteVocab, ...spaces, ...wide])];
+}
+
+function fuzzInputs(pattern: string, after: string, count: number, seed: number): string[] {
+  const alphabet = fuzzAlphabet(pattern, after);
+  const rnd = makeRng(seed);
+  return Array.from({ length: count }, () => {
+    const len = 1 + Math.floor(rnd() * MAX_FUZZ_LEN);
+    return Array.from({ length: len }, () => alphabet[Math.floor(rnd() * alphabet.length)]!).join("");
+  });
+}
+
+// ---------------------------------------------------------------------------
+// RE2 oracle (Go regexp)
+// ---------------------------------------------------------------------------
+
+const GO_ORACLE = `package main
+
+import (
+	"encoding/json"
+	"os"
+	"regexp"
+	"strings"
+)
+
+type job struct {
+	Pattern string   \`json:"pattern"\`
+	Inputs  []string \`json:"inputs"\`
+}
+
+type result struct {
+	OK      bool   \`json:"ok"\`
+	Error   string \`json:"error"\`
+	Matches string \`json:"matches"\`
+}
+
+func main() {
+	var jobs []job
+	if err := json.NewDecoder(os.Stdin).Decode(&jobs); err != nil {
+		os.Exit(2)
+	}
+	out := make([]result, 0, len(jobs))
+	for _, j := range jobs {
+		re, err := regexp.Compile(j.Pattern)
+		if err != nil {
+			out = append(out, result{OK: false, Error: err.Error()})
+			continue
+		}
+		var b strings.Builder
+		for _, in := range j.Inputs {
+			if re.MatchString(in) {
+				b.WriteByte('1')
+			} else {
+				b.WriteByte('0')
+			}
+		}
+		out = append(out, result{OK: true, Matches: b.String()})
+	}
+	json.NewEncoder(os.Stdout).Encode(out)
+}
+`;
+
+interface GoJob {
+  readonly pattern: string;
+  readonly inputs: readonly string[];
+}
+
+interface GoResult {
+  readonly ok: boolean;
+  readonly error: string;
+  readonly matches: string;
+}
+
+/** Escape every non-ASCII code unit so lone surrogates survive transport. */
+function encodeJobs(jobs: readonly GoJob[]): string {
+  return JSON.stringify(jobs).replace(/[\u007f-\uffff]/gu, (c) => `\\u${c.charCodeAt(0).toString(16).padStart(4, "0")}`);
+}
+
+function runGo(jobs: readonly GoJob[]): GoResult[] {
+  const dir = mkdtempSync(join(tmpdir(), "atr-re2-eq-"));
+  const src = join(dir, "main.go");
+  writeFileSync(src, GO_ORACLE, "utf8");
+  const stdout = execFileSync("go", ["run", src], {
+    input: encodeJobs(jobs),
+    encoding: "utf8",
+    maxBuffer: 512 * 1024 * 1024,
+  });
+  return JSON.parse(stdout) as GoResult[];
+}
+
+/** Go has no per-call flags; the ATR engine always compiles case-insensitive. */
+function toGoSource(value: string): string {
+  return `(?i)${normalizeRegex(value)}`;
+}
+
+// ---------------------------------------------------------------------------
+// Dialect controls: divergence classes that exist WITHOUT any rewrite
+// ---------------------------------------------------------------------------
+
+/**
+ * Every one of these patterns is already RE2-legal and contains no `\u`
+ * escape, so this script never rewrites them. If JS and RE2 still disagree on
+ * them, the disagreement belongs to the JS/RE2 dialect gap, not to the escape
+ * rewrite. This turns "that mismatch is pre-existing" from an assertion into a
+ * measurement.
+ */
+interface Control {
+  readonly name: string;
+  readonly pattern: string;
+  readonly input: string;
+  readonly why: string;
+}
+
+const CONTROLS: readonly Control[] = [
+  { name: "whitespace-nbsp", pattern: "a\\sb", input: "a\u00a0b", why: "JS \\s includes U+00A0; RE2 \\s is [\\t\\n\\f\\r ]" },
+  { name: "whitespace-emsp", pattern: "a\\sb", input: "a\u2003b", why: "JS \\s includes U+2003; RE2 \\s does not" },
+  { name: "dot-granularity", pattern: "^.$", input: "\u{1F600}", why: "JS . is one UTF-16 code unit; RE2 . is one rune" },
+  { name: "negclass-granularity", pattern: "^[^a]{1}$", input: "\u{1F600}", why: "negated class counts code units in JS, runes in RE2" },
+  { name: "surrogate-coerced", pattern: "^[\\x{DB40}]$", input: "\uDB40", why: "RE2 silently folds a surrogate escape to U+FFFD -- it compiles and matches nothing real" },
+  { name: "surrogate-pair-dead", pattern: "^\\x{DB40}[\\x{DC00}-\\x{DC7F}]$", input: "\u{E0000}", why: "a UTF-16 surrogate-pair pattern can never match its own astral codepoint in RE2" },
+  { name: "surrogate-pair-fixed", pattern: "^[\\x{E0000}-\\x{E007F}]$", input: "\u{E0000}", why: "the codepoint-range refactor of that same pattern DOES match" },
+];
+
+interface ControlResult extends Control {
+  readonly js: boolean;
+  readonly re2: boolean;
+  readonly diverges: boolean;
+}
+
+function runControls(): ControlResult[] {
+  const results = runGo(CONTROLS.map((c) => ({ pattern: `(?i)${c.pattern}`, inputs: [c.input] })));
+  return CONTROLS.map((c, i) => {
+    const js = engineCompile(c.pattern)?.test(c.input) ?? false;
+    const re2 = results[i]!.ok && results[i]!.matches === "1";
+    return { ...c, js, re2, diverges: js !== re2 };
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Verification
+// ---------------------------------------------------------------------------
+
+interface Verdict {
+  readonly ruleId: string;
+  readonly file: string;
+  readonly location: string;
+  readonly before: string;
+  readonly after: string;
+  readonly inputs: number;
+  readonly jsOriginalCompiles: boolean;
+  readonly jsRewrittenCompiles: boolean;
+  readonly re2RejectsOriginal: boolean;
+  readonly re2AcceptsRewrite: boolean;
+  readonly engineEquivalent: boolean;
+  readonly re2Equivalent: boolean;
+  readonly engineMismatches: number;
+  readonly re2Mismatches: number;
+  readonly engineDiffSamples: readonly string[];
+  readonly re2DiffSamples: readonly string[];
+  readonly notes: readonly string[];
+  readonly re2DivergenceCauses: readonly string[];
+}
+
+// ---------------------------------------------------------------------------
+// Why a rewritten pattern still behaves differently under RE2
+// ---------------------------------------------------------------------------
+//
+// These causes are dialect gaps that the escape rewrite cannot close: the
+// rewrite fixes the SPELLING, but JavaScript and RE2 still disagree about what
+// some constructs MEAN. They are only ever attached to a pattern the
+// differential run actually caught diverging, so this classification explains
+// observed evidence rather than predicting it.
+
+const SURROGATE_ESCAPE = /\\[ux]\{?(D[89AB][0-9A-F]{2})\}?/i;
+
+/** Best-effort cause list for an observed RE2 divergence. Pure. */
+function classifyRe2Divergence(before: string, after: string): string[] {
+  const causes: string[] = [];
+  if (SURROGATE_ESCAPE.test(before)) {
+    causes.push(
+      "pattern names UTF-16 surrogate codepoints (U+D800-U+DFFF); RE2 has no " +
+        "surrogates and folds them to U+FFFD, so the ported pattern compiles but can never match"
+    );
+  }
+  if (/\\[sS]/.test(after)) {
+    causes.push(
+      "\\s/\\S differ by dialect: JavaScript includes Unicode spaces (U+00A0, U+2003, U+3000, ...), " +
+        "RE2 restricts them to ASCII [\\t\\n\\f\\r ]"
+    );
+  }
+  if (/\[\^/.test(after) || /\[\\s\\S\]/.test(after) || /(?:^|[^\\])\./.test(after)) {
+    causes.push(
+      "any-character constructs count differently: JavaScript without the u flag counts UTF-16 " +
+        "code units (an astral character is two), RE2 counts runes (one), so bounded repeats disagree"
+    );
+  }
+  return causes.length > 0
+    ? causes
+    : ["observed divergence not attributable to a known dialect gap; requires human review"];
+}
+
+/** Render an input so an invisible-codepoint divergence is actually readable. */
+function showInput(s: string): string {
+  const shown = [...s.slice(0, 48)]
+    .map((ch) => {
+      const cp = ch.codePointAt(0)!;
+      return cp >= 0x20 && cp <= 0x7e ? ch : `\\u{${cp.toString(16).toUpperCase()}}`;
+    })
+    .join("");
+  return `"${shown}"${s.length > 48 ? ` (+${s.length - 48} chars)` : ""}`;
+}
+
+/** Up to `limit` positions where two match vectors disagree, with the input. */
+function diffSamples(a: string, b: string, inputs: readonly string[], limit = 4): string[] {
+  const out: string[] = [];
+  for (let i = 0; i < Math.min(a.length, b.length) && out.length < limit; i += 1) {
+    if (a[i] !== b[i]) out.push(`input#${i} ${showInput(inputs[i]!)} -> ${a[i]} vs ${b[i]}`);
+  }
+  if (a.length !== b.length) out.push("vector length differs");
+  return out;
+}
+
+function countDiff(a: string, b: string): number {
+  return [...a].reduce((n, ch, i) => (ch === b[i] ? n : n + 1), 0);
+}
+
+interface Case {
+  readonly ref: PatternRef;
+  readonly after: string;
+  readonly inputs: readonly string[];
+}
+
+function buildBase(shared: readonly string[], fuzzCount: number): Case[] {
+  return loadCorpus()
+    .map((ref) => ({ ref, rewrite: rewriteForRe2(ref.pattern) }))
+    .filter(({ rewrite }) => rewrite.plan.length > 0)
+    .map(({ ref, rewrite }, i) => ({
+      ref,
+      after: rewrite.source,
+      inputs: [
+        ...shared,
+        ...boundaryProbes(ref.pattern),
+        ...rewriteArtifactProbes(rewrite.source),
+        ...fuzzInputs(ref.pattern, rewrite.source, fuzzCount, 0x5eed + i * 7919),
+      ],
+    }));
+}
+
+/** Inputs either JS arm already matches -- the seeds worth mutating. */
+function matchedInputs(c: Case): string[] {
+  const before = engineCompile(c.ref.pattern);
+  const afterRe = engineCompile(c.after);
+  return c.inputs.filter((s) => (before?.test(s) ?? false) || (afterRe?.test(s) ?? false)).slice(0, 24);
+}
+
+function buildCases(shared: readonly string[], fuzzCount: number): Case[] {
+  return buildBase(shared, fuzzCount).map((c) => ({
+    ...c,
+    inputs: [...c.inputs, ...mutationProbes(c.ref.pattern, c.after, matchedInputs(c))],
+  }));
+}
+
+function judge(c: Case, re2Orig: GoResult, re2New: GoResult): Verdict {
+  const jsBefore = jsVector(c.ref.pattern, c.inputs);
+  const jsAfter = jsVector(c.after, c.inputs);
+  const notes: string[] = [];
+  if (jsAfter === null) notes.push("rewritten pattern does not compile in JavaScript at all");
+  if (!re2Orig.ok) notes.push(`RE2 rejects the original: ${re2Orig.error}`);
+  if (!re2New.ok) notes.push(`RE2 rejects the rewrite: ${re2New.error}`);
+  const engineEquivalent = jsBefore !== null && jsAfter !== null && jsBefore === jsAfter;
+  const re2Equivalent = jsBefore !== null && re2New.ok && jsBefore === re2New.matches;
+  return {
+    ruleId: c.ref.ruleId,
+    file: relative(process.cwd(), c.ref.file),
+    location: `detection.conditions[${c.ref.index}].value`,
+    before: c.ref.pattern,
+    after: c.after,
+    inputs: c.inputs.length,
+    jsOriginalCompiles: jsBefore !== null,
+    jsRewrittenCompiles: jsAfter !== null,
+    re2RejectsOriginal: !re2Orig.ok,
+    re2AcceptsRewrite: re2New.ok,
+    engineEquivalent,
+    re2Equivalent,
+    engineMismatches: jsBefore !== null && jsAfter !== null ? countDiff(jsBefore, jsAfter) : c.inputs.length,
+    re2Mismatches: jsBefore !== null && re2New.ok ? countDiff(jsBefore, re2New.matches) : c.inputs.length,
+    engineDiffSamples: jsBefore !== null && jsAfter !== null ? diffSamples(jsBefore, jsAfter, c.inputs) : [],
+    re2DiffSamples: jsBefore !== null && re2New.ok ? diffSamples(jsBefore, re2New.matches, c.inputs) : [],
+    notes,
+    re2DivergenceCauses: re2Equivalent ? [] : classifyRe2Divergence(c.ref.pattern, c.after),
+  };
+}
+
+function renderControls(controls: readonly ControlResult[]): string[] {
+  return [
+    "DIALECT CONTROLS -- RE2-legal patterns this script never rewrites",
+    ...controls.map(
+      (c) =>
+        `  ${c.name.padEnd(22)} JS=${c.js ? 1 : 0} RE2=${c.re2 ? 1 : 0}  ${c.diverges ? "DIVERGES" : "agrees  "}  ${c.why}`
+    ),
+    "",
+  ];
+}
+
+function renderReport(verdicts: readonly Verdict[], sharedCount: number, controls: readonly ControlResult[]): string {
+  const engineOk = verdicts.filter((v) => v.engineEquivalent);
+  const re2Ok = verdicts.filter((v) => v.re2Equivalent);
+  const line = (v: Verdict): string =>
+    `  ${v.ruleId} ${v.location.padEnd(32)} inputs=${String(v.inputs).padStart(5)}  ` +
+    `JS=${v.engineEquivalent ? "SAME" : `DIFF(${v.engineMismatches})`}  ` +
+    `RE2=${v.re2Equivalent ? "SAME" : `DIFF(${v.re2Mismatches})`}`;
+  return [
+    "RE2 rewrite equivalence proof -- executed, not argued",
+    "=".repeat(78),
+    `patterns rewritten            ${verdicts.length}`,
+    `shared inputs per pattern     ${sharedCount}`,
+    `total match comparisons       ${verdicts.reduce((n, v) => n + v.inputs * 2, 0)}`,
+    "",
+    `RE2 rejects the ORIGINAL      ${verdicts.filter((v) => v.re2RejectsOriginal).length} / ${verdicts.length}  (control: the problem is real)`,
+    `RE2 accepts the REWRITE       ${verdicts.filter((v) => v.re2AcceptsRewrite).length} / ${verdicts.length}`,
+    "",
+    `JS(before) == JS(after)       ${engineOk.length} / ${verdicts.length}  <- safe to write into rules/`,
+    `JS(before) == RE2(after)      ${re2Ok.length} / ${verdicts.length}  <- faithful downstream port`,
+    "",
+    ...verdicts.map(line),
+    "",
+    ...renderControls(controls),
+    ...verdicts
+      .filter((v) => !v.engineEquivalent || !v.re2Equivalent)
+      .flatMap((v) => [
+        `${v.ruleId} ${v.location}`,
+        `  before  ${v.before}`,
+        `  after   ${v.after}`,
+        ...v.engineDiffSamples.map((d) => `  JS  diverges: ${d}`),
+        ...v.re2DiffSamples.map((d) => `  RE2 diverges: ${d}`),
+        ...v.notes.map((n) => `  note: ${n}`),
+        "",
+      ]),
+  ].join("\n");
+}
+
+/**
+ * Persist the executed verdict so the exporters can tag portability from
+ * measured behaviour instead of re-deriving engine semantics in another
+ * language. scripts/generate-sigma.py reads this file; regenerate it with
+ * `--write-equivalence` whenever a rewritten pattern changes.
+ */
+function writeEquivalenceArtifact(path: string, verdicts: readonly Verdict[]): void {
+  const diverging = verdicts.filter((v) => !v.re2Equivalent);
+  const byRule = diverging.reduce<Record<string, unknown[]>>(
+    (acc, v) => ({
+      ...acc,
+      [v.ruleId]: [
+        ...(acc[v.ruleId] ?? []),
+        {
+          location: v.location,
+          mismatches: v.re2Mismatches,
+          inputs: v.inputs,
+          causes: v.re2DivergenceCauses,
+          examples: v.re2DiffSamples.slice(0, 2),
+        },
+      ],
+    }),
+    {}
+  );
+  writeFileSync(
+    path,
+    JSON.stringify(
+      {
+        generatedAt: new Date().toISOString(),
+        note:
+          "Patterns whose mechanical RE2 escape rewrite compiles under RE2 but does NOT reproduce " +
+          "the original JavaScript match vector. Produced by scripts/verify-re2-equivalence.ts " +
+          "(differential execution, not static analysis). Consumed by scripts/generate-sigma.py " +
+          "so a rule that would silently mis-detect on an RE2 backend is tagged, not shipped as clean.",
+        patternsRewritten: verdicts.length,
+        re2Equivalent: verdicts.length - diverging.length,
+        re2Divergent: diverging.length,
+        divergentRules: byRule,
+      },
+      null,
+      2
+    ) + "\n",
+    "utf8"
+  );
+}
+
+function main(): void {
+  const argv = process.argv.slice(2);
+  const fuzzArg = argv.indexOf("--samples");
+  const fuzzCount = fuzzArg === -1 ? DEFAULT_FUZZ : Number(argv[fuzzArg + 1] ?? DEFAULT_FUZZ);
+  const shared = [...new Set([...loadCorpusTestInputs(), ...loadBenignSample()])];
+  const cases = buildCases(shared, fuzzCount);
+  const re2Orig = runGo(cases.map((c) => ({ pattern: toGoSource(c.ref.pattern), inputs: c.inputs })));
+  const re2New = runGo(cases.map((c) => ({ pattern: toGoSource(c.after), inputs: c.inputs })));
+  const verdicts = cases.map((c, i) => judge(c, re2Orig[i]!, re2New[i]!));
+  const controls = runControls();
+
+  const writeArg = argv.indexOf("--write-equivalence");
+  if (writeArg !== -1) {
+    const out = resolve(process.cwd(), argv[writeArg + 1] ?? "data/re2-equivalence.json");
+    writeEquivalenceArtifact(out, verdicts);
+    console.error(`[verify-re2] wrote ${relative(process.cwd(), out)}`);
+  }
+
+  if (argv.includes("--json")) {
+    process.stdout.write(JSON.stringify({ sharedInputs: shared.length, fuzzCount, controls, verdicts }, null, 2) + "\n");
+  } else {
+    process.stdout.write(renderReport(verdicts, shared.length, controls) + "\n");
+  }
+  if (verdicts.some((v) => !v.re2Equivalent)) process.exitCode = 1;
+}
+
+main();


### PR DESCRIPTION
## What

A four-stage chain that makes ATR detection regexes verifiably runnable on RE2-family engines, plus a CI ratchet that stops new incompatibility from landing.

- scripts/audit-re2-portability.ts — finds incompatible constructs. With `--verify-re2` it compiles every pattern with Go's `regexp` package, which IS RE2, so the verdict is measured rather than inferred from a hand-written scanner.
- scripts/fix-re2-escapes.ts — the mechanical, meaning-preserving rewrites (`\uXXXX` to `\x{XXXX}`, `(?<n>` to `(?P<n>`).
- scripts/verify-re2-equivalence.ts — proves each rewrite is faithful instead of assuming it, by running original and rewrite over a shared input battery in both engines and reporting any position where they disagree. Emits data/re2-equivalence.json.
- scripts/generate-sigma.py — consumes that measured verdict and tags every emitted rule `atr.portability.re2-ok` or `atr.portability.re2-blocked`. Adds `--regex-dialect {pcre,re2}` and `--portability-report`. Default output is unchanged.
- scripts/gate-re2-portability.ts + .github/workflows/re2-portability.yml — the ratchet, against data/re2-portability-baseline.json.

No rule files are touched. The RE2 rewrite happens at export time and never lands in rules/ — `git show HEAD -- rules` is empty on this branch.

## Why

Nothing caught this before. generate-sigma.py copied regexes through verbatim and never compiled them, so a rule using PCRE-only syntax exported "successfully" and only failed once a downstream consumer fed it to a real RE2 backend. Go `regexp`, Rust `regex`, and every Sigma backend built on them are RE2: a finite-automaton engine that rejects lookaround, backreferences, atomic groups and possessive quantifiers outright, spells `\uXXXX` as `\x{XXXX}`, and caps repeat bounds at 1000.

Measured on the current corpus: 114 of 768 rules (192 of 3254 patterns) cannot run on RE2 — 83 lookaround, 27 unicode escape, 4 backreference. Those rules are silently dropped by an RE2 consumer today.

The quieter half of the problem is the reason verify-re2-equivalence.ts exists. A static scanner can only find what RE2 refuses to compile. It cannot find a pattern that compiles fine under RE2 and means something different, because JavaScript and RE2 disagree about `\s` (Unicode vs ASCII) and about whether a bounded repeat counts UTF-16 code units or runes. Differential execution found 6 such patterns among the 54 mechanically rewritable ones. Those are the dangerous ones: they would have shipped tagged as clean.

## Evidence

All numbers below are from running the workflow's own steps against a pristine checkout of origin/main plus this branch's 9 files — not against the local working tree — so they are what CI will see.

Corpus: 768 rules, 3254 regex patterns (matches the committed baseline exactly).

Step 1, audit with the Go/RE2 oracle:

    incompatible       114 rules / 192 patterns
    byClass            lookaround 83, unicodeEscape 27, backreference 4,
                       atomicOrPossessive 0, namedGroup 0
    oracle             available, disagreements: []   (real RE2 agrees with the
                       scanner on every one of the 3254 patterns)

Step 2, the ratchet:

    corpus: 768 rules, 3254 regex patterns
    not portable: 114 rules / 192 patterns (baseline 114 rules)
    oracle: real RE2 (Go regexp) agrees with the scanner on every pattern
    GATE PASS -- no new RE2 incompatibility.

Step 3, equivalence artifact: 48 of 54 rewritten patterns verified exactly equivalent under differential execution; 6 divergent across 5 rules (ATR-2026-00129, 00276, 00308, 00309, 02010), each with a named cause rather than a bare failure.

scripts/test_generate_sigma.py: 11 passed. `npx tsc --noEmit`: clean (tsconfig includes src/\*\*/\*.ts only, so the new scripts/ files are outside typecheck scope and run under tsx).

Forward check — the gate still passes once the sibling rule batches land. Re-ran all three steps against a 779-rule corpus (the 11 new rules plus the revived drafts): 3323 patterns, still 114 incompatible rules, GATE PASS. The new rules introduce no new incompatibility.

One defect found and fixed during that forward check. The staleness check on data/re2-equivalence.json originally diffed the whole verdict object, which embeds the input battery magnitudes (`inputs`, `mismatches`, example indices). That battery is built from every test_cases entry in the whole corpus, so adding a single rule shifts those numbers on every entry while changing nothing about which rule is portable. Verified against the 779-rule corpus: the original comparison FAILS, which would have turned main red on the next rule merge and on every auto-crystallize push. The check now compares the tagging verdict only — which rule, at which condition, for which cause — which is exactly what generate-sigma.py reads to choose between re2-ok and re2-blocked. Confirmed still sharp with four negative tests: dropping a divergence, corrupting a cause, and gaining a new divergent rule are all caught; battery-magnitude noise alone correctly stays quiet.

data/re2-equivalence.json is committed as generated against origin/main's 768-rule corpus, so the artifact honestly describes the tree it ships with.

## Risk

Does not trigger npm publish. publish-on-rules-merge.yml fires on `push` to main filtered to `rules/**`, and this PR touches no rule files. publish.yml fires on `v*` tags only.

No effect on existing users. No rule content, no src/, no package.json, no runtime code path changes. generate-sigma.py's default output is byte-identical except for the added `atr.portability.*` tag; the RE2 rewrite only happens under the opt-in `--regex-dialect re2`.

The real cost is a new CI job requiring Go 1.25. `--require-oracle` makes a missing Go toolchain a hard error rather than a silent downgrade to static analysis — deliberate, because a PASS should mean real RE2 compiled every pattern, not that a scanner guessed. Go ships preinstalled on ubuntu-latest but the workflow pins it via actions/setup-go rather than depending on an undeclared property of the runner image.

The gate is a ratchet, not a hard gate. Most of the existing 114-rule debt needs a genuine refactor — lookaround has no RE2 spelling at all — so failing every PR until the backlog clears would stop all rule work. Like maturity-fp-gate.yml, this blocks new damage and lets the backlog drain on its own schedule.

It compares the whole corpus rather than a PR diff, and runs on push to main as well as on PRs, because rules also land through doors that never open a pull request (the CVE collector and auto-crystallize commit straight to main). A diff-scoped gate cannot see those.
