### PR TITLE
fix(adopters): drop OWASP AI Exchange — the PR was closed, not merged

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -81,14 +81,6 @@ Adopters whose adoption is itself a public-good interoperability artefact
 - **Since**: 2026-05-17
 - **Status**: in-review
 
-### OWASP AI Exchange
-- **Org**: OWASP Foundation (AI Exchange / AI Security & Privacy Guide)
-- **Type**: reference
-- **Integration**: Proposal to add Agent Threat Rules to the OWASP AI Exchange guidance as a referenceable agent-threat detection ruleset
-- **Evidence**: <https://github.com/OWASP/www-project-ai-security-and-privacy-guide/pull/181>
-- **Since**: 2026-06-16
-- **Status**: in-review
-
 ### FINOS Common Cloud Controls
 - **Org**: FINOS (Fintech Open Source Foundation, a Linux Foundation project)
 - **Type**: reference

--- a/data/adopters-verification.json
+++ b/data/adopters-verification.json
@@ -1,16 +1,9 @@
 {
   "$comment": "AUTO by scripts/verify-adopters.mjs — every ADOPTERS.md evidence link re-checked against GitHub. Do not edit by hand.",
-  "verified_at": "2026-08-03",
-  "total": 34,
+  "verified_at": "2026-08-04",
+  "total": 33,
   "ok": 33,
-  "drift": [
-    {
-      "name": "OWASP AI Exchange",
-      "declared": "in-review",
-      "observed": "closed",
-      "evidence": "https://github.com/OWASP/www-project-ai-security-and-privacy-guide/pull/181"
-    }
-  ],
+  "drift": [],
   "results": [
     {
       "name": "MISP / CIRCL",
@@ -47,15 +40,6 @@
       "kind": "pr",
       "observed": "open",
       "ok": true
-    },
-    {
-      "name": "OWASP AI Exchange",
-      "tier": "S",
-      "evidence": "https://github.com/OWASP/www-project-ai-security-and-privacy-guide/pull/181",
-      "declared": "in-review",
-      "kind": "pr",
-      "observed": "closed",
-      "ok": false
     },
     {
       "name": "FINOS Common Cloud Controls",


### PR DESCRIPTION
`OWASP/www-project-ai-security-and-privacy-guide#181` was closed unmerged on 2026-07-26. ADOPTERS.md still declared it `in-review`, which the weekly verifier has been failing on for three consecutive runs (2026-07-20, 2026-07-27, 2026-08-03) with `drift entries: 1`.

The close was a neutrality decision rather than a rejection of the work: the Exchange applies a fair-selection procedure before listing any tool in a category, and the maintainer forwarded the contribution to their red-teaming group for roadmap consideration. That is a real outcome and worth tracking, but it is not adoption, and ADOPTERS.md is the machine-readable record of projects that ship ATR — not of proposals that were made.

Removing the entry rather than inventing a status for it: the verifier's contract is `shipped` → merged and `in-review` → open, and a closed-unmerged PR is neither. Adding a third status to accommodate one entry would weaken the guarantee that every line in this file is externally verifiable, which is the reason the file exists.

`node scripts/verify-adopters.mjs` now reports 33/33 verified, 0 drift. (Run it with `GITHUB_TOKEN` set — unauthenticated runs hit the 60 req/h limit and report `api-403` as false drift.)
