### PR TITLE
fix(rules): revive two enforce-lane draft rules the engine could never fire

### DIFF
--- a/rules/prompt-injection/ATR-2026-00080-encoding-evasion.yaml
+++ b/rules/prompt-injection/ATR-2026-00080-encoding-evasion.yaml
@@ -1,7 +1,7 @@
 title: Encoding-Based Prompt Injection Evasion
 id: ATR-2026-00080
 rule_version: 1
-status: draft
+status: experimental
 description: >
   Detects prompt injection attempts that use encoding techniques to bypass text-based detection rules. Attackers encode
   malicious payloads using base64, hex, Unicode escapes, Punycode, or RTL override characters to smuggle instructions

--- a/rules/prompt-injection/ATR-2026-00089-polymorphic-skill.yaml
+++ b/rules/prompt-injection/ATR-2026-00089-polymorphic-skill.yaml
@@ -1,7 +1,7 @@
 title: Polymorphic Skill and Capability Aliasing Attack
 id: ATR-2026-00089
-rule_version: 1
-status: draft
+rule_version: 2
+status: experimental
 description: >
   Detects injection attempts that use polymorphic techniques to disguise malicious capabilities under benign aliases.
   Attackers register or invoke tool functions using misleading names, redefine existing capability names, or use dynamic
@@ -80,13 +80,20 @@ detection:
     - field: user_input
       operator: regex
       value: >-
-        (?i)\b(dynamic|runtime|lazy|deferred|on.?demand)\s+(load|generat|compil|creat|build|assembl)\w*\s+.{0,20}(payload|code|function|script|skill)
-      description: Dynamic generation of code or payloads at runtime to evade static analysis
+        (?i)\b(dynamic|runtime|just.?in.?time)\s+(load|generat|compil|creat|build|assembl)\w*\s+.{0,20}(payload|code|function|script|skill)
+      description: >-
+        Dynamic generation of code or payloads at runtime to evade static analysis. 'lazy', 'deferred' and
+        'on-demand' were removed from the qualifier set: 'lazy loading ... code' is standard front-end performance
+        vocabulary (React/Angular bundle-splitting docs) and carries no evasion signal.
   condition: any
   false_positives:
     - Legitimate software development discussions about function refactoring
     - Developer documentation explaining how to remap keyboard shortcuts for IDE tool commands using configuration files
     - Software architecture discussion about lazy loading patterns for plugin capabilities in a modular system
+    - >-
+      Front-end performance guides describing 'lazy loading and code splitting' or 'Lazy load non-critical code' -
+      the only benign shape condition 4 was matching, which is why 'lazy'/'deferred'/'on-demand' are no longer
+      accepted qualifiers
 response:
   actions:
     - block_input


### PR DESCRIPTION
What

Two rules move from status: draft to status: experimental:

- ATR-2026-00080 Encoding-Based Prompt Injection Evasion (maturity: stable, severity: high) - status flip only, no detection change.
- ATR-2026-00089 Polymorphic Skill and Capability Aliasing Attack (maturity: stable, severity: high) - status flip plus a narrowed condition 4, rule_version 1 -> 2.

Both already carry maturity: stable, which is the enforce (auto-block) lane, so this is the highest-risk slice of the draft-revival work and is deliberately isolated in its own PR.

Why

status: draft means the rule does not exist at runtime. src/engine.ts skips draft rules in both evaluation paths, before the lane gate and before any pattern is compiled:

  src/engine.ts:382  (evaluate)       if (rule.status === 'deprecated' || rule.status === 'draft') continue;
  src/engine.ts:533  (evaluateAsync)  same line

The comment on the lane option says it outright: "Deprecated/draft rules are always skipped regardless of lane." So these two rules validate, pass their test_cases under tooling that promotes drafts in memory, count toward the corpus, appear as maturity: stable in every report, and have never fired once in any lane.

Measured on origin/main, with the rule files exactly as they are on main:

  lane=enforce  ATR-2026-00080 status=draft maturity=stable  tpFired=0/5
  lane=enforce  ATR-2026-00089 status=draft maturity=stable  tpFired=0/5
  lane=alert    same, 0/5
  lane=hunt     same, 0/5

With this PR applied:

  lane=enforce  ATR-2026-00080 status=experimental maturity=stable  tpFired=5/5
  lane=enforce  ATR-2026-00089 status=experimental maturity=stable  tpFired=5/5
  lane=alert    same, 5/5
  lane=hunt     same, 5/5

Evidence

