### PR TITLE
chore(maturity): seed the FP-gate verdict cache

### DIFF
--- a/data/maturity-promote/fp-gate-cache.json
+++ b/data/maturity-promote/fp-gate-cache.json
@@ -1,0 +1,1231 @@
+{
+  "version": 1,
+  "corpusFingerprint": "a43c45114204b96c6df94d92717dfd793fc14a375bdde572185a21e138d86886",
+  "rules": {
+    "ATR-2026-00041": {
+      "sha": "1a3e46eff5c0e0c7ccfbe178e5a68f1dbc4f9518c706ce8de183b25c15df89bc",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00131": {
+      "sha": "132026ff81baadcf6659962c7c51a6251d494900887f3b0902419d4f3b04cbe4",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00132": {
+      "sha": "7de4d939ff62d920f7b0e2ea8323cc35170e7922873dd68419d437758e8fb662",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00134": {
+      "sha": "e8e230eac0920f3a7cd41e2d995186185ff2e6a9d0f3b56ce3cfe1e4921b6ee9",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00140": {
+      "sha": "a346efe793c85174418b92f86cb67e887222cb13f5fc3f6073859160016be3da",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00143": {
+      "sha": "d7cc6bce75992ccfa3b8e27a153c3aa75a01b334ce5b7783e14c85040aead626",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00144": {
+      "sha": "91f45717148cb6483f06525646db7b83e310ecfa9342bb8c4223e9789aea8007",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00145": {
+      "sha": "50c5b9e9e3ec19d167f7a65808ba9ee1241fe0758b290766e8790ba61880d312",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00146": {
+      "sha": "2c7f3ce96356811c119bbd1c1961359040f39bf239076e23596480070d465970",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00147": {
+      "sha": "20779f275058f549eafc001ddd1aa947dac55d072aa1c7817ce667833921c89b",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00151": {
+      "sha": "15647c91e0962812e38eeefd133748689720c9d679613d64f863116f6825c09a",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00152": {
+      "sha": "6223d4040c5d6985f871d767bd2307ab0026a740d1e981aee84e89362b26a6bc",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00155": {
+      "sha": "11b2982276f47b070f312a60ac385cf4d27b80530cecc29b05f67ae7dafacdcd",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00156": {
+      "sha": "6d5bcbf608d4eede7c241d142738ac498f8fda821ffb437615d16f2601cfb665",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00157": {
+      "sha": "3cd30252e43188805fd432453970b03d75f4522d87a9c3219637930da772e89b",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00207": {
+      "sha": "d4bd589ff68cdc5f30ec9d66e47e106078e427b5e57b0c810320741a8ad255a4",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00209": {
+      "sha": "1016a050f8df46c120a90853cc6f3f92466d8ad47e8955851641a6adfc6a7c04",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00210": {
+      "sha": "482bd68fee3c5f786cda8f2ad6cf292eea4deb0e5f468820635546b4c781b6c6",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00212": {
+      "sha": "796933078f5b7471053c7679a0f6ae7ce3211cfcbbc6b8ef01e4509730a5ade9",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00214": {
+      "sha": "d2e30f039da7ff3fb38275234405056ed81be5b76dbc526f045e1184385b4e71",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00230": {
+      "sha": "45dc7de02fd47fc1366e2b612f29f3278a6a394e36cbc2eed3b014fece6d326e",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00235": {
+      "sha": "c52751ceb4fbf63ae9f100e1ca1ccb8174833cacd9fea14d178f59de7032472f",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00236": {
+      "sha": "adb0fe5c4ed4ba56d4ce6d9528f754d78b0603044a9474783833bab0795b26a8",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00239": {
+      "sha": "f16fc6b2912f2e69201b5567c5856c4ab50eced6991582c31210060b4501df36",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00241": {
+      "sha": "8de009cc89bf2822123622decf7455496fb187ce4847d2e9c1b8078643f29db1",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00243": {
+      "sha": "b76333930c667894a7eea6e58f5cfc3d9481e68a2947911d60656ebdf72e0779",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00244": {
+      "sha": "e6b1dbc2d56d590f6a5f189f37aae10628ca943b994d64e4e3dc1cc193dc1b49",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00249": {
+      "sha": "bb9aa111baeeee002537674b1b01d8951366eb46ff87185cda43afa80d80da76",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00253": {
+      "sha": "7f6a40487a16ab1805b4ac72419950ecf8b82cf97bfcd32ef1d74211c186f732",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00256": {
+      "sha": "cf0e2ee1847d24a0d16442f0843b194736ef46faaae544d0fcdd0f8ed5ac6064",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00259": {
+      "sha": "9ed940ddf6e51c6afab7642ef7a0a470651dae9de0967b1f70f7aebe5131ce90",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00261": {
+      "sha": "c6ca6adf41249fc0ab536c1b4392bcd182ff7fb3aa5f2b1d268df624bd737943",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00267": {
+      "sha": "b54608431b666e459a8e284c48055f2061dc2f68524842e6a8ed11e53ea5672c",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00272": {
+      "sha": "14968a0e1a7ab22cc010333ed0138400188a5e4167ec5d879acce4fa1c2f5267",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00273": {
+      "sha": "8f5d8f5d24fe645e641a9e9efe2d181b2f34577114d6248b969dadd2a2d59dfd",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00274": {
+      "sha": "2f6c8102e1493520bc99a282866a0bebfa1a4a871720a00f25c96903c3e52912",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00278": {
+      "sha": "bc014c7435e4aad78dd32cffada31920eafb7757e7930445423d17f0f73ddc32",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00279": {
+      "sha": "703a39f1227f4d12a552a93573e36abeea8e5dd33a76073a0b37b897d89487af",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00280": {
+      "sha": "7f55ec48dadd57c471371d4d38f1976a76be66655ee34b6a3d8ecbc3a1f71449",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00281": {
+      "sha": "7e026450853e4079461b446ce4a96a848edae09a128f1ad8588eaeec054c520f",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00288": {
+      "sha": "ba798aa6ebf63a21bf436937045e1516582a2f9c619f1cdc42389c9cfded572c",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00290": {
+      "sha": "fe72b298ae7900962fc8412f1f8fa44ab2a500513c2c57e9b3652e4c4ac3efe1",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00291": {
+      "sha": "4d47fea0ab73622daf12f9c96a7a9042109ce0c286c8a36c45e78ed9a9af2ddd",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00293": {
+      "sha": "9043fde56b91afbd8b2183effa75de1db22a440d55a9ee633f2b39cdbcd448f3",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00294": {
+      "sha": "d7f769d126c8e7c6b5778a0baed7ad713b7093166de87940b24d75875baa2e5e",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00295": {
+      "sha": "cdd1b5d86656548fb88a9403c70593567a0411a2672f6f0851889322d8e51cdb",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00303": {
+      "sha": "81d38e67e7b63652b1f9d4c5717adc4ef5376cd0c6be460fcf36e4d89dc184be",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00304": {
+      "sha": "201e866d2697b516f0076800f3be9e64a6257735e417226b7ae3369e75fdc83d",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00305": {
+      "sha": "3b71d1dc7404e3894cd2bccd00edcf4c15a4df78e85c6f98ff2da94310121363",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00306": {
+      "sha": "4d813c4ea095bf44a3480262af4c5a86f06dd08abf39bf1f8aa2260d45370958",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00307": {
+      "sha": "24c0efdb1ed676aac717fcad320fe1eb4ed33c1dfc4ae6b9f912e08936f7a60c",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00314": {
+      "sha": "94f67aca902c67efcf88f92efc1b93be56c665e2934fa1de5593a908fd7b3b2e",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00315": {
+      "sha": "094fb14a2cc2ec48297edd8305e0471279ed173f400d2ca8dd1af35c4625d771",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00316": {
+      "sha": "360004d0eb6d35bacb44445c42dd0dca3d25dd3b28336475bd4978ff83cf3580",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00317": {
+      "sha": "39cb51f0cb5d0ecb63b3b0c055243632bba21c274102d4d73077a3c1b8052f50",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00318": {
+      "sha": "25041f51d7daa8333238e73b8e0ae4775176a15d4345b5b8001efed84e6cac5c",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00319": {
+      "sha": "1d9f3a13f473f54399fd1bf4b249feb84211db41ac99387894273d2564fc1439",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00320": {
+      "sha": "fca6947c88f66e5ea779ee7919c1dd7021938cc49dd17abb39f328f8a65907ef",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00321": {
+      "sha": "9bc8dfde383202f565b60f9417138256fcc2f2129ef89e0b5294a4cfdf1827ad",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00323": {
+      "sha": "61a7dd3caab66573115d7728a2eca94fcae6063e31d9986f1780052afde38133",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00324": {
+      "sha": "834eb4ad1ba2485ee48224768cf2d175cf8a2255107dcce288b2a5d2b9d7d002",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00325": {
+      "sha": "4e6d5c5a3f7b8bea9fd86db02c4a1a32253e1df83956bd38c83ef06b3666c6ec",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00326": {
+      "sha": "8f48ea0878bded153fe43e6f8e0bd78d4c04882491872ef86eb1ee22dec05ed0",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00327": {
+      "sha": "6aa4b931d2418c44d5e7aaf75416612e9a6a00d033e2ea007ddd419f37d2cbdc",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00328": {
+      "sha": "29a2e1e55508d084dbbcd16c6252208e35083b9fffd1a6e3c3c0a313aef546b5",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00329": {
+      "sha": "6ad3f8c6fa30b21e797b002ad0e0077f7af1f267ebd017a3cb953580c848101a",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00330": {
+      "sha": "846330dec2c64c855e3c806222ffe7d72a8b70e7dec3aae7313b8cf834689a09",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00331": {
+      "sha": "d58aa6d97998cca30934dd1ee28b2040bea04f769e2750058325eb0ae5d94b2a",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00332": {
+      "sha": "c787972514e26a564a67a545ab6daa97c47afcb876fb2dfa41dd41364492f0de",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00333": {
+      "sha": "6ea91faac2503ca751716ba798307a6a942ee62b539ea7cc43f9f1780373e894",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00334": {
+      "sha": "f6fca985f671d355649f5e9669d44ecd3df77ac33916a3ba01a7ffff4530354c",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00335": {
+      "sha": "6bf7001cc65e93213d2334e487bebc442727850b21983430eec1d6eab5aafd99",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00336": {
+      "sha": "7c2c4dec8c63c3c9a7fa2692733328f2cf393e4bcb9dd8d6b847ea1f2af2e18e",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00337": {
+      "sha": "721b1cfd309117d145474def7b48f0c72227f5f27838660d5e022d4e34fc4265",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00338": {
+      "sha": "bd2af9c3e826003f9e1c0e412192c12e0667859d1e97f67c6e42a8ffcc0843a4",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00340": {
+      "sha": "5e4738cee13105b2c68bf5ea3ae8163525b690627f95be71253837040307af5d",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00341": {
+      "sha": "d4c497182f74969051205aa3b214ce11d83a990d8858be038e6f2550239561d3",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00343": {
+      "sha": "5948ed2f0c0a7d56ea3f69e428898a18caa31748d72e81a868f2b5e2ca5848b3",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00344": {
+      "sha": "6d9fa2329e9a160473f2cbc55586ea169502ea944e223d04699341fa2e4f54c4",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00345": {
+      "sha": "c6e80a67803bc187e97a414a5d030da61557cf281dddaab9056eaea12f809087",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00346": {
+      "sha": "426854ed10ee08aebadeff2a84938106e0916b35e937c39b17b6139a06b841ab",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00348": {
+      "sha": "fd7973887d43f0a84d4a44a608e18aeafdce017aba4baac04e1aebeb99bcf0dc",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00349": {
+      "sha": "c998e909222a75e355cb562ea4ac8ef551a69b08a5ce6941d1e11c3c452a84dc",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00350": {
+      "sha": "5bcd71ea14052a13abdf80ed9aa24936ad9fc2e5c236689433356eaa90170fc9",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00351": {
+      "sha": "bd60665e59a7cbcb81a77a9f32a235d7245e06f305a38997106da7e2c835431b",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00352": {
+      "sha": "e8a46b388d9c7ce11810e7fb58f988b73354ef690f728f6445bb24fc22da353c",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00353": {
+      "sha": "22862b5595d6e8a59f6e185b470cc4cc517e71fcd1edf2db26f819d78fd8cd2c",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00355": {
+      "sha": "eda48401eb5259f72df8b278a4f47d1b821a1da1d9289fdb8e72115b603dba35",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00358": {
+      "sha": "07029619f8c46a7257154768bfa5fb8cd19f8881fca265ccdd5e5eb49471ea62",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00359": {
+      "sha": "5f993d91d8a73dbdf1dc8d16cfabe771ef0d76bef8db046a32055a8ff7dc5e62",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00360": {
+      "sha": "fff54ecaae2cc2bfc75b7a496b275eadbc9d8af0e56479e48af769a4323c9530",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00361": {
+      "sha": "689263a46958ab1e621240f8ef403bcbeaec56280e0913e580233a28d40423b3",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00363": {
+      "sha": "3d30cd861e87276d28036e12584ab432159365f8c6b94c8735d57101e86bb13a",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00364": {
+      "sha": "108799377d0637241b848b9dc04669fa95f14048f3f1768ab7bad76e06333c0c",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00365": {
+      "sha": "3fde5f393b25a78af0e1775c67302ef78961d4fc29f78c01a82808bd6f55aa3d",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00366": {
+      "sha": "213890ffe760ad3a7af14eea58f59a1cd526265d5d9259466cf199b7cdcf7aff",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00368": {
+      "sha": "3ab819083b6d7977c2ccd95bc1abeaabfb5efcadb41fd15379deb741ec109083",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00372": {
+      "sha": "9b237db45f9c574396f25dbf8dbb97bf2e75e1942fddbdac8f4369d9ac7d3767",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00374": {
+      "sha": "79f48d93e4e4820e2375102423e5173495e7dd7db7b3cbe3bd5aa23a82291beb",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00375": {
+      "sha": "b57d53bab9eb0eb16ab1669102ea88f2538e738e6243d516a208f54799d2b85f",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00376": {
+      "sha": "5fefaac0073f91da733e5832f09f553b2e74996617b1b8464e21b2d27f4f57b2",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00377": {
+      "sha": "161071f4c46a91c1dfdb79c25abc58055944020f852eba99de4abaed0ff0daff",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00378": {
+      "sha": "1dbeb6d5c689df45ca96d236ea5e0a7d3de20e37db2fd0b04779ce1b451953c4",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00381": {
+      "sha": "47cac95724eb9cbd4d9b34761588d2a58236c0dbafa906432a9d0fb8ee47c552",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00383": {
+      "sha": "03a8fb5f86c4607e77db0a79284118a9a017cba10ccc2e7c871f90776945beff",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00384": {
+      "sha": "0a85ccdb68ea6cde92900f4c77a5884053ccf0dee105064017559db5f356e8d6",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00386": {
+      "sha": "dca5a1ec26a08fa8f3eb85e0d9f28a60f6796cfe3bf846a22736399b69744015",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00387": {
+      "sha": "9a547f6c67032dfe26fbc25c1a4b899c2eb8c8547504e69c9a0537b4181299c7",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00388": {
+      "sha": "40817667b630864831a661bbd4cbd299e4997cf673d50802d18d65a5fb57de32",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00390": {
+      "sha": "e354911f9355e26152a79db4a017fa03a16dced705bdf1c6ba3c4a4817b2f407",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00391": {
+      "sha": "9d853d408d7afd9bc31d2c9699fd9ce98966b10b71e9ae74ac03d7b02a815582",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00393": {
+      "sha": "d83bdfdd6dec0901a1aaf5ef9b055d38a3c9f2f6ed9ecee809d1028fda8ee5cd",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00396": {
+      "sha": "b197c045313289363e27a87ebb6a5d55a87fdb8333377953f6bd354b28540ba6",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00399": {
+      "sha": "633e98adf29899a736a3b243f3f2be18f8110994d80c3db522a64dd82a6b9a27",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00401": {
+      "sha": "23d70d45aa13dbce47f928305762efc21f134e43d05b494194947fb87fee9806",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00405": {
+      "sha": "435c5408052cf92bec18ca1511b7a0c4408854e1dc927f6249460985764a6fde",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00406": {
+      "sha": "e0bbfce1b53ddc589e435aa29320f28c9274665a23aecd54b55295a3c79030e4",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00411": {
+      "sha": "7f33d277b8ec31ed94ea6c04a14f0062e200dba7f29ae37453dc1a1a9778f7ad",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00412": {
+      "sha": "aaa9401d4ce404e1022d42eb1d9617e933cf14f3e3ed0f386bf459218cb20c8c",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00449": {
+      "sha": "65de88d064893748edfc5df59dc10378b6422591acaf0889c461a49e9a8ba132",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00450": {
+      "sha": "577a0bbb36805fa5a9f5e428404fa514bb442631bea6a1336999fae4e7c064e8",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00451": {
+      "sha": "6695e8563a59c71bc74ab89988ffea73f3a2bdac85469cce34f67783a96bef6d",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00457": {
+      "sha": "6c301df593640f35c56d4089e662ebb08ccaa298f9fb088cd583ac0833d25ed1",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00458": {
+      "sha": "a8c7f2efa9df5325c4e97b51492dd318b7784f05511c3643d9ce09b78257e0d9",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00459": {
+      "sha": "f438cb933db1f646e5edfb801fbab9e000eb633227128c2015805bfa68c899ad",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00460": {
+      "sha": "f4a353ac855e327487d4aea3d1e1b3acaecbd08650367e47422caca4d8a982b8",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00461": {
+      "sha": "04f6654dbd6bb9d714d7151aa2a9f908cbe0edf9ceb878173c291f99e24f2b9f",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00462": {
+      "sha": "3ef6ac85ca0c9ffe4696b9af331c8d4b33b8640d26f4cde9ebc6a790a577b43b",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00466": {
+      "sha": "8c91fc7db38aee39fa490463976bd1821eeaf14967034e05c56bf52f26607918",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00467": {
+      "sha": "5f1948e100f429eb962516314784f066140c9988bcaa4c2052b399f1d13988ca",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00468": {
+      "sha": "fa7a1e8a5ae8a940da30209176d46c87a06a9b27ecff238ed0359dd2a8b3c9ad",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00469": {
+      "sha": "c59e9864df666f23a5598f6d3815d734f7ae674e886478cd243be8ad7ecda51f",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00470": {
+      "sha": "987f92c3b8ed779dcbb745441aa27aa31c27c07a7c87b1ae52a95feec375abed",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00471": {
+      "sha": "8b2e5a35ca78e1fec02c6b270ba228666e8454fa765b565b214ca9f1627709be",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00473": {
+      "sha": "6cb042c7b6174ac3263d0253617133296d8fd193cb7e49b3a34d9020d4087023",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00474": {
+      "sha": "f924a68d3dc994d7d779aa82684a6e3afad227b18f1cf2669ec1a21321e97eeb",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00476": {
+      "sha": "ea2dee6b662f592e0fbff0c9793f5dc2908d730afca70558546d9dd2f7a75e51",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00480": {
+      "sha": "91dfeb38676828699069b123760741e709d1702768a34332cf25d851e82db34d",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00481": {
+      "sha": "6503ebd32134d7b453e48835fbb7e4ef169f6e36d500ad766464a0dd7b82885f",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00482": {
+      "sha": "1b4dcd9d34f9ff9272f3a26451a11adbc90842770ae09f08a20696a51b3758bc",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00483": {
+      "sha": "5464a4bfd2298f6b906187d23ea362866f82d7eb5faeed43793ff034679c2726",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00484": {
+      "sha": "c26f7e11784a6bc7b6dcc789835af4872c470dc2e46694b7a2487700ee3ea5a5",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00486": {
+      "sha": "9658e2cc12234053fd4423172290428d8144346dc3f71254154c1e59e2c123e6",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00487": {
+      "sha": "2e912a0f67d1a913f97f6f2ce170c5a2ec07011a95ad7d55a7ee7f629f00f86f",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00489": {
+      "sha": "a0f1ee6554300a6e66f1d2c6643a81b297eabb7d55e0611aca4f2db5f717b000",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00490": {
+      "sha": "15096fef5869a8782754c7de3deb9a990d98f1055b40043cf7acb638b8dc9f4e",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00495": {
+      "sha": "d81274c07025794f1743edb1412aa61af329921a3009d939ac738584de81650b",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00496": {
+      "sha": "3bd5fede670ce17f9113f95278d7491d906ac0c7e84bcfb3460eec866769a18f",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00499": {
+      "sha": "6f1b6650f41a0d4940b3f3e70460ac8264f354935131da2803414ee9f027da83",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00501": {
+      "sha": "6ff7d33e5640533513be54a3211b2ec030e4e5000fdbceeb37d6f839dc1aad10",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00506": {
+      "sha": "951e31e6e05bd1e760e00be7f259465ae3d577d76569bf030199db57559e0009",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00507": {
+      "sha": "e8bcad37306f6c87d56c434857d9a30f9ff228a6296ad0fb5a0a2453453663cb",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00518": {
+      "sha": "f6dfd42d676bea2c05189e0f74fc1ccf753c45c824a06b7b33fc3e8a50ae964e",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00519": {
+      "sha": "dfc3f90e81b519415b4c42bb9e790696cdfcec3a5560f948517384221c17524f",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00520": {
+      "sha": "45e4af3b645dbb64396ef101f553836cd4be85acc9fb7e05302b77147ffe408d",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00525": {
+      "sha": "a6decd44e42a46c65d3bfdd67c0af7f594239b4b0ef57720433e0066d36e56c1",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00527": {
+      "sha": "6ce75c2d794a61b553919ee6bf8965de628eaf3fcdf72e22fdbcaf8fec3b5463",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00530": {
+      "sha": "d249ce493101a351f9607dde9f5ede243524d2e1277def91ad90b780d68459aa",
+      "verdict": "clean",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00001": {
+      "sha": "4e68a23f16d491acf76668e44f1cfe5a8e3329c76d2754342c48fc13e204a716",
+      "verdict": "dirty",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00004": {
+      "sha": "b307b962415d32c59f0d7e554100ec052ba58afc0cc4321a9f3a2e47e708cc96",
+      "verdict": "dirty",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00005": {
+      "sha": "0a063835417710f50d6654b81155be07c71a57d9e016faecf2c4206ea5786ec9",
+      "verdict": "dirty",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00061": {
+      "sha": "a74777900d699546d5155fb1e1116f31acb436a34ef772d94f96ae156294b120",
+      "verdict": "dirty",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00062": {
+      "sha": "2c8fc4247b3657bea68de247801c4164357aec6165e4ad919fb83cec60449143",
+      "verdict": "dirty",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00063": {
+      "sha": "765d3b63ac2ce53dacd686668eaf8ac8922352d533f8369732e5f039c71f0bac",
+      "verdict": "dirty",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00064": {
+      "sha": "9902f394e041057483bee58034059ec107830b6cef1de87efccfe167dca16beb",
+      "verdict": "dirty",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00065": {
+      "sha": "ba9ff2ca14b883c20a35bb074559c021fca03612592c4ec9d91643b99fd95f25",
+      "verdict": "dirty",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00066": {
+      "sha": "0c7699016a912a9348bfbe905793d28b59caacae02e4516e4ddb5875e92a338f",
+      "verdict": "dirty",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00073": {
+      "sha": "2747f3a9df86ca98200c47ae9dfbbec802ad6e401f38ac31d57c781908e61688",
+      "verdict": "dirty",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00075": {
+      "sha": "36f9d70c52414bb6245f13f802763c362e6183ef2f3486f6e2c814c74aa3e24d",
+      "verdict": "dirty",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00076": {
+      "sha": "86f77848b818dc2ac846a68e41303d34f5a3be3d09accc8a84c6ee480660631d",
+      "verdict": "dirty",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00077": {
+      "sha": "3b8837f2454343c0e8bcb53bb8817fd949b27de933f9452f32de5c2287e62441",
+      "verdict": "dirty",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00098": {
+      "sha": "99249c41cba3e698efec710a3be34fcf91e1d4153ff19f7ff8d31bdadd58f18f",
+      "verdict": "dirty",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00110": {
+      "sha": "2185f4b5308909aafb82eeef62787ce061c14bbdcaea20644a9884e32fd0de61",
+      "verdict": "dirty",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00111": {
+      "sha": "0e933b873af5adc16736ca189c268186c84f22b9c1a27a6b968b81dcbd22681c",
+      "verdict": "dirty",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00113": {
+      "sha": "e4c0edd3336ce35fe9cbeae5d22c22af9163e60bccfd6606e7aed8089df87c34",
+      "verdict": "dirty",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00115": {
+      "sha": "d02bc35e78b172326a6ae14e4202e25890f54338f2450a46e4da0fa363299450",
+      "verdict": "dirty",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00116": {
+      "sha": "1a312006953fa8bdeaccda75e50da98545418efdea1a4127cbd83ecc2cd70d83",
+      "verdict": "dirty",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00118": {
+      "sha": "6f34596b421c62522ab9224f23741e6f6851213626dfa8c95d586de60edc8842",
+      "verdict": "dirty",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00119": {
+      "sha": "2a6472fa3db7f038f42dbf9bd4950636ff0c114cd7b835cc43c2277c18a1a807",
+      "verdict": "dirty",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00120": {
+      "sha": "f4ed3beab8ba927d86037e19283214e72689573e1379d86340f5426baa166bf9",
+      "verdict": "dirty",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00121": {
+      "sha": "ce971eb55c827107bb0f0972af70d3bd7deb8575f5e06fd571efd77fc43f1faf",
+      "verdict": "dirty",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00122": {
+      "sha": "199a90c904895ad09efbf3d4be5f6683fe8526b506cb3592f3e6588164e18546",
+      "verdict": "dirty",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00123": {
+      "sha": "71f4d1cad84222867b4f3628cb48fce74be5c051b9e521adbc86077f72d6dd61",
+      "verdict": "dirty",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00126": {
+      "sha": "97944976def66c8fb7be53dc77bf07602a0d2d487a623dfc7d6231992f5f3cc7",
+      "verdict": "dirty",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00128": {
+      "sha": "73061277edbdd6fd3c7f9f1bd9ecddafe91dbdf101c5e553f01eba38df24e036",
+      "verdict": "dirty",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00133": {
+      "sha": "3b53e4aa5bebb14fb66065736defc79a668f6c5e5a5329c66848159bad0d55c8",
+      "verdict": "dirty",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00135": {
+      "sha": "10893853e3f3df9a68e9c5969c9dcdcde4746868395e06a407dbd17ce879bfec",
+      "verdict": "dirty",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00136": {
+      "sha": "4cb285ccfe43841aeb6f98b70f94d9b37c39ab9b6ea84136498608836292574e",
+      "verdict": "dirty",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00141": {
+      "sha": "f4f84bb649a0d79e4017973d727a1e7e79c45bf720ecd5eab0f59f5c9097f893",
+      "verdict": "dirty",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00142": {
+      "sha": "720c1c17860a0b071434ee2034fd6ed4406f652bbe2beab4c3194e5f88761161",
+      "verdict": "dirty",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00149": {
+      "sha": "6034c7f5dd3de92a71deace47289a3e665c33b3f7b711f7c69096ba0a934f2ed",
+      "verdict": "dirty",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00161": {
+      "sha": "6410dc241fae4caa575b4b702061d6c2a1b683e08eb9a9ef5a076bb739f4c21f",
+      "verdict": "dirty",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00162": {
+      "sha": "1a0955776d5c3aa928fc6efd9a753153514ef0663bff20ca9a47d93a5689415c",
+      "verdict": "dirty",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00201": {
+      "sha": "02564fb8cd1f46b501c1f99e47c305b2d6286c433a7356903b14e8d52035bbb8",
+      "verdict": "dirty",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00204": {
+      "sha": "663aa7baf9ce5cc60ec7a18d4f355d1ce86b3577349b69fec318c802da6e419c",
+      "verdict": "dirty",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00206": {
+      "sha": "68aaaab413dc64e3ab488c4859cf631cb91620da54c4f6adf56772a9e4538f45",
+      "verdict": "dirty",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00217": {
+      "sha": "341ca56af34b481c217b7ecfe45ec6f8f6fffe9565aab07a4b13a89b17bc9f45",
+      "verdict": "dirty",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00220": {
+      "sha": "5426649812ac5701673dcc4b1cd7550f6ffdc5ffef6f59155f5f170b0e42a863",
+      "verdict": "dirty",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00222": {
+      "sha": "2780af5e4c128412e0a59310688427deb174d01eefd5449365edab2e511190c3",
+      "verdict": "dirty",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00223": {
+      "sha": "34c4583a347995e63ad2e2aa9efa90317a654946f9ec8e4337b89e6a969bc64b",
+      "verdict": "dirty",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00224": {
+      "sha": "be2427dea05a1b7f99d5c1cec288b540551135a9601cfca08bd504b0f6c4b8d6",
+      "verdict": "dirty",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00227": {
+      "sha": "0ee65cf2caa7905aa3e34fa0c36b069bc1fcf0385524b5475f03e30eda794c13",
+      "verdict": "dirty",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00237": {
+      "sha": "44b51248ea607ffce6273510150b09a765293f05fe92498cd87611056390c515",
+      "verdict": "dirty",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00240": {
+      "sha": "e7b16b0b1c84601bb022e1bbdad7ad92402aabdc1ab61c517c743b714314052d",
+      "verdict": "dirty",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00242": {
+      "sha": "d79bac3aa3b4fd1a0aa9fa804f387bd0bd66a8bbfd86ad11c2f969ddd444f1b7",
+      "verdict": "dirty",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00258": {
+      "sha": "d64861f87fa2fa45cfac7c78b922e0501df6ebc5faaa68a0e94c378cc3a833bb",
+      "verdict": "dirty",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00263": {
+      "sha": "15f965d9c65843799ff6c983e8eb1a80194bd854d3c30359e31f126e1882f055",
+      "verdict": "dirty",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00264": {
+      "sha": "540d46fea9a99e5c84a1404837796a0f0d3eac3fd9d79ed70c6304e1db65a88a",
+      "verdict": "dirty",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00265": {
+      "sha": "cdd120ebe3f4f3e2f89775e9ea6cb5ef1058ecc46f072c71545b5b4fe73dc028",
+      "verdict": "dirty",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00270": {
+      "sha": "483dbd543d9888ceefc6eaa5b41d65e6fcde397aff14c7fdd5460eb89d526d86",
+      "verdict": "dirty",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00275": {
+      "sha": "dddd60c1fc7743681c32bee6df428db3a5fbddc44a86d797830e0fe38bbe02d7",
+      "verdict": "dirty",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00276": {
+      "sha": "6ef81911a858d910acbfaddeda66de62dfb2e52080ab6a8cb525fed3737122f7",
+      "verdict": "dirty",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00277": {
+      "sha": "77e45a675b3d2256f548f5dbd91a2fe9908c63796e1dec4b477fde747cb0e4a4",
+      "verdict": "dirty",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00282": {
+      "sha": "2e9da4f588ee80a4ee003a331de51cece7fb80a7b6547a20777d6a4d37210718",
+      "verdict": "dirty",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00286": {
+      "sha": "b7a13dac523f956d2ca0ee198bcce47c02ed7e59e13947997afd77651121c38e",
+      "verdict": "dirty",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00297": {
+      "sha": "894f7b9e083ce5f0418dbbad336a5cc640d8efe1438242f483f07039cfce2226",
+      "verdict": "dirty",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00301": {
+      "sha": "5778e3eb55131dc1ef07497a400f333f4a5e4c7f079d72aac94e6b6c419c7ec2",
+      "verdict": "dirty",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00395": {
+      "sha": "0576c17a5dbc890d0af83251bb5aed58c32313a2326b6aa280e31e0b8dee9ee0",
+      "verdict": "dirty",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00398": {
+      "sha": "2ef2de6825218c2ca26809cf765fcf1cba80d41db077a8eba9f564a453d20073",
+      "verdict": "dirty",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00407": {
+      "sha": "8bf651952058d916a09fcaf5a8c8e96218bc469047ae270bf79deaca9cc57a02",
+      "verdict": "dirty",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00441": {
+      "sha": "b8e23ea3ca68e1369c8de387fea2ae284eae8474f3befc0547442ebcb0132279",
+      "verdict": "dirty",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00442": {
+      "sha": "02ab21c6adb265257dfee0227ec917227c5f296612250e8fa9bb23ecb9306b99",
+      "verdict": "dirty",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00445": {
+      "sha": "3f53d095467374cf96022471d7b3fb45763c7b7a52687bde1338aaae7c4635e0",
+      "verdict": "dirty",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00447": {
+      "sha": "c2d389e8c50af516b57f863aa345b76f5ee2823f3425e8b3a36030682608e5dd",
+      "verdict": "dirty",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00448": {
+      "sha": "b148c2b388596013934e778d29fbc5655f62cf9814f5ede04765e67c9d85677c",
+      "verdict": "dirty",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00454": {
+      "sha": "48794301e820b854420c7a85d1682d58824377329d98be68798db14dbe9b7762",
+      "verdict": "dirty",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00455": {
+      "sha": "176207c676970910c7d741eae1b88114cb8823c822902b7afdd2cb75582d9d5c",
+      "verdict": "dirty",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00475": {
+      "sha": "392a92bd2bc120ec5306babbe4c1e4095500a9748cee3dfeebe585610d297a51",
+      "verdict": "dirty",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00477": {
+      "sha": "bf50b81b60af1066c625c11bd890f40bf0b004e5686b6b4a5040f2ed5bf2f2e9",
+      "verdict": "dirty",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00479": {
+      "sha": "53e4c430b7e46d0f8f081b44a911265d03f631ec01784593fe370d3e622cf2dd",
+      "verdict": "dirty",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00488": {
+      "sha": "441215f82ba95ed2438175772a8ebc71060ea04a406cb5a9b05e6161eb677f8a",
+      "verdict": "dirty",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00491": {
+      "sha": "f581a136f7eb0aac9f8eabc792ac19471fdf544c2b5d6272b42b9ed90daab7a6",
+      "verdict": "dirty",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00494": {
+      "sha": "2781a3db6d9b59a42e89e5d0782460231150ccae725af1b7c79dc8ce6c7b4a74",
+      "verdict": "dirty",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00497": {
+      "sha": "bdc2c797679fbf479ca0fb7f597d8e1a03ad0eb118718a0d2f0f14ea11b8af6c",
+      "verdict": "dirty",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00498": {
+      "sha": "011f5de6ebc84033f03edc1027f03aec8157d3caa238fd2cf76d9b60835c9750",
+      "verdict": "dirty",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00500": {
+      "sha": "36ec1840ccc7c155b9d873ca5ccc2c8f6e56e780963314dde50dc4cad6b1fad9",
+      "verdict": "dirty",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00502": {
+      "sha": "506df5c937e593c89c4d0ad0761892d5f5c8dcb13d912a0ae7a49c92bafed682",
+      "verdict": "dirty",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00504": {
+      "sha": "65f58c74d4be4f4319941587e9e93031054c689a8c4b20eec0c4ec1c23d94d3d",
+      "verdict": "dirty",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00505": {
+      "sha": "b4fe9fd687368d7bcb97aa77ac3b85eed06651834f4a013ba04b29b4f92de995",
+      "verdict": "dirty",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00508": {
+      "sha": "07ceccd4110e19bc3926b629f044b4af7caa795ad412bff4aa6466b414c27c9c",
+      "verdict": "dirty",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00521": {
+      "sha": "2b85cf9b0ccbe056930d1421d7f9bc69bb5498e349d31ef8f5bb372639fed386",
+      "verdict": "dirty",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00522": {
+      "sha": "3822f4bcabf6ac596fab2a3f950568b81997429eafad2ea0c00d1409e81cdf65",
+      "verdict": "dirty",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00526": {
+      "sha": "5af4accd99bdaeec263ed939b5dfb89a91770154e70bfa8c546693d79a5d01a3",
+      "verdict": "dirty",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00528": {
+      "sha": "d4310cbd1865f2c93dce47092065fbe091aa2e18f74da01ab3de3b37783b31dc",
+      "verdict": "dirty",
+      "gatedAt": "2026-08-03"
+    },
+    "ATR-2026-00529": {
+      "sha": "bbdede9922078167bb63ac981b3097531f917e793b45434d210c5911bbb9452a",
+      "verdict": "dirty",
+      "gatedAt": "2026-08-03"
+    }
+  }
+}


### PR DESCRIPTION
The daily promoter now caches false-positive verdicts so it re-scans only rules whose file, or whose benign corpus, changed. Without a seed the first run after that change still pays the full cost — 245 rules, 3h16m on the last measured run — to re-derive verdicts we already have.

These 245 entries are the verdicts from the 2026-08-03 promotion run: 158 clean, 87 dirty. They are keyed on the post-promotion rule content, which is what the promoter produces again on the next run, and on a fingerprint of the benign corpus, which is byte-identical between main and that run's branch.

Nothing is trusted blindly. A verdict is reused only while both hashes match; either changing re-gates the affected rules, so a wrong seed costs a scan rather than a bad promotion.

Verified with the cache tool against the real candidate set: 245 candidates, 0 to gate, 87 known dirty, 158 known clean.