### PR TITLE
fix(ci): gate promotions on the event shapes rules actually detect on

### DIFF
--- a/scripts/gate-promotion-fp.ts
+++ b/scripts/gate-promotion-fp.ts
@@ -1,25 +1,84 @@
 #!/usr/bin/env node
 /**
  * gate-promotion-fp.ts — block a maturity promotion that would put an
- * FP-producing rule into the enforce (auto-block) lane.
+ * FP-producing rule into the enforce (auto-block) lane, and/or hand back the
+ * FP-clean subset so an upstream promoter can promote only what is safe.
  *
  * WHY: maturity:stable is the enforce lane (see engine.ts — "enforce = only
  * maturity=stable rules, auto-block, lowest FP"). A promoter that keys on time
- * ("≥60 days in test + 0 FP *reports*") can promote a rule that has never been
+ * (">=60 days in test + 0 FP *reports*") can promote a rule that has never been
  * scanned against a benign corpus. This gate re-runs the rules a PR promotes to
  * stable/production against the local benign corpora and FAILS if any of them
  * false-positive — so a bad promotion turns the PR red instead of shipping.
  *
+ * The same scan is also useful BEFORE a promotion PR exists: run it as a filter,
+ * take the clean ids, and open a PR that only promotes those. That is what
+ * --emit-clean / --emit-dirty / --filter-mode are for.
+ *
  * Modes:
  *   gate-promotion-fp.ts --base origin/main   # auto-detect rules this branch
  *                                             # sets to stable/production, gate them
- *   gate-promotion-fp.ts --ids <file>         # gate an explicit ATR-id list
+ *   gate-promotion-fp.ts --ids <file>         # gate an explicit ATR-id list.
+ *                                             # Every id MUST resolve to a rule
+ *                                             # file on disk (tracked or not);
+ *                                             # an id that does not is exit 3.
  *
- * Exit 0 = no promoted rule false-positives (or nothing promoted).
- * Exit 1 = at least one promoted rule FPs on the benign corpus.
+ * Output flags (compose with either mode):
+ *   --emit-clean <path>   write the FP-clean ids, one per line
+ *   --emit-dirty <path>   write the FP-producing ids, one per line (worst first)
+ *   --filter-mode         report FP-dirty rules but still exit 0
+ *
+ * Exit codes:
+ *   0  gate passed (no promoted rule false-positives), nothing to gate, OR
+ *      --filter-mode was requested (the caller consumes the emitted lists
+ *      instead of the exit code)
+ *   1  gate failed: at least one promoted rule FPs on the benign corpus
+ *      (default/gate semantics — unchanged), or an unexpected runtime error
+ *   2  usage error: the flags given cannot produce a meaningful run
+ *   3  --ids named rule ids that no file on disk carries. The requested scan
+ *      cannot be performed, so no verdict is reported (see below).
+ *
+ * DEFAULT BEHAVIOUR IS FROZEN: with no output flags this script behaves exactly
+ * as before (CI's maturity-fp-gate workflow depends on it). --emit-clean alone
+ * keeps gate semantics — it only adds a side output. Only the explicit opt-in
+ * --filter-mode relaxes the exit code, and it refuses to run unless it is
+ * paired with an emit target, so it can never be used to silently mute the gate.
+ *
+ * THREE WAYS THIS GATE USED TO PASS WITHOUT MEASURING ANYTHING (all fixed here):
+ *
+ *   1. The candidate list came from `git ls-files rules/` — tracked files only.
+ *      Rules are routinely written to rules/ and gated BEFORE being committed
+ *      (scripts/fn-mine-llm.ts authors straight into the tree, then gates), and
+ *      for those `--ids` resolved zero targets, printed "nothing to gate" and
+ *      exited 0. A zero-measurement PASS on precisely the rules that had never
+ *      been measured. Candidates now include untracked-but-not-ignored files.
+ *
+ *   2. An id in the --ids file that matched no rule on disk was a WARN and
+ *      nothing more. A promoter feeding a stale or typo'd id list therefore got
+ *      exit 0 and an empty clean list, which reads as "scanned, all fine". That
+ *      is now exit 3, with the unresolved ids named, and no list is written —
+ *      an unread verdict must not leave a consumable artifact behind.
+ *
+ *   3. THE EVENT SHAPE COULD NOT RESOLVE THE FIELD THE RULE DETECTS ON. The scan
+ *      built one `mcp_exchange` event carrying only tool_name / tool_input /
+ *      tool_response / user_input. `field: tool_args` resolves to undefined on
+ *      that event (src/engine.ts resolveField wants fields.tool_args, or an event
+ *      typed tool_call), so all 40 rules that detect on tool_args — three of them
+ *      maturity:stable, i.e. already in the auto-blocking enforce lane — were
+ *      scored against a field no sample ever filled, and every one came back
+ *      CLEAN. Same for agent_output, agent_message and tool_description. The
+ *      shape set now lives in scripts/lib/corpus-event.ts, mirrors what
+ *      src/hook-handler.ts actually emits (including the JSON encoding of
+ *      tool_args), and is meant to be shared with the true-positive side so a
+ *      rule can never earn its detection credit on a wider shape than the one it
+ *      pays its false positives on. Fields a text corpus genuinely cannot fill
+ *      (tool_name, trace, behavioral) are now reported as NOT MEASURED instead of
+ *      being folded silently into the clean list.
  */
 import {
   readFileSync,
+  writeFileSync,
+  mkdirSync,
   readdirSync,
   existsSync,
   statSync,
@@ -31,66 +90,252 @@ import { tmpdir } from "node:os";
 import { execFileSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { ATREngine } from "../src/engine.js";
-import type { AgentEvent } from "../src/types.js";
+import {
+  corpusShapes,
+  shapeNames,
+  fieldCoverage,
+  unmeasurableReason,
+  type FieldCoverage,
+} from "./lib/corpus-event.js";
 
 const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
-const RULES_DIR = join(REPO_ROOT, "rules");
-const CORPORA = [
-  join(REPO_ROOT, "data/skill-benchmark/benign"),
-  join(REPO_ROOT, "data/benign-corpus-extended"),
-  join(REPO_ROOT, "data/benign-code"),
-];
 const ENFORCE_MATURITIES = new Set(["stable", "production"]);
 
-function arg(name: string): string | null {
-  const i = process.argv.indexOf(name);
-  return i >= 0 ? (process.argv[i + 1] ?? null) : null;
+export const EXIT_OK = 0;
+export const EXIT_FAIL = 1;
+export const EXIT_USAGE = 2;
+export const EXIT_MISSING_IDS = 3;
+
+/** Thrown when the given flag combination cannot produce a meaningful run. */
+export class GateUsageError extends Error {}
+
+export interface GateOptions {
+  readonly idsFile: string | null;
+  readonly base: string;
+  readonly emitClean: string | null;
+  readonly emitDirty: string | null;
+  readonly filterMode: boolean;
 }
 
-/** Rule files this branch sets to an enforce-lane maturity, vs the base ref. */
-function promotedFilesFromDiff(base: string): string[] {
-  const diff = execFileSync(
-    "git",
-    ["diff", `${base}...HEAD`, "--unified=0", "--", "rules/"],
-    { cwd: REPO_ROOT, encoding: "utf-8", maxBuffer: 64 * 1024 * 1024 },
-  );
+/**
+ * Filesystem surface the gate reads. Injected so tests can run the whole gate
+ * against a fixture corpus. Deliberately NOT reachable from the CLI or the
+ * environment: a security gate must not be re-pointable by configuration.
+ */
+export interface GateDeps {
+  readonly repoRoot: string;
+  readonly rulesDir: string;
+  readonly corpora: readonly string[];
+  /** Repo-relative paths of every rule file the gate can scan. */
+  readonly listRuleFiles: () => readonly string[];
+}
+
+export function defaultDeps(): GateDeps {
+  return {
+    repoRoot: REPO_ROOT,
+    rulesDir: join(REPO_ROOT, "rules"),
+    corpora: [
+      join(REPO_ROOT, "data/skill-benchmark/benign"),
+      join(REPO_ROOT, "data/benign-corpus-extended"),
+      join(REPO_ROOT, "data/benign-code"),
+    ],
+    listRuleFiles: () => gitRuleFiles(REPO_ROOT),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// CLI parsing (pure)
+// ---------------------------------------------------------------------------
+
+/** Legacy lookup for --ids / --base: absent or value-less both read as null. */
+function legacyValue(argv: readonly string[], name: string): string | null {
+  const i = argv.indexOf(name);
+  return i >= 0 ? (argv[i + 1] ?? null) : null;
+}
+
+/** Strict lookup for the output flags: a flag without a value is an error. */
+function pathValue(argv: readonly string[], name: string): string | null {
+  const i = argv.indexOf(name);
+  if (i < 0) return null;
+  const value = argv[i + 1];
+  if (value === undefined || value.startsWith("--") || value.trim() === "") {
+    throw new GateUsageError(`${name} requires a <path> value`);
+  }
+  return value;
+}
+
+export function parseCliOptions(argv: readonly string[]): GateOptions {
+  const emitClean = pathValue(argv, "--emit-clean");
+  const emitDirty = pathValue(argv, "--emit-dirty");
+  const filterMode = argv.includes("--filter-mode");
+  if (emitClean !== null && emitClean === emitDirty) {
+    throw new GateUsageError("--emit-clean and --emit-dirty must be different paths");
+  }
+  if (filterMode && emitClean === null && emitDirty === null) {
+    throw new GateUsageError(
+      "--filter-mode suppresses the failure exit code, so it must be paired with " +
+        "--emit-clean <path> and/or --emit-dirty <path>. Without an emitted list the " +
+        "run produces no machine-readable output and would only hide FP-dirty rules.",
+    );
+  }
+  return {
+    idsFile: legacyValue(argv, "--ids"),
+    base: legacyValue(argv, "--base") ?? "origin/main",
+    emitClean,
+    emitDirty,
+    filterMode,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Pure helpers
+// ---------------------------------------------------------------------------
+
+/** Rule files a diff sets to an enforce-lane maturity. */
+export function parsePromotedFiles(diff: string): readonly string[] {
   const files = new Set<string>();
   let current: string | null = null;
   for (const line of diff.split("\n")) {
-    const m = /^\+\+\+ b\/(rules\/.*\.ya?ml)$/.exec(line);
-    if (m) {
-      current = m[1] ?? null;
+    const header = /^\+\+\+ b\/(rules\/.*\.ya?ml)$/.exec(line);
+    if (header) {
+      current = header[1] ?? null;
       continue;
     }
-    const mm = /^\+\s*maturity:\s*["']?(\w+)["']?\s*$/.exec(line);
-    if (mm && current && ENFORCE_MATURITIES.has(mm[1] ?? "")) files.add(current);
+    const maturity = /^\+\s*maturity:\s*["']?(\w+)["']?\s*$/.exec(line);
+    if (maturity && current && ENFORCE_MATURITIES.has(maturity[1] ?? "")) files.add(current);
   }
   return [...files];
 }
 
-function ruleIdOf(file: string): string | null {
-  for (const line of readFileSync(join(REPO_ROOT, file), "utf-8").split("\n")) {
+export interface FpPartition {
+  readonly clean: readonly string[];
+  readonly dirty: readonly (readonly [string, number])[];
+}
+
+/** Split scanned ids into FP-clean and FP-producing, deterministically ordered. */
+export function partitionByFp(counts: ReadonlyMap<string, number>): FpPartition {
+  const entries = [...counts.entries()];
+  const clean = entries
+    .filter(([, n]) => n === 0)
+    .map(([id]) => id)
+    .sort((a, b) => a.localeCompare(b));
+  const dirty = entries
+    .filter(([, n]) => n > 0)
+    .map(([id, n]) => [id, n] as const)
+    .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]));
+  return { clean, dirty };
+}
+
+/**
+ * Gate semantics (default): any FP-dirty rule fails the run.
+ * Filter semantics (--filter-mode): the caller wants the lists, not a verdict,
+ * so a dirty finding is data — exiting non-zero would abort a `set -e` promoter.
+ */
+export function resolveExitCode(dirtyCount: number, filterMode: boolean): number {
+  if (dirtyCount === 0) return EXIT_OK;
+  return filterMode ? EXIT_OK : EXIT_FAIL;
+}
+
+/** One id per line; an empty list yields an empty file, never a blank line. */
+export function formatIdList(ids: readonly string[]): string {
+  return ids.length === 0 ? "" : `${ids.join("\n")}\n`;
+}
+
+// ---------------------------------------------------------------------------
+// Filesystem / git
+// ---------------------------------------------------------------------------
+
+/** Runs a git command in the repo and returns stdout. Injected so the file
+ *  discovery contract can be tested without spawning git. */
+export type GitRunner = (args: readonly string[]) => string;
+
+function execGit(repoRoot: string): GitRunner {
+  return (args) =>
+    execFileSync("git", [...args], {
+      cwd: repoRoot,
+      encoding: "utf-8",
+      maxBuffer: 64 * 1024 * 1024,
+    });
+}
+
+/**
+ * Every rule file the gate may scan: tracked, PLUS untracked-but-not-ignored.
+ *
+ * The untracked half is the whole point. `git ls-files rules/` alone made the
+ * gate blind to rules that exist on disk but have never been committed — which
+ * is the normal state of a freshly authored rule, and the exact moment its FP
+ * behaviour most needs measuring. With them invisible, `--ids` resolved zero
+ * targets and the gate printed "nothing to gate" and exited 0.
+ *
+ * Files that git still tracks but that are gone from the working tree are
+ * dropped: the gate measures what is on disk, and a deleted rule cannot be
+ * scanned. If such an id was explicitly requested it surfaces as a missing id
+ * (exit 3) rather than as a crash or a silent skip.
+ */
+export function gitRuleFiles(repoRoot: string, run: GitRunner = execGit(repoRoot)): readonly string[] {
+  const isRule = (f: string): boolean => f.endsWith(".yaml") || f.endsWith(".yml");
+  const tracked = run(["ls-files", "--", "rules/"]).split("\n").filter(isRule);
+  const untracked = run(["ls-files", "--others", "--exclude-standard", "--", "rules/"])
+    .split("\n")
+    .filter(isRule);
+  return [...new Set([...tracked, ...untracked])]
+    .filter((f) => existsSync(join(repoRoot, f)))
+    .sort();
+}
+
+function promotedFilesFromDiff(base: string, repoRoot: string): readonly string[] {
+  const diff = execFileSync("git", ["diff", `${base}...HEAD`, "--unified=0", "--", "rules/"], {
+    cwd: repoRoot,
+    encoding: "utf-8",
+    maxBuffer: 64 * 1024 * 1024,
+  });
+  return parsePromotedFiles(diff);
+}
+
+function ruleIdOf(repoRoot: string, file: string): string | null {
+  for (const line of readFileSync(join(repoRoot, file), "utf-8").split("\n")) {
     const m = /^id:\s*(\S+)/.exec(line);
     if (m) return m[1] ?? null;
   }
   return null;
 }
 
-function asTextEvent(content: string): AgentEvent {
-  return {
-    type: "mcp_exchange",
-    timestamp: new Date().toISOString(),
-    content,
-    fields: {
-      tool_name: "corpus-sample",
-      tool_input: content,
-      tool_response: content,
-      user_input: content,
-    },
-  };
+function writeIdList(path: string, ids: readonly string[]): void {
+  const target = resolve(path);
+  mkdirSync(dirname(target), { recursive: true });
+  writeFileSync(target, formatIdList(ids), "utf-8");
 }
 
-function loadCorpusTexts(pathStr: string): string[] {
+/** Always write the requested lists — even empty ones — so `set -e` callers can read unconditionally. */
+function emitLists(options: GateOptions, partition: FpPartition): void {
+  if (options.emitClean !== null) {
+    writeIdList(options.emitClean, partition.clean);
+    console.log(`[fp-gate] wrote ${partition.clean.length} clean id(s) -> ${options.emitClean}`);
+  }
+  if (options.emitDirty !== null) {
+    const ids = partition.dirty.map(([id]) => id);
+    writeIdList(options.emitDirty, ids);
+    console.log(`[fp-gate] wrote ${ids.length} dirty id(s) -> ${options.emitDirty}`);
+  }
+}
+
+/**
+ * Every rule id a benign sample matches, across the whole canonical shape set.
+ *
+ * Counted PER SAMPLE, not per shape: a document that trips a rule on two shapes
+ * is one false positive, not two. That keeps the number comparable with what the
+ * gate reported before the shape set was widened.
+ */
+function matchedRuleIds(engine: ATREngine, text: string): ReadonlySet<string> {
+  const matched = new Set<string>();
+  for (const shape of corpusShapes(text)) {
+    for (const m of engine.evaluate(shape.event)) matched.add(m.rule.id);
+  }
+  for (const m of engine.scanSkill(text)) matched.add(m.rule.id);
+  return matched;
+}
+
+function loadCorpusTexts(pathStr: string): readonly string[] {
   const texts: string[] = [];
   if (!existsSync(pathStr)) return texts;
   const files: string[] = [];
@@ -124,72 +369,202 @@ function loadCorpusTexts(pathStr: string): string[] {
 }
 
 /** Copy just the target rule files into a temp dir so the engine loads only them. */
-function scopedRulesDir(files: string[]): string {
+function scopedRulesDir(repoRoot: string, files: readonly string[]): string {
   const dir = mkdtempSync(join(tmpdir(), "atr-gate-"));
-  for (const f of files) copyFileSync(join(REPO_ROOT, f), join(dir, basename(f)));
+  for (const f of files) copyFileSync(join(repoRoot, f), join(dir, basename(f)));
   return dir;
 }
 
-async function main(): Promise<void> {
-  const idsFile = arg("--ids");
-  const base = arg("--base") ?? "origin/main";
+// ---------------------------------------------------------------------------
+// Gate
+// ---------------------------------------------------------------------------
 
-  let targetFiles: string[];
-  let targetIds: Set<string>;
+interface Targets {
+  readonly files: readonly string[];
+  readonly ids: ReadonlySet<string>;
+  /** Ids requested via --ids that no rule file on disk carries. */
+  readonly missing: readonly string[];
+}
 
-  if (idsFile) {
-    targetIds = new Set(
-      readFileSync(idsFile, "utf-8").split("\n").map((s) => s.trim()).filter(Boolean),
-    );
-    targetFiles = [];
-    for (const f of execFileSync("git", ["ls-files", "rules/"], {
-      cwd: REPO_ROOT,
-      encoding: "utf-8",
-      maxBuffer: 64 * 1024 * 1024,
-    }).split("\n")) {
-      if (!f.endsWith(".yaml") && !f.endsWith(".yml")) continue;
-      const id = ruleIdOf(f);
-      if (id && targetIds.has(id)) targetFiles.push(f);
+function targetsFromIdsFile(idsFile: string, deps: GateDeps): Targets {
+  const requested = new Set(
+    readFileSync(idsFile, "utf-8")
+      .split("\n")
+      .map((s) => s.trim())
+      .filter(Boolean),
+  );
+  const files: string[] = [];
+  const found = new Set<string>();
+  for (const f of deps.listRuleFiles()) {
+    const id = ruleIdOf(deps.repoRoot, f);
+    if (id !== null && requested.has(id)) {
+      files.push(f);
+      found.add(id);
     }
-  } else {
-    targetFiles = promotedFilesFromDiff(base);
-    targetIds = new Set(targetFiles.map(ruleIdOf).filter((x): x is string => !!x));
   }
+  const missing = [...requested].filter((id) => !found.has(id)).sort();
+  return { files, ids: found, missing };
+}
 
-  if (targetFiles.length === 0) {
-    console.log(`[fp-gate] no rules promoted to enforce lane vs ${base} — nothing to gate.`);
-    return;
-  }
-  console.log(`[fp-gate] gating ${targetFiles.length} promoted rule(s) against the benign corpus`);
+function resolveTargets(options: GateOptions, deps: GateDeps): Targets {
+  if (options.idsFile !== null) return targetsFromIdsFile(options.idsFile, deps);
+  const files = promotedFilesFromDiff(options.base, deps.repoRoot);
+  const ids = files
+    .map((f) => ruleIdOf(deps.repoRoot, f))
+    .filter((x): x is string => x !== null);
+  return { files, ids: new Set(ids), missing: [] };
+}
 
-  const engine = new ATREngine({ rulesDir: scopedRulesDir(targetFiles) });
+interface ScanResult {
+  readonly counts: ReadonlyMap<string, number>;
+  readonly sampleCount: number;
+  /** Target rules with conditions this corpus cannot measure. */
+  readonly coverage: readonly FieldCoverage[];
+}
+
+async function scanFpCounts(targets: Targets, deps: GateDeps): Promise<ScanResult> {
+  const engine = new ATREngine({ rulesDir: scopedRulesDir(deps.repoRoot, targets.files) });
   await engine.loadRules();
 
   const samples: string[] = [];
-  for (const c of CORPORA) samples.push(...loadCorpusTexts(c));
+  for (const c of deps.corpora) samples.push(...loadCorpusTexts(c));
 
-  const fp = new Map<string, number>();
-  for (const id of targetIds) fp.set(id, 0);
+  const counts = new Map<string, number>();
+  for (const id of targets.ids) counts.set(id, 0);
   for (const text of samples) {
-    const matched = new Set<string>();
-    for (const m of engine.evaluate(asTextEvent(text))) matched.add(m.rule.id);
-    for (const m of engine.scanSkill(text)) matched.add(m.rule.id);
-    for (const id of matched) if (targetIds.has(id)) fp.set(id, (fp.get(id) ?? 0) + 1);
+    for (const id of matchedRuleIds(engine, text)) {
+      if (targets.ids.has(id)) counts.set(id, (counts.get(id) ?? 0) + 1);
+    }
   }
-
-  const dirty = [...fp.entries()].filter(([, n]) => n > 0).sort((a, b) => b[1] - a[1]);
-  console.log(`[fp-gate] corpus = ${samples.length} benign samples`);
-  console.log(`[fp-gate] clean = ${targetIds.size - dirty.length} · dirty = ${dirty.length}`);
-  if (dirty.length > 0) {
-    console.error(`\n[fp-gate] FAIL — these promoted rules false-positive on benign content and`);
-    console.error(`must not enter the enforce (auto-block) lane:`);
-    for (const [id, n] of dirty) console.error(`  ${id} — ${n} FP`);
-    process.exit(1);
-  }
-  console.log(`[fp-gate] PASS — all promoted rules are FP-clean on the benign corpus.`);
+  const coverage = fieldCoverage(engine.getRules()).filter((c) => targets.ids.has(c.ruleId));
+  return { counts, sampleCount: samples.length, coverage };
 }
 
-main().catch((e: unknown) => {
-  console.error(e instanceof Error ? e.stack : String(e));
-  process.exit(1);
-});
+/**
+ * "Clean" must never be allowed to mean "never looked at it".
+ *
+ * A condition on a field this corpus cannot fill (tool_name has no benign corpus;
+ * trace/behavioral rules need a span DAG or a metric window) contributes nothing
+ * to the FP count. Silence from such a rule is an absence of evidence, so it is
+ * named here rather than folded into the clean list without comment. The exit
+ * code is deliberately NOT changed: these rules are unmeasurABLE with a text
+ * corpus, so failing them would block promotion with no available remedy. Making
+ * it loud is the honest half of the fix.
+ */
+function reportCoverage(coverage: readonly FieldCoverage[]): void {
+  if (coverage.length === 0) return;
+  console.log(
+    `\n[fp-gate] NOT MEASURED — ${coverage.length} rule(s) declare conditions this benign ` +
+      `corpus cannot exercise. Their silence below is not evidence of precision:`,
+  );
+  for (const c of coverage) {
+    const tag = c.zeroMeasurement ? "ZERO-MEASUREMENT" : "partially measured";
+    console.log(`  ${c.ruleId} — ${tag}`);
+    for (const f of c.unmeasured) console.log(`      ${f}: ${unmeasurableReason(f)}`);
+  }
+}
+
+function report(
+  partition: FpPartition,
+  sampleCount: number,
+  filterMode: boolean,
+  coverage: readonly FieldCoverage[] = [],
+): void {
+  console.log(`[fp-gate] corpus = ${sampleCount} benign samples`);
+  console.log(
+    `[fp-gate] shapes = ${shapeNames().join(", ")}, skill ` +
+      `(a rule's true positives MUST be measured on this same set)`,
+  );
+  console.log(`[fp-gate] clean = ${partition.clean.length} · dirty = ${partition.dirty.length}`);
+  reportCoverage(coverage);
+  if (partition.dirty.length === 0) {
+    console.log(`[fp-gate] PASS — all promoted rules are FP-clean on the benign corpus.`);
+    return;
+  }
+  if (filterMode) {
+    console.log(`\n[fp-gate] FILTERED — these rules false-positive on benign content and were`);
+    console.log(`excluded from the clean list (they must not enter the enforce lane):`);
+    for (const [id, n] of partition.dirty) console.log(`  ${id} — ${n} FP`);
+    return;
+  }
+  console.error(`\n[fp-gate] FAIL — these promoted rules false-positive on benign content and`);
+  console.error(`must not enter the enforce (auto-block) lane:`);
+  for (const [id, n] of partition.dirty) console.error(`  ${id} — ${n} FP`);
+}
+
+/**
+ * An id the caller asked us to scan that no rule file carries is not a warning.
+ * The requested measurement did not happen, so there is no verdict to report —
+ * and reporting exit 0 with an empty clean list is indistinguishable from
+ * "scanned it, it was fine". Fail loudly, name the ids, and write nothing:
+ * leaving a consumable list behind would let a caller that ignores the exit
+ * code act on a scan that never ran.
+ */
+function reportMissingIds(missing: readonly string[], idsFile: string): number {
+  console.error(
+    `[fp-gate] FAIL — ${missing.length} requested id(s) match no rule file on disk. ` +
+      `Nothing was measured for them:`,
+  );
+  for (const id of missing) console.error(`  ${id}`);
+  console.error(
+    `\nThe id list (${idsFile}) is stale, misspelled, or names rules that were removed.\n` +
+      `No clean/dirty list was written — an unmeasured rule must not be promoted.`,
+  );
+  return EXIT_MISSING_IDS;
+}
+
+export async function runGate(options: GateOptions, deps: GateDeps = defaultDeps()): Promise<number> {
+  const targets = resolveTargets(options, deps);
+  if (targets.missing.length > 0 && options.idsFile !== null) {
+    return reportMissingIds(targets.missing, options.idsFile);
+  }
+
+  if (targets.files.length === 0) {
+    const scope = options.idsFile !== null ? `in ${options.idsFile}` : `vs ${options.base}`;
+    console.log(`[fp-gate] no rules promoted to enforce lane ${scope} — nothing to gate.`);
+    emitLists(options, { clean: [], dirty: [] });
+    return EXIT_OK;
+  }
+
+  console.log(
+    `[fp-gate] gating ${targets.files.length} promoted rule(s) against the benign corpus`,
+  );
+  const { counts, sampleCount, coverage } = await scanFpCounts(targets, deps);
+  const partition = partitionByFp(counts);
+  report(partition, sampleCount, options.filterMode, coverage);
+  emitLists(options, partition);
+  return resolveExitCode(partition.dirty.length, options.filterMode);
+}
+
+export async function main(
+  argv: readonly string[],
+  deps: GateDeps = defaultDeps(),
+): Promise<number> {
+  let options: GateOptions;
+  try {
+    options = parseCliOptions(argv);
+  } catch (e: unknown) {
+    if (e instanceof GateUsageError) {
+      console.error(`[fp-gate] usage error: ${e.message}`);
+      return EXIT_USAGE;
+    }
+    throw e;
+  }
+  return runGate(options, deps);
+}
+
+// Only run when invoked directly (so unit tests can import the pure helpers).
+const INVOKED_DIRECTLY =
+  process.argv[1] !== undefined &&
+  resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url));
+
+if (INVOKED_DIRECTLY) {
+  main(process.argv.slice(2))
+    .then((code) => {
+      process.exitCode = code;
+    })
+    .catch((e: unknown) => {
+      console.error(e instanceof Error ? e.stack : String(e));
+      process.exitCode = EXIT_FAIL;
+    });
+}

--- a/scripts/lib/corpus-event.ts
+++ b/scripts/lib/corpus-event.ts
@@ -1,0 +1,339 @@
+/**
+ * corpus-event.ts — the ONE way a text sample becomes engine events.
+ *
+ * WHY THIS FILE EXISTS
+ *
+ * An ATR rule condition names a field (`field: tool_args`). The engine resolves
+ * that name against the event it is given (src/engine.ts resolveField). If the
+ * harness that measures false positives builds an event that cannot resolve the
+ * field, every condition on that field silently evaluates to false: the rule
+ * cannot fire, cannot be counted as an FP, and the gate reports it CLEAN. That
+ * is a zero-measurement PASS — indistinguishable, in the output, from a rule
+ * that was measured and found innocent.
+ *
+ * That is exactly what happened. Five harnesses each carried a private copy of
+ *
+ *     { type: "mcp_exchange",
+ *       fields: { tool_name, tool_input, tool_response, user_input } }
+ *
+ * which resolves NONE of tool_args / agent_output / agent_message /
+ * tool_description. 40 rules declare `field: tool_args` (3 of them
+ * maturity: stable, i.e. the enforce/auto-block lane) and their tool_args
+ * conditions had never been measured against a single benign sample.
+ *
+ * THE RULE THIS FILE ENFORCES
+ *
+ * True positives and benign samples MUST be pushed through the IDENTICAL shape
+ * set. Measuring TP on a wide shape and FP on a narrow one manufactures a 0-FP
+ * result: the rule earns its detection credit on a shape that is never charged
+ * for its false positives. Whatever shape a rule is allowed to fire on is the
+ * shape it must also survive the benign corpus on. Import this module from both
+ * sides of any measurement rather than hand-rolling an event.
+ *
+ * ENCODING FIDELITY
+ *
+ * Production does not hand the engine one flat string. src/hook-handler.ts
+ * builds `tool_args: JSON.stringify(toolInput)` — a JSON-ENCODED string, where a
+ * newline is the two characters `\` `n`, not U+000A. A pattern can match one
+ * encoding and not the other (a real FP was found this way: a JSON-escaped `\n`
+ * read as a shell line-continuation and joined two independent commands). So the
+ * sample is presented in both the raw and the JSON-encoded form, and each field
+ * receives the encoding production would actually put there — no more, no less.
+ *
+ * @module scripts/lib/corpus-event
+ */
+import type { AgentEvent } from "../../src/types.js";
+
+/**
+ * Placeholder tool name — deliberately NOT the sample text.
+ *
+ * The corpus is a corpus of documents; it contains no tool names. In production
+ * `tool_name` holds a short identifier ("Bash", "mcp__github__create_issue"),
+ * and the rules that key on it match short verbs — `(?i)(exec|execute|shell|
+ * bash|cmd|eval)`, `(?i)(delete|remove|drop|truncate)`, `(?i)(pay|payment|
+ * transfer)`. Pouring a whole SKILL.md into that field would match nearly every
+ * document and report a flood of false positives that cannot occur in
+ * production, which is worse than not measuring: fabricated FPs push a
+ * maintainer to weaken a rule that is correct.
+ *
+ * So tool_name is pinned to a constant. Conditions on it are therefore NOT
+ * measured, and that is reported explicitly (see UNMEASURABLE_FIELDS) instead of
+ * being passed off as clean. Frozen at the legacy value so the historical shape
+ * is reproduced byte for byte and old FP counts stay comparable.
+ */
+export const CORPUS_TOOL_NAME = "corpus-sample";
+
+/** Name of a shape, for reporting which presentation produced a match. */
+export type CorpusShapeName =
+  | "wide-raw"
+  | "pre-tool-json-arg"
+  | "pre-tool-json-both"
+  | "post-tool-json";
+
+export interface CorpusShape {
+  readonly name: CorpusShapeName;
+  readonly event: AgentEvent;
+}
+
+/**
+ * Every field name a sample's text is actually poured into by some shape.
+ * A condition on any of these IS measured. Kept in sync with the shapes below
+ * by tests/corpus-event-shapes.test.ts, which proves reachability through the
+ * real engine rather than trusting this list.
+ */
+export const MEASURED_FIELDS: readonly string[] = Object.freeze([
+  "content",
+  "user_input",
+  "agent_output",
+  "agent_message",
+  "tool_response",
+  "tool_args",
+  "tool_input",
+  "tool_description",
+]);
+
+/**
+ * Field names the engine can resolve but that a TEXT corpus cannot honestly
+ * fill, with the reason. A rule whose conditions live here is UNMEASURED by
+ * this harness — callers must say so out loud rather than report it clean.
+ */
+export const UNMEASURABLE_FIELDS: ReadonlyMap<string, string> = Object.freeze(
+  new Map([
+    [
+      "tool_name",
+      "production tool_name is a short identifier, not a document; pouring corpus " +
+        "text in would fabricate FPs on rules that are correct in production",
+    ],
+    [
+      "metric",
+      "behavioral metric is a number over a time window, not text; the sync " +
+        "evaluate() path cannot maintain the window at all",
+    ],
+  ]),
+);
+
+/** A trace-method rule needs event.trace (a span DAG), which text cannot supply. */
+export const TRACE_FIELD_PREFIX = "trace.";
+/** A behavioral condition needs a numeric metric window, which text cannot supply. */
+export const BEHAVIORAL_FIELD_PREFIX = "behavioral.";
+
+/** True when a condition field can be measured with a text corpus. */
+export function isMeasurableField(field: string): boolean {
+  if (field.startsWith(TRACE_FIELD_PREFIX)) return false;
+  if (field.startsWith(BEHAVIORAL_FIELD_PREFIX)) return false;
+  return MEASURED_FIELDS.includes(field);
+}
+
+/** Why a field cannot be measured — a sentence, or null when it can be. */
+export function unmeasurableReason(field: string): string | null {
+  if (isMeasurableField(field)) return null;
+  if (field.startsWith(TRACE_FIELD_PREFIX)) {
+    return "trace-method rule: needs an event.trace span DAG, which a text corpus cannot supply";
+  }
+  if (field.startsWith(BEHAVIORAL_FIELD_PREFIX)) {
+    return "behavioral condition: needs a numeric metric window, which a text corpus cannot supply";
+  }
+  return (
+    UNMEASURABLE_FIELDS.get(field) ??
+    "unknown field name — the engine resolves it from event.metadata, which this " +
+      "harness does not populate; no shape carries the sample into it"
+  );
+}
+
+const now = (): string => new Date().toISOString();
+
+/**
+ * Shape 1 — WIDE, RAW. type `mcp_exchange` so the engine applies NO source-type
+ * filtering (EVENT_TYPE_TO_SOURCE has no mcp_exchange entry), which means every
+ * rule is evaluated regardless of its declared agent_source.type. Every
+ * content-bearing field carries the raw sample.
+ *
+ * This is a strict superset of the legacy harness shape (same type, same
+ * tool_name, same tool_input/tool_response/user_input), so no FP that the old
+ * shape counted can disappear — the change can only reveal, never hide.
+ */
+function wideRaw(text: string): AgentEvent {
+  return Object.freeze({
+    type: "mcp_exchange" as const,
+    timestamp: now(),
+    content: text,
+    fields: Object.freeze({
+      tool_name: CORPUS_TOOL_NAME,
+      tool_input: text,
+      tool_response: text,
+      user_input: text,
+      agent_output: text,
+      agent_message: text,
+      tool_description: text,
+      tool_args: text,
+      content: text,
+    }),
+  });
+}
+
+/**
+ * Shape 2 — PreToolUse where the payload IS a string tool argument
+ * (`Write`, `Edit`, ...). src/hook-handler.ts:52-61 verbatim: `content` stays
+ * raw because toolInput.content is a string, while `tool_args` is the
+ * JSON-ENCODED whole argument object. This is the shape that exposes patterns
+ * which only match escaped text.
+ */
+function preToolJsonArg(text: string): AgentEvent {
+  const toolInput = { content: text };
+  return Object.freeze({
+    type: "tool_call" as const,
+    timestamp: now(),
+    content: toolInput.content,
+    fields: Object.freeze({
+      tool_name: CORPUS_TOOL_NAME,
+      tool_args: JSON.stringify(toolInput),
+      content: toolInput.content,
+    }),
+  });
+}
+
+/**
+ * Shape 3 — PreToolUse where the payload is NOT under a `content` key
+ * (`Bash` and most MCP tools). src/hook-handler.ts:53-55 then falls back to
+ * JSON.stringify for `content` too, so BOTH content and tool_args are encoded.
+ */
+function preToolJsonBoth(text: string): AgentEvent {
+  const toolInput = { command: text };
+  const encoded = JSON.stringify(toolInput);
+  return Object.freeze({
+    type: "tool_call" as const,
+    timestamp: now(),
+    content: encoded,
+    fields: Object.freeze({
+      tool_name: CORPUS_TOOL_NAME,
+      tool_args: encoded,
+      content: encoded,
+    }),
+  });
+}
+
+/**
+ * Shape 4 — PostToolUse. src/hook-handler.ts:64-69: the tool has already run,
+ * its output lands in tool_response, and tool_args is still the JSON-encoded
+ * argument object.
+ *
+ * This shape is NOT redundant with shapes 2-3, and the reason is the engine's
+ * source-type filter. A `tool_call` event only evaluates rules whose
+ * agent_source.type is tool_call or mcp_exchange. A `tool_response` event maps
+ * to source mcp_exchange AND additionally admits llm_io rules (the engine's
+ * indirect-prompt-injection route: poisoned tool output is the channel those
+ * rules exist for). Four rules declare `field: tool_args` with
+ * `agent_source.type: llm_io`; without this shape the JSON-encoded encoding of
+ * tool_args would never be measured for them.
+ */
+function postToolJson(text: string): AgentEvent {
+  const toolInput = { output: text };
+  const encoded = JSON.stringify(toolInput);
+  return Object.freeze({
+    type: "tool_response" as const,
+    timestamp: now(),
+    content: encoded,
+    fields: Object.freeze({
+      tool_name: CORPUS_TOOL_NAME,
+      tool_args: encoded,
+      tool_response: text,
+      content: encoded,
+    }),
+  });
+}
+
+/**
+ * The canonical shape set. Callers must ALSO run engine.scanSkill(text) — the
+ * SKILL.md path is a separate engine entry point, not an event shape.
+ *
+ * Two axes have to be covered, and missing either one hides false positives:
+ *   - ENCODING: raw (shape 1) vs JSON-encoded (shapes 2-4), because a pattern
+ *     can match one and not the other.
+ *   - RULE ADMISSION: the engine filters rules by agent_source.type against the
+ *     event type. mcp_exchange (shape 1) is filtered against nothing, so every
+ *     rule runs; tool_call (2-3) admits tool_call + mcp_exchange rules;
+ *     tool_response (4) admits mcp_exchange + llm_io rules.
+ *
+ * Deliberately omitted: `llm_input` / `llm_output` / `multi_agent_message`
+ * events. Shape 1 already carries user_input / agent_output / agent_message
+ * explicitly and is admitted for every rule, so those types can only narrow.
+ */
+export function corpusShapes(text: string): readonly CorpusShape[] {
+  return Object.freeze([
+    Object.freeze({ name: "wide-raw" as const, event: wideRaw(text) }),
+    Object.freeze({ name: "pre-tool-json-arg" as const, event: preToolJsonArg(text) }),
+    Object.freeze({ name: "pre-tool-json-both" as const, event: preToolJsonBoth(text) }),
+    Object.freeze({ name: "post-tool-json" as const, event: postToolJson(text) }),
+  ]);
+}
+
+/** Human-readable list of the shapes, for harness banners. */
+export function shapeNames(): readonly string[] {
+  return corpusShapes("").map((s) => s.name);
+}
+
+// ---------------------------------------------------------------------------
+// Coverage: which of a rule's conditions this harness can actually measure
+// ---------------------------------------------------------------------------
+
+/** Minimal view of a rule — avoids importing the full ATRRule type surface. */
+export interface RuleLike {
+  readonly id: string;
+  readonly detection?: {
+    readonly method?: string;
+    readonly condition?: string;
+    readonly conditions?: unknown;
+  };
+}
+
+/** Every field name a rule's conditions declare, in declaration order. */
+export function conditionFields(rule: RuleLike): readonly string[] {
+  const conds = rule.detection?.conditions;
+  const list = Array.isArray(conds)
+    ? conds
+    : conds !== null && typeof conds === "object"
+      ? Object.values(conds as Record<string, unknown>)
+      : [];
+  const out: string[] = [];
+  for (const c of list) {
+    if (c === null || typeof c !== "object") continue;
+    const field = (c as { field?: unknown }).field;
+    if (typeof field === "string" && !out.includes(field)) out.push(field);
+  }
+  return out;
+}
+
+export interface FieldCoverage {
+  readonly ruleId: string;
+  /** Declared fields this harness cannot pour the sample into. */
+  readonly unmeasured: readonly string[];
+  /**
+   * True when NOTHING about this rule was measured — either no declared field is
+   * measurable, or the rule ANDs its conditions so a single unmeasurable field
+   * makes the whole rule unable to fire.
+   */
+  readonly zeroMeasurement: boolean;
+}
+
+/** Rules whose conditions this harness cannot fully measure. Clean rules omitted. */
+export function fieldCoverage(rules: readonly RuleLike[]): readonly FieldCoverage[] {
+  const out: FieldCoverage[] = [];
+  for (const rule of rules) {
+    const fields = conditionFields(rule);
+    const unmeasured = fields.filter((f) => !isMeasurableField(f));
+    const method = rule.detection?.method;
+    const methodBlind = method === "trace" || method === "behavioral" || method === "signature";
+    if (unmeasured.length === 0 && !methodBlind) continue;
+    const expr = (rule.detection?.condition ?? "any").toLowerCase();
+    const anyOf = expr === "any" || expr === "or";
+    const measurable = fields.length - unmeasured.length;
+    out.push(
+      Object.freeze({
+        ruleId: rule.id,
+        unmeasured: Object.freeze(unmeasured),
+        zeroMeasurement: methodBlind || measurable === 0 || (!anyOf && unmeasured.length > 0),
+      }),
+    );
+  }
+  return Object.freeze(out);
+}

--- a/tests/corpus-event-shapes.test.ts
+++ b/tests/corpus-event-shapes.test.ts
@@ -1,0 +1,479 @@
+/**
+ * Tests for scripts/lib/corpus-event.ts — the event shapes every FP/TP
+ * measurement must use.
+ *
+ * THE BUG THESE TESTS EXIST TO PREVENT
+ *
+ * A rule condition names a field. The engine resolves that name against the
+ * event the harness built. If the harness cannot resolve it, the condition is
+ * false for every sample, the rule never fires, and the FP gate reports it
+ * CLEAN — a zero-measurement PASS that is indistinguishable in the output from
+ * a rule that was measured and found innocent.
+ *
+ * That shipped: the gate built one `mcp_exchange` event with only tool_name /
+ * tool_input / tool_response / user_input, so `field: tool_args` resolved to
+ * undefined. 40 rules detect on tool_args, 3 of them maturity:stable (the
+ * auto-blocking enforce lane). None of their tool_args conditions had ever been
+ * measured against a benign sample.
+ *
+ * The load-bearing test here is "every field the engine can resolve is either
+ * measured or explicitly declared unmeasurable", and it derives the field list
+ * FROM src/engine.ts rather than from a hand-written copy. Adding a new field to
+ * resolveField without teaching the harness about it turns this test red — which
+ * is the only way this class of blindness gets caught at the moment it is
+ * introduced rather than months later in production.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, readdirSync, statSync, rmSync } from "node:fs";
+import { join, resolve, dirname } from "node:path";
+import { tmpdir } from "node:os";
+import { fileURLToPath } from "node:url";
+import yaml from "js-yaml";
+import { ATREngine } from "../src/engine.js";
+import type { AgentEvent } from "../src/types.js";
+import {
+  corpusShapes,
+  shapeNames,
+  conditionFields,
+  fieldCoverage,
+  isMeasurableField,
+  unmeasurableReason,
+  CORPUS_TOOL_NAME,
+  MEASURED_FIELDS,
+  UNMEASURABLE_FIELDS,
+  type RuleLike,
+} from "../scripts/lib/corpus-event.js";
+import { runGate, EXIT_FAIL, EXIT_OK, type GateDeps } from "../scripts/gate-promotion-fp.js";
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const SENTINEL = "zzq-reachability-sentinel-zzq";
+
+/** A schema-valid one-condition rule whose regex is `pattern` on `field`. */
+function ruleYaml(
+  id: string,
+  field: string,
+  pattern: string,
+  source = "llm_io",
+  scanTarget = "runtime",
+): string {
+  return [
+    `title: probe ${field}`,
+    `id: ${id}`,
+    "rule_version: 1",
+    "status: experimental",
+    "description: fixture rule for the corpus event shape tests",
+    "author: test",
+    "date: 2026/07/29",
+    "schema_version: '0.1'",
+    "detection_tier: pattern",
+    "maturity: test",
+    "severity: high",
+    "tags:",
+    "  category: tool-poisoning",
+    `  scan_target: ${scanTarget}`,
+    "  confidence: high",
+    "agent_source:",
+    `  type: ${source}`,
+    "  framework: [any]",
+    "  provider: [any]",
+    "detection:",
+    "  condition: any",
+    "  false_positives: []",
+    "  conditions:",
+    `    - field: ${field}`,
+    "      operator: regex",
+    `      value: ${pattern}`,
+    "      description: probe",
+    "response:",
+    "  actions: [alert]",
+    "test_cases:",
+    "  true_positives: []",
+    "  true_negatives: []",
+    "",
+  ].join("\n");
+}
+
+/** The legacy shape, verbatim, so its blindness stays pinned as a regression. */
+function legacyEvent(content: string): AgentEvent {
+  return {
+    type: "mcp_exchange",
+    timestamp: new Date().toISOString(),
+    content,
+    fields: {
+      tool_name: "corpus-sample",
+      tool_input: content,
+      tool_response: content,
+      user_input: content,
+    },
+  };
+}
+
+/** Load an engine holding exactly one probe rule for `field`. */
+async function engineForField(
+  field: string,
+  pattern = SENTINEL,
+  source = "llm_io",
+): Promise<ATREngine> {
+  const dir = mkdtempSync(join(tmpdir(), "atr-shape-"));
+  writeFileSync(join(dir, "probe.yaml"), ruleYaml("ATR-2026-95001", field, pattern, source), "utf-8");
+  const engine = new ATREngine({ rulesDir: dir });
+  await engine.loadRules();
+  return engine;
+}
+
+/** Does a condition on `field` fire on `text` through the canonical shapes? */
+function firesOnShapes(engine: ATREngine, text: string): boolean {
+  return corpusShapes(text).some((s) => engine.evaluate(s.event).length > 0);
+}
+
+// ---------------------------------------------------------------------------
+// The field list, derived from the engine so it cannot drift
+// ---------------------------------------------------------------------------
+
+/**
+ * Field names src/engine.ts resolveField() knows: every `case '...'` in its
+ * body plus every default field EVENT_TYPE_TO_FIELD maps an event type to.
+ * Parsed from source on purpose — a hand-copied list is exactly how the harness
+ * fell behind the engine in the first place.
+ */
+function engineResolvableFields(): readonly string[] {
+  const src = readFileSync(join(REPO_ROOT, "src/engine.ts"), "utf-8");
+
+  const start = src.indexOf("private resolveField(");
+  expect(start, "resolveField not found in src/engine.ts — update this parser").toBeGreaterThan(0);
+  const end = src.indexOf("\n  }", start);
+  const body = src.slice(start, end);
+  const cases = [...body.matchAll(/case '([a-z_]+)'/g)].map((m) => m[1] as string);
+
+  const mapStart = src.indexOf("const EVENT_TYPE_TO_FIELD");
+  expect(mapStart, "EVENT_TYPE_TO_FIELD not found — update this parser").toBeGreaterThan(0);
+  const mapBody = src.slice(mapStart, src.indexOf("};", mapStart));
+  const defaults = [...mapBody.matchAll(/:\s*'([a-z_]+)'/g)].map((m) => m[1] as string);
+
+  return [...new Set([...cases, ...defaults, "content"])].sort();
+}
+
+/** Every `field:` name declared by any rule on disk. */
+function ruleDeclaredFields(): readonly string[] {
+  const walk = (dir: string): string[] => {
+    const out: string[] = [];
+    for (const e of readdirSync(dir)) {
+      const p = join(dir, e);
+      if (statSync(p).isDirectory()) out.push(...walk(p));
+      else if (e.endsWith(".yaml") || e.endsWith(".yml")) out.push(p);
+    }
+    return out;
+  };
+  const fields = new Set<string>();
+  for (const file of walk(join(REPO_ROOT, "rules"))) {
+    let doc: unknown;
+    try {
+      doc = yaml.load(readFileSync(file, "utf-8"));
+    } catch {
+      continue;
+    }
+    if (doc === null || typeof doc !== "object") continue;
+    for (const f of conditionFields(doc as RuleLike)) fields.add(f);
+  }
+  return [...fields].sort();
+}
+
+// ---------------------------------------------------------------------------
+
+describe("field reachability — no rule may be scored against a field nothing fills", () => {
+  it("every field src/engine.ts can resolve is either measured or declared unmeasurable", () => {
+    const undeclared = engineResolvableFields().filter(
+      (f) => !isMeasurableField(f) && !UNMEASURABLE_FIELDS.has(f),
+    );
+    expect(
+      undeclared,
+      "these fields resolve in the engine but no shape fills them and no reason is on " +
+        "record — a rule detecting on them would be scored CLEAN without being measured. " +
+        "Add them to a shape in scripts/lib/corpus-event.ts, or to UNMEASURABLE_FIELDS " +
+        "with the reason they cannot be measured.",
+    ).toEqual([]);
+  });
+
+  it("every field a rule on disk declares is either measured or declared unmeasurable", () => {
+    const undeclared = ruleDeclaredFields().filter(
+      (f) =>
+        !isMeasurableField(f) &&
+        !UNMEASURABLE_FIELDS.has(f) &&
+        !f.startsWith("trace.") &&
+        !f.startsWith("behavioral."),
+    );
+    expect(
+      undeclared,
+      "rules detect on these fields but the FP harness cannot fill them",
+    ).toEqual([]);
+  });
+
+  it.each([...MEASURED_FIELDS])("resolves %s from the canonical shapes (proved end to end)", async (field) => {
+    const engine = await engineForField(field);
+    expect(firesOnShapes(engine, `benign preamble ${SENTINEL} trailer`)).toBe(true);
+  });
+
+  /**
+   * Second axis of the same disease. Resolving the field is not enough: the
+   * engine also drops a rule whose agent_source.type does not match the event
+   * type, so a shape set that only emits `tool_call` events would never evaluate
+   * an llm_io rule at all — every one of them scored clean without being read.
+   */
+  it("evaluates rules of every agent_source.type declared on disk", async () => {
+    const sources = new Set<string>();
+    const walk = (dir: string): string[] => {
+      const out: string[] = [];
+      for (const e of readdirSync(dir)) {
+        const p = join(dir, e);
+        if (statSync(p).isDirectory()) out.push(...walk(p));
+        else if (e.endsWith(".yaml") || e.endsWith(".yml")) out.push(p);
+      }
+      return out;
+    };
+    for (const file of walk(join(REPO_ROOT, "rules"))) {
+      try {
+        const doc = yaml.load(readFileSync(file, "utf-8")) as { agent_source?: { type?: string } };
+        const t = doc?.agent_source?.type;
+        if (typeof t === "string") sources.add(t);
+      } catch {
+        continue;
+      }
+    }
+    expect(sources.size).toBeGreaterThan(3);
+    for (const source of sources) {
+      const engine = await engineForField("content", SENTINEL, source);
+      expect(
+        firesOnShapes(engine, `benign preamble ${SENTINEL} trailer`),
+        `no shape admits a rule with agent_source.type: ${source} — every such rule ` +
+          `would be reported FP-clean without ever being evaluated`,
+      ).toBe(true);
+    }
+  });
+
+  it("pins the fields that are deliberately NOT measured, with a stated reason", async () => {
+    for (const field of UNMEASURABLE_FIELDS.keys()) {
+      const engine = await engineForField(field);
+      expect(
+        firesOnShapes(engine, `benign preamble ${SENTINEL} trailer`),
+        `${field} is now reachable. That may be correct — but decide it deliberately: ` +
+          `pouring document text into a field production fills with a short identifier ` +
+          `manufactures false positives that cannot happen in production.`,
+      ).toBe(false);
+      expect(unmeasurableReason(field)).toBeTruthy();
+    }
+  });
+
+  it("an unknown field name is reported as unmeasurable rather than silently ignored", () => {
+    expect(isMeasurableField("no_such_field")).toBe(false);
+    expect(unmeasurableReason("no_such_field")).toContain("no shape carries the sample into it");
+  });
+});
+
+describe("the legacy shape — the blindness these shapes replace", () => {
+  it.each(["tool_args", "agent_output", "agent_message", "tool_description"])(
+    "%s was unreachable on the old single-event shape",
+    async (field) => {
+      const engine = await engineForField(field);
+      const text = `benign preamble ${SENTINEL} trailer`;
+      expect(engine.evaluate(legacyEvent(text))).toHaveLength(0);
+      expect(firesOnShapes(engine, text)).toBe(true);
+    },
+  );
+
+  it("keeps every field the legacy shape did resolve (the change only widens)", async () => {
+    for (const field of ["content", "user_input", "tool_response", "tool_input"]) {
+      const engine = await engineForField(field);
+      const text = `benign preamble ${SENTINEL} trailer`;
+      expect(engine.evaluate(legacyEvent(text)).length).toBeGreaterThan(0);
+      expect(firesOnShapes(engine, text)).toBe(true);
+    }
+  });
+
+  it("keeps the legacy tool_name placeholder so old FP counts stay comparable", () => {
+    expect(CORPUS_TOOL_NAME).toBe("corpus-sample");
+    for (const shape of corpusShapes("x")) {
+      expect(shape.event.fields?.["tool_name"]).toBe(CORPUS_TOOL_NAME);
+    }
+  });
+});
+
+describe("JSON encoding — production puts JSON.stringify(toolInput) in tool_args", () => {
+  it("carries both the raw and the JSON-encoded form of the sample", () => {
+    const shapes = corpusShapes("a\nb");
+    const args = shapes.map((s) => s.event.fields?.["tool_args"]);
+    expect(args).toContain("a\nb");
+    expect(args.some((a) => typeof a === "string" && a.includes("a\\nb"))).toBe(true);
+  });
+
+  // `.` does not cross a real newline, but JSON turns U+000A into the two
+  // characters \ and n, which `.` happily traverses — so a pattern can join two
+  // independent lines. A real critical-severity rule false-positives on a benign
+  // Azure pricing document exactly this way, and the old shape could not see it
+  // because it never presented the encoded form.
+  //
+  // Both source types are checked because the engine also filters rules by
+  // agent_source.type against the event type: a tool_call event never evaluates
+  // an llm_io rule. Covering only tool_call would leave the four llm_io rules
+  // that detect on tool_args measured on the raw encoding alone.
+  it.each(["tool_call", "llm_io", "mcp_exchange"])(
+    "catches a pattern that only matches once newlines are escaped (agent_source: %s)",
+    async (source) => {
+      const engine = await engineForField("tool_args", "api-version=\\d{4}.*metadata", source);
+      const text = "GET /prices?api-version=2023-01-01\nsee the metadata docs";
+      expect(engine.evaluate(legacyEvent(text))).toHaveLength(0);
+      expect(firesOnShapes(engine, text)).toBe(true);
+    },
+  );
+
+  it("names its shapes so a harness banner can state what was measured", () => {
+    expect(shapeNames()).toEqual([
+      "wide-raw",
+      "pre-tool-json-arg",
+      "pre-tool-json-both",
+      "post-tool-json",
+    ]);
+  });
+});
+
+describe("fieldCoverage — 'clean' must never quietly mean 'never looked at'", () => {
+  const rule = (id: string, fields: readonly string[], condition = "any", method?: string): RuleLike => ({
+    id,
+    detection: {
+      condition,
+      ...(method === undefined ? {} : { method }),
+      conditions: fields.map((f) => ({ field: f, operator: "regex", value: "x" })),
+    },
+  });
+
+  it("says nothing about a fully measurable rule", () => {
+    expect(fieldCoverage([rule("A", ["tool_args", "user_input"])])).toEqual([]);
+  });
+
+  it("flags an unmeasurable field and keeps ANY-rules as partially measured", () => {
+    const [c] = fieldCoverage([rule("B", ["tool_name", "user_input"], "any")]);
+    expect(c?.unmeasured).toEqual(["tool_name"]);
+    expect(c?.zeroMeasurement).toBe(false);
+  });
+
+  it("calls an ALL-rule with one unmeasurable field zero-measurement", () => {
+    const [c] = fieldCoverage([rule("C", ["tool_name", "user_input"], "all")]);
+    expect(c?.zeroMeasurement).toBe(true);
+  });
+
+  it("calls a rule whose every field is unmeasurable zero-measurement", () => {
+    const [c] = fieldCoverage([rule("D", ["tool_name"], "any")]);
+    expect(c?.zeroMeasurement).toBe(true);
+  });
+
+  it("calls trace and behavioral rules zero-measurement whatever their fields say", () => {
+    expect(fieldCoverage([rule("E", ["trace.forbid_violation"], "any", "trace")])[0]?.zeroMeasurement).toBe(true);
+    expect(fieldCoverage([rule("F", ["content"], "any", "behavioral")])[0]?.zeroMeasurement).toBe(true);
+  });
+
+  it("reads both the array and the named-map condition formats", () => {
+    const named: RuleLike = {
+      id: "G",
+      detection: { condition: "a AND b", conditions: { a: { field: "tool_args" }, b: { field: "tool_name" } } },
+    };
+    expect(conditionFields(named)).toEqual(["tool_args", "tool_name"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// End to end through the gate itself
+// ---------------------------------------------------------------------------
+
+describe("the gate measures a tool_args rule end to end", () => {
+  const TOOL_ARGS_ID = "ATR-2026-95101";
+  const CONTROL_ID = "ATR-2026-95102";
+  let root: string;
+  let deps: GateDeps;
+
+  beforeAll(() => {
+    root = mkdtempSync(join(tmpdir(), "atr-shape-gate-"));
+    const rulesDir = join(root, "rules");
+    const corpusDir = join(root, "corpus");
+    mkdirSync(rulesDir, { recursive: true });
+    mkdirSync(corpusDir, { recursive: true });
+
+    writeFileSync(
+      join(rulesDir, `${TOOL_ARGS_ID}.yaml`),
+      ruleYaml(TOOL_ARGS_ID, "tool_args", "169\\.254\\.169\\.254"),
+      "utf-8",
+    );
+    writeFileSync(
+      join(rulesDir, `${CONTROL_ID}.yaml`),
+      ruleYaml(CONTROL_ID, "tool_args", "zzq-not-in-this-corpus-zzq"),
+      "utf-8",
+    );
+    writeFileSync(
+      join(corpusDir, "benign.jsonl"),
+      `${JSON.stringify({ text: "curl http://169.254.169.254/latest/meta-data to read instance metadata" })}\n` +
+        `${JSON.stringify({ text: "This skill formats CSV files." })}\n`,
+      "utf-8",
+    );
+
+    deps = {
+      repoRoot: root,
+      rulesDir,
+      corpora: [corpusDir],
+      listRuleFiles: () => [`rules/${TOOL_ARGS_ID}.yaml`, `rules/${CONTROL_ID}.yaml`],
+    };
+  });
+
+  afterAll(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  function idsFile(name: string, ids: readonly string[]): string {
+    const p = join(root, name);
+    writeFileSync(p, `${ids.join("\n")}\n`, "utf-8");
+    return p;
+  }
+
+  it("fails a tool_args rule that false-positives — it used to pass unmeasured", async () => {
+    const code = await runGate(
+      {
+        idsFile: idsFile("dirty.txt", [TOOL_ARGS_ID]),
+        base: "origin/main",
+        emitClean: null,
+        emitDirty: null,
+        filterMode: false,
+      },
+      deps,
+    );
+    expect(code).toBe(EXIT_FAIL);
+  });
+
+  it("still passes a tool_args rule that genuinely does not fire", async () => {
+    const code = await runGate(
+      {
+        idsFile: idsFile("clean.txt", [CONTROL_ID]),
+        base: "origin/main",
+        emitClean: null,
+        emitDirty: null,
+        filterMode: false,
+      },
+      deps,
+    );
+    expect(code).toBe(EXIT_OK);
+  });
+
+  it("counts one false positive per sample, not one per shape", async () => {
+    const dirty = join(root, "out-dirty.txt");
+    await runGate(
+      {
+        idsFile: idsFile("count.txt", [TOOL_ARGS_ID]),
+        base: "origin/main",
+        emitClean: null,
+        emitDirty: dirty,
+        filterMode: true,
+      },
+      deps,
+    );
+    // The one triggering sample matches on every shape; the gate must report the
+    // rule once, and the corpus has exactly one such document.
+    expect(readFileSync(dirty, "utf-8").split("\n").filter(Boolean)).toEqual([TOOL_ARGS_ID]);
+  });
+});

--- a/tests/gate-promotion-fp.test.ts
+++ b/tests/gate-promotion-fp.test.ts
@@ -1,0 +1,474 @@
+/**
+ * Tests for scripts/gate-promotion-fp.ts — the enforce-lane FP gate and its
+ * new filter mode.
+ *
+ * Five contracts are pinned here:
+ *
+ *  1. DEFAULT BEHAVIOUR IS FROZEN. CI (.github/workflows/maturity-fp-gate.yml)
+ *     runs this script with no output flags and relies on exit 1 when a
+ *     promoted rule false-positives. Adding --emit-clean must NOT relax that.
+ *  2. SEPARATION. --emit-clean / --emit-dirty must partition the scanned ids
+ *     exactly: every scanned id lands in one list, never both, never neither.
+ *  3. FILTER MODE. --filter-mode exits 0 on a dirty finding (so a `set -e`
+ *     promoter can consume the clean list), but refuses to run without an emit
+ *     target — it must never become a way to silently mute the gate.
+ *  4. DISCOVERY SEES UNCOMMITTED RULES. Candidates come from tracked AND
+ *     untracked-not-ignored files. Tracked-only discovery made the gate report
+ *     "nothing to gate" + exit 0 for rules that exist on disk but have not been
+ *     committed — a zero-measurement PASS on exactly the rules nobody had
+ *     measured yet (scripts/fn-mine-llm.ts authors into the tree, then gates).
+ *  5. AN UNRESOLVABLE ID IS A FAILURE, NOT A WARNING. Exit 3, ids named, and no
+ *     list written. Anything softer reads as "scanned it, all fine".
+ *
+ * The gate scan runs against an injected fixture corpus (GateDeps), so these
+ * tests are deterministic and do not depend on the precision of any real rule.
+ * Two subprocess smoke tests cover the CLI entry point itself, because a broken
+ * "invoked directly" guard would turn the CI gate into a silent no-op.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, existsSync, rmSync } from "node:fs";
+import { join, resolve, dirname } from "node:path";
+import { tmpdir } from "node:os";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
+import {
+  parseCliOptions,
+  parsePromotedFiles,
+  partitionByFp,
+  resolveExitCode,
+  formatIdList,
+  gitRuleFiles,
+  runGate,
+  GateUsageError,
+  EXIT_OK,
+  EXIT_FAIL,
+  EXIT_USAGE,
+  EXIT_MISSING_IDS,
+  type GateDeps,
+  type GitRunner,
+} from "../scripts/gate-promotion-fp.js";
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const SCRIPT = join(REPO_ROOT, "scripts/gate-promotion-fp.ts");
+
+const DIRTY_ID = "ATR-2026-90001";
+const CLEAN_ID = "ATR-2026-90002";
+
+/** A minimal but schema-valid rule whose single regex is `pattern`. */
+function fixtureRule(id: string, title: string, pattern: string): string {
+  return [
+    `title: ${title}`,
+    `id: ${id}`,
+    "rule_version: 1",
+    "status: experimental",
+    "description: fixture rule for the promotion FP gate tests",
+    "author: test",
+    "date: 2026/07/28",
+    "schema_version: '0.1'",
+    "detection_tier: pattern",
+    "maturity: test",
+    "severity: high",
+    "tags:",
+    "  category: tool-poisoning",
+    "  scan_target: runtime",
+    "  confidence: high",
+    "agent_source:",
+    "  type: llm_io",
+    "  framework: [any]",
+    "  provider: [any]",
+    "detection:",
+    "  condition: any",
+    "  false_positives: []",
+    "  conditions:",
+    "    - field: content",
+    "      operator: regex",
+    `      value: ${pattern}`,
+    "      description: fixture",
+    "response:",
+    "  actions: [alert]",
+    "test_cases:",
+    "  true_positives: []",
+    "  true_negatives: []",
+    "",
+  ].join("\n");
+}
+
+interface Fixture {
+  readonly root: string;
+  readonly deps: GateDeps;
+  readonly out: string;
+}
+
+/**
+ * A throwaway repo root: two rules (one that fires on the benign corpus, one
+ * that cannot) plus a tiny benign corpus.
+ */
+function makeFixture(): Fixture {
+  const root = mkdtempSync(join(tmpdir(), "atr-gate-test-"));
+  const rulesDir = join(root, "rules");
+  const corpusDir = join(root, "corpus");
+  const out = join(root, "out");
+  mkdirSync(rulesDir, { recursive: true });
+  mkdirSync(corpusDir, { recursive: true });
+
+  const dirtyFile = `${DIRTY_ID}-fixture-dirty.yaml`;
+  const cleanFile = `${CLEAN_ID}-fixture-clean.yaml`;
+  writeFileSync(
+    join(rulesDir, dirtyFile),
+    fixtureRule(DIRTY_ID, "fixture rule that fires on benign code", "(?i)import random"),
+    "utf-8",
+  );
+  writeFileSync(
+    join(rulesDir, cleanFile),
+    fixtureRule(CLEAN_ID, "fixture rule that never fires", "zzq-never-in-benign-corpus-zzq"),
+    "utf-8",
+  );
+
+  const samples = [
+    { text: "import random\nprint(random.random())" },
+    { text: "This skill formats CSV files for the user." },
+    { text: "from bs4 import BeautifulSoup" },
+  ];
+  writeFileSync(
+    join(corpusDir, "benign.jsonl"),
+    `${samples.map((s) => JSON.stringify(s)).join("\n")}\n`,
+    "utf-8",
+  );
+
+  return {
+    root,
+    out,
+    deps: {
+      repoRoot: root,
+      rulesDir,
+      corpora: [corpusDir],
+      listRuleFiles: () => [`rules/${dirtyFile}`, `rules/${cleanFile}`],
+    },
+  };
+}
+
+function writeIdsFile(fixture: Fixture, name: string, ids: readonly string[]): string {
+  const path = join(fixture.root, name);
+  writeFileSync(path, formatIdList(ids), "utf-8");
+  return path;
+}
+
+function readIds(path: string): string[] {
+  return readFileSync(path, "utf-8").split("\n").filter(Boolean);
+}
+
+const BASE_OPTIONS = {
+  base: "origin/main",
+  emitClean: null,
+  emitDirty: null,
+  filterMode: false,
+} as const;
+
+describe("parseCliOptions", () => {
+  it("defaults to gate semantics with no output flags", () => {
+    expect(parseCliOptions([])).toEqual({
+      idsFile: null,
+      base: "origin/main",
+      emitClean: null,
+      emitDirty: null,
+      filterMode: false,
+    });
+  });
+
+  it("keeps the existing --ids / --base parsing", () => {
+    const opts = parseCliOptions(["--ids", "/tmp/ids.txt", "--base", "origin/release"]);
+    expect(opts.idsFile).toBe("/tmp/ids.txt");
+    expect(opts.base).toBe("origin/release");
+  });
+
+  it("parses the emit paths", () => {
+    const opts = parseCliOptions(["--emit-clean", "/tmp/c.txt", "--emit-dirty", "/tmp/d.txt"]);
+    expect(opts.emitClean).toBe("/tmp/c.txt");
+    expect(opts.emitDirty).toBe("/tmp/d.txt");
+    expect(opts.filterMode).toBe(false);
+  });
+
+  it("rejects --filter-mode without an emit target (would only mute the gate)", () => {
+    expect(() => parseCliOptions(["--filter-mode"])).toThrow(GateUsageError);
+    expect(() => parseCliOptions(["--filter-mode", "--emit-clean", "/tmp/c.txt"])).not.toThrow();
+    expect(() => parseCliOptions(["--filter-mode", "--emit-dirty", "/tmp/d.txt"])).not.toThrow();
+  });
+
+  it("rejects an emit flag with no value or a value that is another flag", () => {
+    expect(() => parseCliOptions(["--emit-clean"])).toThrow(GateUsageError);
+    expect(() => parseCliOptions(["--emit-clean", "--filter-mode"])).toThrow(GateUsageError);
+  });
+
+  it("rejects emitting both lists to the same path", () => {
+    expect(() => parseCliOptions(["--emit-clean", "/tmp/x", "--emit-dirty", "/tmp/x"])).toThrow(
+      GateUsageError,
+    );
+  });
+});
+
+describe("pure helpers", () => {
+  it("partitionByFp separates clean from dirty and orders deterministically", () => {
+    const counts = new Map([
+      ["ATR-2026-00003", 0],
+      ["ATR-2026-00001", 5],
+      ["ATR-2026-00002", 0],
+      ["ATR-2026-00004", 9],
+      ["ATR-2026-00005", 5],
+    ]);
+    const { clean, dirty } = partitionByFp(counts);
+    expect(clean).toEqual(["ATR-2026-00002", "ATR-2026-00003"]);
+    expect(dirty).toEqual([
+      ["ATR-2026-00004", 9],
+      ["ATR-2026-00001", 5],
+      ["ATR-2026-00005", 5],
+    ]);
+  });
+
+  it("resolveExitCode keeps gate semantics by default and relaxes only in filter mode", () => {
+    expect(resolveExitCode(0, false)).toBe(EXIT_OK);
+    expect(resolveExitCode(0, true)).toBe(EXIT_OK);
+    expect(resolveExitCode(3, false)).toBe(EXIT_FAIL);
+    expect(resolveExitCode(3, true)).toBe(EXIT_OK);
+  });
+
+  it("formatIdList writes one id per line and an empty file for an empty list", () => {
+    expect(formatIdList([])).toBe("");
+    expect(formatIdList(["A", "B"])).toBe("A\nB\n");
+  });
+
+  it("parsePromotedFiles only picks up enforce-lane maturities", () => {
+    const diff = [
+      "+++ b/rules/tool-poisoning/ATR-2026-00001-a.yaml",
+      "+maturity: stable",
+      "+++ b/rules/prompt-injection/ATR-2026-00002-b.yaml",
+      "+maturity: test",
+      "+++ b/rules/prompt-injection/ATR-2026-00003-c.yaml",
+      '+maturity: "production"',
+    ].join("\n");
+    expect(parsePromotedFiles(diff)).toEqual([
+      "rules/tool-poisoning/ATR-2026-00001-a.yaml",
+      "rules/prompt-injection/ATR-2026-00003-c.yaml",
+    ]);
+  });
+});
+
+describe("runGate against a fixture corpus", () => {
+  let fixture: Fixture;
+  let mixedIds: string;
+
+  beforeAll(() => {
+    fixture = makeFixture();
+    mixedIds = writeIdsFile(fixture, "mixed.txt", [DIRTY_ID, CLEAN_ID]);
+  });
+
+  afterAll(() => {
+    rmSync(fixture.root, { recursive: true, force: true });
+  });
+
+  it("default mode still fails on a dirty rule and writes nothing", async () => {
+    const code = await runGate({ ...BASE_OPTIONS, idsFile: mixedIds }, fixture.deps);
+    expect(code).toBe(EXIT_FAIL);
+    expect(existsSync(fixture.out)).toBe(false);
+  });
+
+  it("default mode passes when every requested rule is FP-clean", async () => {
+    const cleanOnly = writeIdsFile(fixture, "clean-only.txt", [CLEAN_ID]);
+    const code = await runGate({ ...BASE_OPTIONS, idsFile: cleanOnly }, fixture.deps);
+    expect(code).toBe(EXIT_OK);
+  });
+
+  it("--emit-clean partitions the ids exactly and keeps gate semantics", async () => {
+    const clean = join(fixture.out, "gate-clean.txt");
+    const dirty = join(fixture.out, "gate-dirty.txt");
+    const code = await runGate(
+      { ...BASE_OPTIONS, idsFile: mixedIds, emitClean: clean, emitDirty: dirty },
+      fixture.deps,
+    );
+    expect(code).toBe(EXIT_FAIL);
+    expect(readIds(clean)).toEqual([CLEAN_ID]);
+    expect(readIds(dirty)).toEqual([DIRTY_ID]);
+  });
+
+  it("--filter-mode emits the same lists but exits 0 so a `set -e` promoter survives", async () => {
+    const clean = join(fixture.out, "filter-clean.txt");
+    const dirty = join(fixture.out, "filter-dirty.txt");
+    const code = await runGate(
+      {
+        ...BASE_OPTIONS,
+        idsFile: mixedIds,
+        emitClean: clean,
+        emitDirty: dirty,
+        filterMode: true,
+      },
+      fixture.deps,
+    );
+    expect(code).toBe(EXIT_OK);
+    expect(readIds(clean)).toEqual([CLEAN_ID]);
+    expect(readIds(dirty)).toEqual([DIRTY_ID]);
+  });
+
+  it("emits empty lists (not missing files) when the id list is empty", async () => {
+    const empty = writeIdsFile(fixture, "empty.txt", []);
+    const clean = join(fixture.out, "empty-clean.txt");
+    const dirty = join(fixture.out, "empty-dirty.txt");
+    const code = await runGate(
+      { ...BASE_OPTIONS, idsFile: empty, emitClean: clean, emitDirty: dirty },
+      fixture.deps,
+    );
+    expect(code).toBe(EXIT_OK);
+    expect(readFileSync(clean, "utf-8")).toBe("");
+    expect(readFileSync(dirty, "utf-8")).toBe("");
+  });
+
+  // Was: "never lets an unresolvable id reach the clean list" — which asserted
+  // exit 0. Keeping the ghost id out of the clean list is necessary but not
+  // sufficient: exit 0 told the caller the scan happened. It did not.
+  it("fails with a distinct code when an id matches no rule on disk", async () => {
+    const withGhost = writeIdsFile(fixture, "ghost.txt", [CLEAN_ID, "ATR-2026-99999"]);
+    const clean = join(fixture.out, "ghost-clean.txt");
+    const code = await runGate(
+      { ...BASE_OPTIONS, idsFile: withGhost, emitClean: clean },
+      fixture.deps,
+    );
+    expect(code).toBe(EXIT_MISSING_IDS);
+    expect(code).not.toBe(EXIT_OK);
+  });
+
+  it("writes no list at all when ids are missing, so a stale file cannot be consumed", async () => {
+    const ghostOnly = writeIdsFile(fixture, "ghost-only.txt", ["ATR-2026-99999"]);
+    const clean = join(fixture.out, "never-written-clean.txt");
+    const dirty = join(fixture.out, "never-written-dirty.txt");
+    const code = await runGate(
+      { ...BASE_OPTIONS, idsFile: ghostOnly, emitClean: clean, emitDirty: dirty },
+      fixture.deps,
+    );
+    expect(code).toBe(EXIT_MISSING_IDS);
+    expect(existsSync(clean)).toBe(false);
+    expect(existsSync(dirty)).toBe(false);
+  });
+
+  it("missing ids fail even in --filter-mode (filter relaxes the FP verdict, not bad input)", async () => {
+    const ghostOnly = writeIdsFile(fixture, "ghost-filter.txt", ["ATR-2026-99999"]);
+    const clean = join(fixture.out, "filter-missing-clean.txt");
+    const code = await runGate(
+      { ...BASE_OPTIONS, idsFile: ghostOnly, emitClean: clean, filterMode: true },
+      fixture.deps,
+    );
+    expect(code).toBe(EXIT_MISSING_IDS);
+    expect(existsSync(clean)).toBe(false);
+  });
+
+});
+
+describe("gitRuleFiles — candidate discovery", () => {
+  let root: string;
+
+  /** Records the argv of every git invocation so the flag contract is pinned. */
+  function fakeGit(tracked: string, untracked: string): { run: GitRunner; calls: string[][] } {
+    const calls: string[][] = [];
+    const run: GitRunner = (args) => {
+      calls.push([...args]);
+      return args.includes("--others") ? untracked : tracked;
+    };
+    return { run, calls };
+  }
+
+  function touch(rel: string): void {
+    const abs = join(root, rel);
+    mkdirSync(dirname(abs), { recursive: true });
+    writeFileSync(abs, "id: ATR-2026-00000\n", "utf-8");
+  }
+
+  beforeAll(() => {
+    root = mkdtempSync(join(tmpdir(), "atr-discovery-"));
+    touch("rules/a/tracked.yaml");
+    touch("rules/b/untracked.yaml");
+    touch("rules/b/notes.md");
+  });
+
+  afterAll(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("asks git for untracked files with --exclude-standard (the flag that was missing)", () => {
+    const { run, calls } = fakeGit("rules/a/tracked.yaml\n", "");
+    gitRuleFiles(root, run);
+    const others = calls.find((c) => c.includes("--others"));
+    expect(others).toBeDefined();
+    expect(others).toContain("--exclude-standard");
+    expect(others).toContain("rules/");
+  });
+
+  it("includes an uncommitted rule file — the case that produced a zero-measurement PASS", () => {
+    const { run } = fakeGit("rules/a/tracked.yaml\n", "rules/b/untracked.yaml\n");
+    expect(gitRuleFiles(root, run)).toEqual([
+      "rules/a/tracked.yaml",
+      "rules/b/untracked.yaml",
+    ]);
+  });
+
+  it("keeps the previous tracked-only result when nothing is uncommitted", () => {
+    const { run } = fakeGit("rules/a/tracked.yaml\n", "");
+    expect(gitRuleFiles(root, run)).toEqual(["rules/a/tracked.yaml"]);
+  });
+
+  it("de-duplicates, sorts, and ignores non-rule files", () => {
+    const { run } = fakeGit(
+      "rules/b/untracked.yaml\nrules/a/tracked.yaml\nrules/b/notes.md\n",
+      "rules/b/untracked.yaml\n",
+    );
+    expect(gitRuleFiles(root, run)).toEqual([
+      "rules/a/tracked.yaml",
+      "rules/b/untracked.yaml",
+    ]);
+  });
+
+  it("drops a still-tracked file that is gone from the working tree", () => {
+    const { run } = fakeGit("rules/a/tracked.yaml\nrules/a/deleted.yaml\n", "");
+    expect(gitRuleFiles(root, run)).toEqual(["rules/a/tracked.yaml"]);
+  });
+});
+
+describe("CLI entry point (guards against a no-op gate)", () => {
+  function run(args: readonly string[]): { status: number; stderr: string } {
+    const r = spawnSync("npx", ["tsx", SCRIPT, ...args], {
+      cwd: REPO_ROOT,
+      encoding: "utf-8",
+      timeout: 120_000,
+    });
+    return { status: r.status ?? -1, stderr: r.stderr ?? "" };
+  }
+
+  it("exits 2 on a usage error instead of silently doing nothing", () => {
+    const { status, stderr } = run(["--filter-mode"]);
+    expect(status).toBe(EXIT_USAGE);
+    expect(stderr).toContain("usage error");
+  });
+
+  it("actually executes main when invoked directly (emits the requested file)", () => {
+    const dir = mkdtempSync(join(tmpdir(), "atr-gate-cli-"));
+    const ids = join(dir, "ids.txt");
+    const clean = join(dir, "clean.txt");
+    // An EMPTY id list is the only genuinely empty scan: nothing was requested,
+    // so nothing is unmeasured. A nonexistent id is a different thing entirely
+    // and is asserted below.
+    writeFileSync(ids, "", "utf-8");
+    const { status } = run(["--ids", ids, "--emit-clean", clean]);
+    expect(status).toBe(EXIT_OK);
+    expect(existsSync(clean)).toBe(true);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("exits 3 and names the id when --ids points at a rule that does not exist", () => {
+    const dir = mkdtempSync(join(tmpdir(), "atr-gate-cli-missing-"));
+    const ids = join(dir, "ids.txt");
+    const clean = join(dir, "clean.txt");
+    writeFileSync(ids, "ATR-2026-99999\n", "utf-8");
+    const { status, stderr } = run(["--ids", ids, "--emit-clean", clean]);
+    expect(status).toBe(EXIT_MISSING_IDS);
+    expect(stderr).toContain("ATR-2026-99999");
+    expect(existsSync(clean)).toBe(false);
+    rmSync(dir, { recursive: true, force: true });
+  });
+});


### PR DESCRIPTION
What

scripts/gate-promotion-fp.ts now measures a promoted rule on the event shapes the rule can actually fire on, and refuses to report a verdict for a rule it did not measure.

- scripts/lib/corpus-event.ts (new) holds the canonical shape set a benign sample is poured into. It mirrors what src/hook-handler.ts emits, in both the raw and the JSON-encoded form, and is meant to be imported by both sides of any measurement so a rule can never earn its detection credit on a wider shape than the one it pays its false positives on.
- Candidate rule files now include untracked-but-not-ignored files under rules/, not only `git ls-files rules/`.
- An --ids entry that matches no rule file on disk is now exit 3 with the unresolved ids named, and no clean/dirty list is written.
- Fields a text corpus cannot honestly fill (tool_name, trace.*, behavioral.*) are printed as NOT MEASURED instead of being folded into the clean list.
- New --emit-clean / --emit-dirty / --filter-mode, so an upstream promoter can filter its candidate list before opening a PR instead of opening one that CI turns red.
- tests/gate-promotion-fp.test.ts and tests/corpus-event-shapes.test.ts lock the script's contract and prove the shape set is reachable through the real engine rather than trusting a hand-maintained list.

Why

This gate exists to stop a time-based promoter ("60 days in test plus zero FP reports") from putting a never-scanned rule into the enforce (auto-block) lane. It could report PASS without measuring anything, three separate ways.

1. The event shape could not resolve the field the rule detects on.

The scan built a single mcp_exchange event carrying only tool_name / tool_input / tool_response / user_input. resolveField() (src/engine.ts:1340) resolves `field: tool_args` from event.fields.tool_args, or from the event-type default map at src/engine.ts:148 for a tool_call event. Neither was present, so every tool_args condition evaluated to false: the rule could not fire, could not be counted as a false positive, and came back CLEAN. That is a zero-measurement PASS, and in the output it is indistinguishable from a rule that was measured and found innocent.

On this branch's base, 36 rule files declare `field: tool_args`, and three of them are maturity: stable, i.e. already inside the auto-blocking enforce lane:

  rules/context-exfiltration/ATR-2026-01606-ssrf-internal-network-scan.yaml
  rules/privilege-escalation/ATR-2026-01601-sql-injection-destructive-ddl.yaml
  rules/privilege-escalation/ATR-2026-01602-sql-injection-union-select-exfil.yaml

tool_description (9 files) and agent_output (2 files) had the same hole.

Encoding matters as much as presence. src/hook-handler.ts sets tool_args to JSON.stringify(toolInput), so in production a newline inside that field is the two characters backslash and n, not U+000A. A pattern can match one encoding and not the other, so the sample is now presented in both, and each field receives the encoding production would actually put there.

2. Candidates came from tracked files only.

`git ls-files rules/` misses rules that exist on disk but have never been committed, which is the normal state of a freshly authored rule and the exact moment its FP behaviour most needs measuring. With them invisible, --ids resolved zero targets, printed "nothing to gate", and exited 0 -- a pass on precisely the rules that had never been measured.

3. An unresolved id was only a WARN.

A promoter feeding a stale or misspelled id list got exit 0 and an empty clean list, which reads as "scanned, all fine". Now it is exit 3, the ids are named, and nothing consumable is written: an unread verdict must not leave an artifact behind.

Evidence

Tests: 59 tests across the two new files pass (tests/gate-promotion-fp.test.ts 26, tests/corpus-event-shapes.test.ts 33), run on a clean worktree checked out from this branch's base.

Full local suite on the same worktree: 706 passed, 3 skipped, 1 failed out of 710. The single failure is tests/skill-benchmark.test.ts asserting SKILL.md scan latency under the local-machine ceiling (199.87ms measured against a 150ms local ceiling; the CI ceiling in that same test is 1000ms). It is a machine-speed threshold in a benchmark this PR does not touch -- no engine, rule, or scanSkill code changes here -- so CI is the authority on it.

Backward compatibility of the default path: `npx tsx scripts/gate-promotion-fp.ts --base origin/main` on this branch prints "no rules promoted to enforce lane vs origin/main - nothing to gate." and exits 0, unchanged.

The three maturity: stable tool_args rules above, measured for the first time against the in-repo benign corpora (466 samples from data/skill-benchmark/benign, data/benign-corpus-extended, data/benign-code):

  ATR-2026-01601  old shape 0 FP  ->  new shape 0 FP
  ATR-2026-01602  old shape 0 FP  ->  new shape 0 FP
  ATR-2026-01606  old shape 0 FP  ->  new shape 0 FP

Widened to the whole enforce lane: all 112 rule files on the base carrying maturity stable or production, old shape versus new shape, same 466 benign samples.

  rules that flip 0 FP -> more than 0 FP : 0
  rules whose FP count merely grows      : 0
  dirty enforce-lane rules               : 0 before, 0 after

So the enforce lane is not retroactively broken by this change. The rules that were unmeasured are now measured, and they are still clean.

False positives are counted per sample, not per shape, so a document that trips a rule on two shapes is one FP, not two, and the numbers stay comparable with what the gate reported before.

Risk

Scope of blast radius is CI, not production. Nothing in this PR is loaded by the engine at runtime: it changes a gate script, a scripts/lib helper used only by harnesses, and two test files. No rule content changes, so .github/workflows/publish-on-rules-merge.yml (which triggers on rules/** pushed to main) does not fire and no npm publish happens on merge.

The real risk is future rule PRs turning red. .github/workflows/maturity-fp-gate.yml runs this script on every PR touching rules/**. With a wider event shape, a rule that was "clean" only because its field was permanently undefined can now be charged with real false positives, and any PR promoting such a rule to stable/production will fail. That is the intended behaviour and the reason this ships as its own PR: if the gate starts failing, it should be obvious which change caused it. The measured evidence above says no enforce-lane rule on the base flips, so no already-merged rule is retroactively invalidated by this alone.

The wide shape is a strict superset of the old one (same type, same tool_name, same tool_input / tool_response / user_input), so no false positive the old shape counted can disappear. The change can only reveal, never hide.

Default behaviour is frozen. With no output flags the exit codes are exactly as before, --emit-clean alone keeps gate semantics and only adds a side output, and --filter-mode refuses to run unless paired with an emit target, so it can never be used to silently mute the gate. The GateDeps injection point that lets the tests run against a fixture corpus is deliberately not reachable from the CLI or the environment: a security gate must not be re-pointable by configuration.