1. FP gate, named ids, against the benign corpus on this branch:

  npx tsx scripts/gate-promotion-fp.ts --ids <file listing ATR-2026-00080, ATR-2026-00089>

  [fp-gate] gating 2 promoted rule(s) against the benign corpus
  [fp-gate] corpus = 5317 benign samples
  [fp-gate] clean = 2 - dirty = 0
  [fp-gate] PASS - all promoted rules are FP-clean on the benign corpus.
  exit 0

  The same two ids were also run through the widened canonical shape harness (wide-raw, pre-tool-json-arg, pre-tool-json-both, post-tool-json, skill), which measures the JSON-encoded encodings production actually produces: clean = 2, dirty = 0 there as well.

2. Why ATR-2026-00089 needed a detection change, not just a status flip. Its condition 4 read:

  \b(dynamic|runtime|lazy|deferred|on.?demand)\s+(load|generat|compil|creat|build|assembl)\w*\s+.{0,20}(payload|code|function|script|skill)

  "lazy", "deferred" and "on-demand" are ordinary front-end performance vocabulary. Measured against the 5,317-sample benign corpus, that regex matches 8 samples - phrases of the shape "lazy loading and code splitting" and "Lazy load non-critical code". Revived unchanged, those 8 would have become auto-blocks. The qualifier set is narrowed to dynamic/runtime/just-in-time, which is 0 false positives on the same corpus with all 5 true positives retained, and the benign shape is written into false_positives so the next author does not re-add it.

3. Rule validation on this branch: 768 passed, 0 failed, 768 total (npx tsx tests/validate-rules.ts).

Not in this PR, on purpose

ATR-2026-00091 Advanced Structured Data Injection with Nested Payloads is the third stable draft in this group and it stays at status: draft. It fails the FP gate:

  [fp-gate] clean = 2 - dirty = 1
  [fp-gate] FAIL - these promoted rules false-positive on benign content and must not enter the enforce (auto-block) lane:
    ATR-2026-00091 - 479 FP
  exit 1

All 479 come from one condition, in one shape:

  condition 2: (?:\\n|\\r|\\t|%0[aAdD]|%09).{0,30}(ignore|override|system prompt|new instructions)
  shape:       post-tool-json (a tool_response event), 479 of 5317 samples, 9 percent

The condition treats an escaped newline as evidence that someone is hiding a payload boundary. On a PostToolUse event, src/hook-handler.ts sets content = JSON.stringify(toolInput), so every ordinary newline in ordinary tool output is already the two characters \ and n, and src/engine.ts:1340 resolveField maps user_input to event.content on tool_response (the indirect-prompt-injection route). The premise of the condition is destroyed by the encoding, and the rule carries block_input, quarantine_session, kill_agent at auto_response_threshold: critical. It needs a rewrite and its own measurement, so it is left inert rather than promoted into the enforce lane on a bad pattern.

Risk

- Blast radius: any consumer running the enforce lane starts auto-blocking on these two rules for the first time. That is the intended effect, and it is why the FP measurement above is against the benign corpus rather than the rules' own test_cases.
- No CI gate covers this transition today. maturity-fp-gate keys on promotions to stable: parsePromotedFiles only treats a file as promoted when the diff contains a new maturity: stable line. Neither file changes maturity - it was already stable - so the gate sees nothing to gate and passes without measuring. The measurement in this PR was run by hand for exactly that reason.
- npm publish: not triggered. publish-on-rules-merge fires on rule merges to main; this changes no package version and adds no rule, so the effective rule count is unchanged at 768 with two more of them actually reachable.
- Existing users on the hunt lane (the default) also start seeing these two fire. Same 0-FP evidence applies; hunt is advisory, not blocking.
- Reviewer option: if two live rules entering the auto-block lane in one step is more exposure than wanted, demote both to maturity: test in this PR. They then fire in the alert and hunt lanes only, get a real observation round on live traffic, and the existing promoter can lift them back to stable. That is a two-line change and does not affect any of the evidence above.

Merge order

This PR should land after the other draft-revival PRs. It is the smallest one and the only one that puts rules directly into the auto-block lane.

Follow-up, not included here

Once every draft-revival PR has merged, data/rule-status-baseline.json should be tightened once with npx tsx scripts/gate-rule-status.ts --write-baseline. It is not in this PR: the baseline file does not exist on main yet (it arrives with the rule-status gate), and shrinking it before the other revival PRs land would report every rule that is still legitimately draft as an unbaselined draft and fail the gate on main.
