### PR TITLE
fix(sigma): make logsource.category deterministic across runs

### DIFF
--- a/scripts/generate-sigma.py
+++ b/scripts/generate-sigma.py
@@ -523,7 +523,16 @@ def convert_rule(
     fields_used = [f for f in fields_used if f]
     category = None
     if fields_used:
-        primary = max(set(fields_used), key=fields_used.count)
+        # dict.fromkeys, not set(): `max` walks the container, so on a tie the
+        # winner is whichever element the iteration reaches first. A set of
+        # strings iterates in an order that depends on per-process hash
+        # randomisation, so a rule whose top two surfaces tie -- 13 rules in the
+        # corpus today, e.g. tool_args vs user_input -- would emit a different
+        # logsource.category on different runs of the same code against the same
+        # rule. That is phantom churn for any consumer diffing the export.
+        # Insertion-ordered dedupe breaks the tie by first appearance in the
+        # rule, which is both stable and the rule author's own ordering.
+        primary = max(dict.fromkeys(fields_used), key=fields_used.count)
         category = FIELD_TO_CATEGORY.get(primary)
         if category is None:
             category = "ai_agent_other"

--- a/scripts/test_generate_sigma.py
+++ b/scripts/test_generate_sigma.py
@@ -343,6 +343,35 @@ def test_would_unlock_matches_a_real_re2_dialect_run():
     finally:
         shutil.rmtree(out, ignore_errors=True)
 
+def test_logsource_category_is_stable_across_processes():
+    """The same rule must convert to the same logsource.category every run.
+
+    `max()` walks its container, so a tie is decided by iteration order. Over a
+    set of strings that order depends on per-process hash randomisation, which
+    made rules whose top two detection surfaces tie (tool_args vs user_input and
+    friends) emit a different category on different runs of identical code.
+    Downstream consumers diff these exports, so the churn looks like a rule
+    change that never happened.
+
+    Asserted across separate interpreters with different PYTHONHASHSEEDs,
+    because within one process the order is already fixed.
+    """
+    tied = "rules/prompt-injection/ATR-2026-00395-llm-special-token-boundary-injection.yaml"
+    if not os.path.exists(_abs(tied)):
+        print(f"   (skipped: {tied} no longer in corpus)", file=sys.stderr)
+        return
+    seen = set()
+    for seed in ("0", "1", "42", "12345"):
+        env = dict(os.environ, PYTHONHASHSEED=seed)
+        proc = subprocess.run(
+            [sys.executable, os.path.join(REPO, "scripts", "generate-sigma.py"),
+             "--rule", _abs(tied), "--stdout", "--quiet"],
+            cwd=REPO, check=True, capture_output=True, text=True, env=env,
+        )
+        doc = yaml.safe_load(proc.stdout)
+        seen.add(doc["logsource"].get("category"))
+    assert len(seen) == 1, f"logsource.category varies with PYTHONHASHSEED: {sorted(seen)}"
+
 
 def test_no_untagged_rule_fails_re2_compilation():
     """The load-bearing guarantee: an RE2 backend that honours the


### PR DESCRIPTION
`scripts/generate-sigma.py` derives `logsource.category` from the dominant detection field:

```python
primary = max(set(fields_used), key=fields_used.count)
```

`max()` walks its container, so on a tie the winner is whichever element the iteration reaches first — and a `set` of strings iterates in an order that depends on per-process hash randomisation. A rule whose top two detection surfaces tie therefore emits a different `logsource.category` on different runs of identical code against an identical corpus.

Thirteen rules tie in the corpus today (mostly `tool_args` vs `user_input`, plus `content` vs `tool_args`). Converting the whole corpus twice under different `PYTHONHASHSEED` values produced eleven differing files. For anyone diffing the Sigma export between pulls — which is exactly what a downstream detection pipeline does — that reads as a rule change that never happened, and it means the export is not reproducible.

`dict.fromkeys` preserves insertion order, so the tie now breaks by first appearance in the rule: stable, and the rule author's own ordering rather than an arbitrary one.

The test asserts across separate interpreters with four different `PYTHONHASHSEED` values, because within a single process the iteration order is already fixed and asserting there would test nothing. It fails on the unfixed code (`category varies with PYTHONHASHSEED: ['ai_agent_prompt', 'ai_agent_tool_response']`) and passes with the fix. Converting the corpus twice under different seeds now produces zero differing files.

Found while verifying that an unrelated change left the export byte-identical. It did not, and this was why.
