### PR TITLE
feat(sigma): tell the operator when --regex-dialect re2 would unlock rules

### DIFF
--- a/scripts/generate-sigma.py
+++ b/scripts/generate-sigma.py
@@ -217,6 +217,16 @@ def strip_leading_i_flag(pattern: str) -> tuple[str, bool]:
 # unrunnable from the rule itself instead of from a compile error.
 
 RE2_MAX_REPEAT = 1000
+
+# The one blocker that --regex-dialect re2 removes by itself. Named rather than
+# inlined because the end-of-run summary decides what "would unlock" means by
+# comparing against it: if the two spellings drift apart, the summary silently
+# starts counting zero, and a downstream RE2 consumer goes on believing the
+# corpus is less portable than it is.
+SPELLING_BLOCKER = (
+    "JS-style \\uXXXX / (?<name> spelling; RE2 needs \\x{XXXX} / (?P<name> "
+    "(re-run with --regex-dialect re2)"
+)
 _HEX4_RE = re.compile(r"[0-9a-fA-F]{4}")
 _BRACED_HEX_RE = re.compile(r"\{([0-9a-fA-F]{1,6})\}")
 _GROUP_NAME_RE = re.compile(r"([A-Za-z_][A-Za-z0-9_]*)>")
@@ -394,10 +404,7 @@ def emit_for_dialect(pattern: str, regex_dialect: str) -> tuple[str, list[str]]:
             out = out[:start] + replacement + out[end:]
         return out, blockers
     if rewrites:
-        blockers = blockers + [
-            "JS-style \\uXXXX / (?<name> spelling; RE2 needs \\x{XXXX} / (?P<name> "
-            "(re-run with --regex-dialect re2)"
-        ]
+        blockers = blockers + [SPELLING_BLOCKER]
     return pattern, blockers
 
 
@@ -667,6 +674,37 @@ def out_filename(atr_id: str, source_path: str) -> str:
     return f"{base}.sigma.yml"
 
 
+def rules_unlocked_by_re2_dialect(
+    blocked_rules: list[dict], regex_dialect: str, divergences: dict
+) -> list[str]:
+    """Rule ids that --regex-dialect re2 would move from blocked to runnable.
+
+    A rule qualifies only when escape spelling is its ONLY blocker: a rule that
+    also uses lookaround or a backreference stays blocked in either dialect,
+    and reporting it here would promise a downstream RE2 backend rules it still
+    cannot run.
+
+    Rules with a MEASURED divergence are excluded even though their only static
+    blocker is the spelling. Those are the ones whose rewrite compiles under RE2
+    and then matches a different language; the divergence warning is attached
+    under --regex-dialect re2 only (under pcre they are already blocked for the
+    earlier reason), so counting reasons alone would quietly over-promise by
+    exactly that set. Excluding them is what keeps this number equal to what
+    a real re2-dialect run produces.
+
+    Returns [] under --regex-dialect re2: there is nothing left to advertise.
+    """
+    if regex_dialect != "pcre":
+        return []
+    return [
+        r["id"]
+        for r in blocked_rules
+        if r["reasons"]
+        and all(reason == SPELLING_BLOCKER for reason in r["reasons"])
+        and not divergences.get(str(r["id"]))
+    ]
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description="Convert ATR YAML rules to Sigma format.")
     parser.add_argument("--rule", action="append", default=[], help="path to a single ATR rule YAML (repeatable)")
@@ -732,6 +770,7 @@ def main() -> int:
 
     portable = converted - len(blocked_rules)
     coverage = (portable / converted * 100.0) if converted else 0.0
+    would_unlock = rules_unlocked_by_re2_dialect(blocked_rules, args.regex_dialect, divergences)
     if args.portability_report:
         with open(args.portability_report, "w") as fh:
             json.dump(
@@ -741,6 +780,7 @@ def main() -> int:
                     "re2_portable": portable,
                     "re2_blocked": len(blocked_rules),
                     "re2_coverage_pct": round(coverage, 2),
+                    "would_unlock_with_re2_dialect": would_unlock,
                     "blocked": blocked_rules,
                 },
                 fh,
@@ -759,6 +799,13 @@ def main() -> int:
         f"({coverage:.1f}%); {len(blocked_rules)} tagged atr.portability.re2-blocked.",
         file=sys.stderr,
     )
+    if would_unlock:
+        print(
+            f"  {len(would_unlock)} of those {len(blocked_rules)} are blocked only by escape "
+            f"spelling: re-run with --regex-dialect re2 to make them runnable "
+            f"({portable + len(would_unlock)}/{converted}).",
+            file=sys.stderr,
+        )
     return 0
 
 

--- a/scripts/test_generate_sigma.py
+++ b/scripts/test_generate_sigma.py
@@ -275,6 +275,75 @@ def test_re2_dialect_rewrites_unicode_escapes():
     assert not any("\\u{" in p for p in re2_pats), "re2 dialect must not leave \\u{...} behind"
 
 
