### PR TITLE
fix(rules): stop ATR-2026-02408 self-FPing under whitespace collapse

### DIFF
--- a/rules/data-poisoning/ATR-2026-02408-dataset-loader-code-execution.yaml
+++ b/rules/data-poisoning/ATR-2026-02408-dataset-loader-code-execution.yaml
@@ -216,7 +216,7 @@ detection:
     # repeat stays linear (ReDoS gate).
     - field: tool_args
       operator: regex
-      value: '(?i)(?:\b(?:vllm|sglang|text-generation-launcher|lm[_-]eval|tgi|accelerate\s+launch|torchrun|python\s+-m\s+[\w.]{1,40})\b(?:[^\n\\]|\\\\\\n|\\\n|\\[^\nn\\]){0,300}?--trust[-_]remote[-_]code\b|--trust[-_]remote[-_]code\b(?:[^\n\\]|\\\\\\n|\\\n|\\[^\nn\\]){0,300}?--(?:model|model[-_]id|model[-_]args|tasks|served[-_]model[-_]name|dataset)\b)'
+      value: '(?i)(?:\b(?:vllm|sglang|text-generation-launcher|lm[_-]eval|tgi|accelerate\s+launch|torchrun|python\s+-m\s+[\w.]{1,40})\b(?:[^\n\\`]|\\\\\\n|\\\n|\\[^\nn\\]){0,300}?--trust[-_]remote[-_]code\b|--trust[-_]remote[-_]code\b(?:[^\n\\`]|\\\\\\n|\\\n|\\[^\nn\\]){0,300}?--(?:model|model[-_]id|model[-_]args|tasks|served[-_]model[-_]name|dataset)\b)'
       description: "Serving or evaluation runtime launched with --trust-remote-code - the loaded repository is authorised to execute its own Python inside the worker process"
 
     # -- Layer 6 (secondary): content instructing suppression of the trust gate --


### PR DESCRIPTION
The generalization gate went red on main after #390 landed:

  GATE FAIL - new regressions introduced:
    ATR-2026-02408: fires on its own benign true_negative

Cause. Condition 4 detects a serving-runtime launcher near a
--trust-remote-code flag. Its connector was written to let the pair span a
shell line continuation:

  (?:[^\n\\]|\\\\\\n|\\\n|\\[^\nn\\]){0,300}

Under the gate's whitespace-collapse mutation there are no newlines left, so
[^\n\\] matches everything and the connector runs straight through a fenced
code block boundary. True negative 11 is a docs page with two independent
bash examples; collapsed, the --trust-remote-code from the first example and
the launcher from the second sit inside one window and the rule fires.

Fix. Exclude the backtick from the connector so it cannot cross a fence.

Measured, both connectors, raw and whitespace-collapsed:

  before   own TP hit by cond 4: 2/11   TN false-positive: [11]
  after    own TP hit by cond 4: 2/11   TN false-positive: none

Recall on the rule's own true positives is unchanged. The other nine true
positives are carried by conditions 0, 1, 2, 3 and 5 and are untouched.

Verification:

  validate-rule-testcases ATR-2026-02408   23 pass / 0 fail (TP=11, TN=12)
  gate:generalization                      GATE PASS, self-FP 2 (baseline 3)
  validate-rules                           779 passed, 0 failed
  gate-promotion-fp --ids 02408            5317 samples, clean=1 dirty=0, PASS
  gate-re2-portability                     GATE PASS, no new incompatibility

The gate also reports five rules that are now fixed and can leave the
baseline (01600, 01607, 01608, 01616, 00040). Tightening the baseline is
left to a separate change so this one stays minimal.