### PR TITLE
fix(promotion): stop the stable gate writing an invalid maturity

### DIFF
--- a/scripts/corpus-owner-report.ts
+++ b/scripts/corpus-owner-report.ts
@@ -1,0 +1,158 @@
+#!/usr/bin/env node
+/**
+ * corpus-owner-report.ts — who actually owns the benign corpus.
+ *
+ * The corpus decides which rules may enter the enforce lane: a rule that matches
+ * anything in it is held back. So whoever contributed the most samples has the
+ * most say over what ATR is allowed to auto-block, and nobody has been counting.
+ *
+ * REPORT ONLY. This enforces nothing and changes no file. A concentration cap is
+ * worth having, but picking the threshold before seeing the distribution would
+ * cut real ecosystem samples on a guess.
+ *
+ * Usage:
+ *   npx tsx scripts/corpus-owner-report.ts            # table to stdout
+ *   npx tsx scripts/corpus-owner-report.ts --json     # machine-readable
+ */
+import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+/** The corpora that gate promotions, i.e. the ones with power over the enforce lane. */
+const CORPORA = [
+  "data/skill-benchmark/benign",
+  "data/benign-corpus-extended",
+  "data/benign-code",
+] as const;
+
+interface Sample {
+  readonly source: string;
+  readonly owner: string;
+}
+
+/**
+ * Best-effort owner for a sample. Sources carry different identifier shapes, so
+ * an unattributable sample is reported as such rather than bucketed into a
+ * plausible-looking owner -- an invented attribution would be worse than a gap.
+ */
+function ownerOf(record: Record<string, unknown>): string {
+  const candidates = ["source_id", "repo", "url", "id", "name", "package"];
+  for (const key of candidates) {
+    const raw = record[key];
+    if (typeof raw !== "string" || raw.length === 0) continue;
+
+    // A URL from somewhere other than a code host attributes to that host, not
+    // to a person: arxiv abstracts are all one publisher and should read that
+    // way rather than collapsing into a "http:" bucket.
+    const url = /^https?:\/\//.exec(raw) ? tryUrl(raw) : null;
+    if (url !== null) {
+      const host = url.hostname.replace(/^www\./, "");
+      if (host === "github.com") {
+        const [head] = url.pathname.replace(/^\//, "").split("/");
+        if (head !== undefined && head.length > 0) return head;
+      }
+      return host;
+    }
+
+    const [head] = raw.replace(/^@/, "").split("/");
+    if (head !== undefined && head.length > 0 && !head.includes(" ")) return head;
+  }
+  return "(unattributed)";
+}
+
+function tryUrl(raw: string): URL | null {
+  try {
+    return new URL(raw);
+  } catch {
+    return null;
+  }
+}
+
+function loadSamples(): Sample[] {
+  const out: Sample[] = [];
+  for (const rel of CORPORA) {
+    const base = join(REPO_ROOT, rel);
+    if (!existsSync(base)) continue;
+    const files = statSync(base).isDirectory()
+      ? readdirSync(base).map((e) => join(base, e))
+      : [base];
+    for (const file of files) {
+      if (!statSync(file).isFile()) continue;
+      const source = file.replace(`${REPO_ROOT}/`, "");
+      if (file.endsWith(".md")) {
+        // One manifest per file; the directory is the attribution we have.
+        out.push({ owner: "(skill-benchmark fixtures)", source });
+        continue;
+      }
+      if (!file.endsWith(".jsonl")) continue;
+      for (const line of readFileSync(file, "utf-8").split("\n")) {
+        const trimmed = line.trim();
+        if (!trimmed) continue;
+        try {
+          out.push({ owner: ownerOf(JSON.parse(trimmed) as Record<string, unknown>), source });
+        } catch {
+          out.push({ owner: "(unparseable)", source });
+        }
+      }
+    }
+  }
+  return out;
+}
+
+function tally(samples: readonly Sample[], key: (s: Sample) => string): Map<string, number> {
+  const counts = new Map<string, number>();
+  for (const s of samples) counts.set(key(s), (counts.get(key(s)) ?? 0) + 1);
+  return new Map([...counts].sort((a, b) => b[1] - a[1]));
+}
+
+function main(): void {
+  const samples = loadSamples();
+  const total = samples.length;
+  if (total === 0) {
+    console.error("[owner-report] no corpus samples found; is the repo root right?");
+    process.exit(1);
+  }
+
+  const byOwner = tally(samples, (s) => s.owner);
+  const bySource = tally(samples, (s) => s.source);
+
+  if (process.argv.includes("--json")) {
+    console.log(
+      JSON.stringify(
+        {
+          total,
+          owners: [...byOwner].map(([owner, n]) => ({ owner, n, pct: +(n * 100 / total).toFixed(2) })),
+          sources: [...bySource].map(([source, n]) => ({ source, n })),
+        },
+        null,
+        2,
+      ),
+    );
+    return;
+  }
+
+  console.log(`benign corpus that gates the enforce lane: ${total} samples\n`);
+  console.log("by source file");
+  for (const [source, n] of bySource) {
+    console.log(`  ${String(n).padStart(6)}  ${((n * 100) / total).toFixed(1).padStart(5)}%  ${source}`);
+  }
+  console.log("\nby owner (top 15)");
+  for (const [owner, n] of [...byOwner].slice(0, 15)) {
+    console.log(`  ${String(n).padStart(6)}  ${((n * 100) / total).toFixed(1).padStart(5)}%  ${owner}`);
+  }
+
+  const [top] = [...byOwner];
+  if (top !== undefined) {
+    const [owner, n] = top;
+    const pct = (n * 100) / total;
+    console.log(
+      `\nlargest single owner: ${owner} at ${pct.toFixed(1)}% of everything that can ` +
+        `hold a rule out of the enforce lane.`,
+    );
+  }
+  console.log("\nReport only; nothing was enforced or changed.");
+}
+
+main();

--- a/scripts/promote-to-stable.ts
+++ b/scripts/promote-to-stable.ts
@@ -38,6 +38,7 @@ import {
 import { join, resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { load as yamlLoad } from "js-yaml";
+import { MATURITIES, type Maturity } from "../src/quality/rule-contract.js";
 import { ATREngine } from "../src/engine.js";
 import type { AgentEvent } from "../src/types.js";
 
@@ -169,12 +170,26 @@ function loadTestCandidates(): Candidate[] {
   return out;
 }
 
-/** Bump `maturity: test` -> `maturity: production` in a rule file (single field). */
+/**
+ * The tier this gate promotes into. Typed as `Maturity` on purpose: this script
+ * previously wrote `production`, which is not a member, so `normalizeMaturity`
+ * mapped every "promoted" rule to `experimental` and dropped it out of both the
+ * enforce and the alert lane. A promotion gate that silently demotes is worse
+ * than no gate, and only the type binding makes that impossible to reintroduce.
+ */
+const PROMOTION_TARGET: Maturity = "stable";
+
+/** Bump `maturity: test` -> the promotion target in a rule file (single field). */
 function promoteFile(file: string): boolean {
+  if (!MATURITIES.includes(PROMOTION_TARGET)) {
+    throw new Error(
+      `promotion target ${PROMOTION_TARGET} is not a valid maturity; refusing to write`,
+    );
+  }
   const raw = readFileSync(file, "utf-8");
   const next = raw.replace(
     /^(\s*maturity:\s*)["']?test["']?\s*$/m,
-    "$1production",
+    `$1${PROMOTION_TARGET}`,
   );
   if (next === raw) return false;
   writeFileSync(file, next);
@@ -239,7 +254,7 @@ async function main(): Promise<void> {
       `\n[stable-gate] dry-run. ${clean.length} rule(s) are FP-clean on this corpus.` +
         (corpusTooSmall
           ? " Not production-eligible until validated on the wild corpus."
-          : " Re-run with --write to promote them to maturity:production."),
+          : " Re-run with --write to promote them to maturity:stable."),
     );
     return;
   }
@@ -255,7 +270,7 @@ async function main(): Promise<void> {
   for (const c of clean) {
     if (promoteFile(c.file)) promoted++;
   }
-  console.log(`\n[stable-gate] promoted ${promoted} rule(s) test -> production.`);
+  console.log(`\n[stable-gate] promoted ${promoted} rule(s) test -> stable.`);
 }
 
 main().catch((err: unknown) => {


### PR DESCRIPTION
promote-to-stable.ts rewrote `maturity: test` to `maturity: production`. That is not a member of MATURITIES (draft, experimental, test, stable, deprecated), and normalizeMaturity maps anything outside the set to `experimental` — so every rule this gate promoted would have been read back as experimental and dropped out of both the enforce and the alert lane. A promotion gate that silently demotes is worse than no gate.

Nothing is damaged. No rule on main carries `maturity: production`; the workflow is workflow_dispatch only and refuses to write below --min-corpus 20000, which the public 5.2K corpus never reaches, so the write path has never completed. It is a landmine rather than a fire — the documented intended use is to feed it the private wild corpus, and that run would have demoted everything it touched.

The target is now a `Maturity`-typed constant with a runtime membership check, so the same mistake cannot come back through an edited string literal.

Also adds `scripts/corpus-owner-report.ts`, report-only. The benign corpus decides which rules may enter the enforce lane, so whoever contributes most of it has the most say over what ATR may auto-block — and nobody was counting. Current distribution:

| owner | samples | share |
|---|---|---|
| one GitHub account | 1,316 | 24.8% |
| arxiv.org | 1,163 | 21.9% |
| skill-benchmark fixtures | 431 | 8.1% |

It enforces nothing. Choosing a concentration cap before seeing the distribution would cut real ecosystem samples on a guess.

Test plan

- [x] `production` confirmed absent from MATURITIES; `stable` confirmed present
- [x] No rule on main carries an invalid maturity
- [x] Owner report runs against the real corpus and totals 5,317
- [ ] CI green