+def test_would_unlock_counts_only_spelling_only_blockers():
+    """The advertised count must never include a rule RE2 still cannot run.
+
+    A rule whose blockers include a lookaround stays blocked in both dialects,
+    so promising it to a downstream RE2 backend would be a lie the backend only
+    discovers at compile time.
+    """
+    spelling = CONV.SPELLING_BLOCKER
+    blocked = [
+        {"id": "SPELLING-ONLY", "path": "x", "reasons": [spelling]},
+        {"id": "ALSO-LOOKAROUND", "path": "x", "reasons": [spelling, "lookahead ... RE2 rejects it"]},
+        {"id": "LOOKAROUND-ONLY", "path": "x", "reasons": ["lookahead ... RE2 rejects it"]},
+    ]
+    got = CONV.rules_unlocked_by_re2_dialect(blocked, "pcre", {})
+    assert got == ["SPELLING-ONLY"], f"expected only the spelling-only rule, got {got}"
+
+
+def test_would_unlock_excludes_measured_divergences():
+    """A rewrite that compiles under RE2 and then matches a different language
+    is not an unlock. Those carry their divergence warning only under the re2
+    dialect, so counting reasons alone would over-promise by exactly that set.
+    """
+    blocked = [
+        {"id": "CLEAN", "path": "x", "reasons": [CONV.SPELLING_BLOCKER]},
+        {"id": "DIVERGENT", "path": "x", "reasons": [CONV.SPELLING_BLOCKER]},
+    ]
+    got = CONV.rules_unlocked_by_re2_dialect(blocked, "pcre", {"DIVERGENT": [{"causes": ["differs"]}]})
+    assert got == ["CLEAN"], f"divergent rule must not be advertised as an unlock, got {got}"
+
+
+def test_would_unlock_is_empty_under_re2_dialect():
+    """Nothing left to advertise once the run already emits RE2 spelling."""
+    blocked = [{"id": "SPELLING-ONLY", "path": "x", "reasons": [CONV.SPELLING_BLOCKER]}]
+    assert CONV.rules_unlocked_by_re2_dialect(blocked, "re2", {}) == []
+
+
+def test_would_unlock_matches_a_real_re2_dialect_run():
+    """The number the summary advertises has to equal what actually happens.
+
+    Converts the whole corpus twice and asserts that the set the pcre run says
+    would unlock is exactly the set that stops being blocked under re2 -- so the
+    claim is an identity, not an estimate.
+    """
+    out = tempfile.mkdtemp(prefix="atr-sigma-unlock-")
+    try:
+        reports = {}
+        for dialect in ("pcre", "re2"):
+            rep = os.path.join(out, f"{dialect}.json")
+            subprocess.run(
+                [sys.executable, os.path.join(REPO, "scripts", "generate-sigma.py"),
+                 "--all", "--out", os.path.join(out, dialect), "--quiet",
+                 "--regex-dialect", dialect, "--portability-report", rep],
+                cwd=REPO, check=True, capture_output=True,
+            )
+            with open(rep) as fh:
+                reports[dialect] = json.load(fh)
+        blocked_pcre = {r["id"] for r in reports["pcre"]["blocked"]}
+        blocked_re2 = {r["id"] for r in reports["re2"]["blocked"]}
+        advertised = set(reports["pcre"]["would_unlock_with_re2_dialect"])
+        assert advertised == blocked_pcre - blocked_re2, (
+            "advertised unlock set != rules that actually stop being blocked: "
+            f"over-promised {sorted(advertised - (blocked_pcre - blocked_re2))}, "
+            f"missed {sorted((blocked_pcre - blocked_re2) - advertised)}"
+        )
+        assert not reports["re2"]["would_unlock_with_re2_dialect"]
+    finally:
+        shutil.rmtree(out, ignore_errors=True)
+
+
 def test_no_untagged_rule_fails_re2_compilation():
     """The load-bearing guarantee: an RE2 backend that honours the
     `atr.portability.re2-blocked` tag never hits a pattern it cannot compile.


### PR DESCRIPTION
A downstream RE2 engine (agentshield-ai/sigma-ai#13) ran the whole corpus through `generate-sigma.py` on the default `pcre` dialect, hit 15 rules its engine could not parse, and wrote them off as unrunnable. They were runnable. The only blocker was the escape spelling, which `--regex-dialect re2` rewrites.

The converter already warned about this per rule, but it says so once per affected rule in the middle of a 779-rule `--all` run, which is not where an operator is looking.

This adds an end-of-run line after the portability summary:

```
RE2 portability: 665/779 rules runnable on RE2 backends (85.4%); 114 tagged atr.portability.re2-blocked.
  20 of those 114 are blocked only by escape spelling: re-run with --regex-dialect re2 to make them runnable (685/779).
```

and a `would_unlock_with_re2_dialect` list in `--portability-report`. Nothing prints under `--regex-dialect re2`, where there is nothing left to advertise. The default dialect is unchanged: `pcre` is correct for PCRE and Python-`re` backends, and switching it would break them to fix a message.

The count is an identity, not an estimate. A rule qualifies only when escape spelling is its *only* blocker — a rule that also uses lookaround stays blocked in either dialect, and advertising it would promise an RE2 backend rules it still cannot run. Rules with a *measured* divergence are excluded even though their static blocker looks identical: their divergence warning is attached under the `re2` dialect only, so counting reasons alone over-promises by exactly that set (4 rules today). `test_would_unlock_matches_a_real_re2_dialect_run` converts the corpus in both dialects and asserts the advertised set equals the set that actually stops being blocked.

The `SPELLING_BLOCKER` string is now a named constant rather than an inline literal, because the summary decides what "would unlock" means by comparing against it — if the two spellings drift, the summary silently starts reporting zero and downstream consumers go on believing the corpus is less portable than it is.

Converter tests: 15/15 (4 new). No behaviour change to emitted Sigma: with `PYTHONHASHSEED` pinned, both dialects produce byte-identical output to before — only stderr and the report gain a field. The pin is needed because `logsource.category` is currently not reproducible across processes; that is a separate pre-existing bug, fixed in its own PR.
