### PR TITLE
feat(compliance): add CEN-CENELEC JTC 21 allowlist, map 14 stable rules to prEN 18282

### DIFF
--- a/data/compliance-frameworks/cen_jtc21.json
+++ b/data/compliance-frameworks/cen_jtc21.json
@@ -1,0 +1,23 @@
+{
+  "framework": "CEN-CENELEC JTC 21 — harmonised standards supporting the EU AI Act",
+  "fullName": "CEN-CENELEC Joint Technical Committee 21 (Artificial Intelligence), standardisation request M/593",
+  "idField": "standard",
+  "idType": "string",
+  "source": "https://jtc21.eu/working-groups/",
+  "note": "The layer between an EU AI Act article and an executable check. An ATR rule cites the standard whose requirement it produces runtime detection evidence for; cite the corresponding article via the eu_ai_act allowlist as well. THREE LIMITS, all deliberate. (1) NOT harmonised yet: as of 2026-08 no JTC 21 deliverable has been cited in the Official Journal, including the published EN 18286:2026 — citing one here does NOT create a presumption of conformity under Article 40, and no ATR artefact may claim otherwise. (2) Standard-level identifiers only, on purpose: prEN drafts are paywalled, so this allowlist admits only designations verifiable in public standards registries. Clause- and outcome-level identifiers (e.g. an outcome category within prEN 18282) are deliberately NOT offered until the published EN can be checked — a rule may describe which outcome it serves in its `context` prose, where it reads as the rule author's assessment rather than as a machine-readable identifier downstream tools may treat as canonical. (3) ATR rules are detection evidence, NOT a compliance guarantee — same boundary as the eu_ai_act allowlist. Add identifiers by PR as standards publish and as rules genuinely map.",
+  "strengthValues": [
+    "primary",
+    "secondary",
+    "partial"
+  ],
+  "valids": {
+    "EN 18286": "Quality management system for EU AI Act regulatory purposes — supports Article 17. Published 2026-07 (first JTC 21 deliverable to reach publication); not yet OJ-cited.",
+    "prEN 18228": "Artificial intelligence — Risk management — supports Article 9. Public enquiry closed 2026-07-30.",
+    "prEN 18282": "Artificial intelligence — Cybersecurity specifications for AI systems — supports Article 15. Public enquiry closed 2026-07-30.",
+    "prEN 18229-1": "AI trustworthiness framework — Part 1: Logging — supports Article 12 (record-keeping). Public enquiry closes 2026-08-20.",
+    "prEN 18229-2": "AI trustworthiness framework — Part 2: Transparency — supports Article 13. Part name from the JTC 21 WG4 project listing; registered title not confirmed.",
+    "prEN 18229-3": "AI trustworthiness framework — Part 3: Human oversight — supports Article 14. In CEN Enquiry; ballot dates not published. Part name from the WG4 project listing; registered title not confirmed.",
+    "prEN 18229-4": "AI trustworthiness framework — Part 4: Accuracy — supports Article 15. Part name from the WG4 project listing; registered title not confirmed.",
+    "prEN 18229-5": "AI trustworthiness framework — Part 5: Robustness — supports Article 15. Part name from the WG4 project listing; registered title not confirmed."
+  }
+}

--- a/rules/context-exfiltration/ATR-2026-00702-ipi-credential-exfil-via-agent-action.yaml
+++ b/rules/context-exfiltration/ATR-2026-00702-ipi-credential-exfil-via-agent-action.yaml
@@ -54,6 +54,11 @@ compliance:
       context: "Clause 8.1: control of externally-provided processes; this rule detects credential exfil directives in consumed external content."
       strength: primary
 
+  cen_jtc21:
+    - standard: "prEN 18282"
+      context: "Detection evidence for the case where the agent becomes the exfiltration actor, using its own authorised tool access to locate and transmit credentials. Each tool call is individually permitted; only the origin of the instruction is adversarial."
+      strength: primary
+
 tags:
   category: context-exfiltration
   subcategory: credential-exfil-indirect

--- a/rules/context-exfiltration/ATR-2026-00706-ipi-physical-biometric-exfil.yaml
+++ b/rules/context-exfiltration/ATR-2026-00706-ipi-physical-biometric-exfil.yaml
@@ -53,6 +53,11 @@ compliance:
       context: "ISO/IEC 42001 Clause 8.1: control of external processes containing deepfake/biometric exfil directives."
       strength: primary
 
+  cen_jtc21:
+    - standard: "prEN 18282"
+      context: "Detection evidence for biometric and physical-media exfiltration, including deepfake synthesis from recorded voice samples. Distinct from document exfiltration because the harmed subject is the person rather than the file."
+      strength: primary
+
 tags:
   category: context-exfiltration
   subcategory: physical-biometric-exfil

--- a/rules/context-exfiltration/ATR-2026-01453-markdown-image-base64-exfil-carrier.yaml
+++ b/rules/context-exfiltration/ATR-2026-01453-markdown-image-base64-exfil-carrier.yaml
@@ -65,6 +65,11 @@ compliance:
       context: "ISO/IEC 42001 Clause 6.2 (AI objectives and planning) requires treatment of this documented markdown exfil pattern."
       strength: secondary
 
+  cen_jtc21:
+    - standard: "prEN 18282"
+      context: "Detection evidence for exfiltration that occurs as a rendering side effect rather than an agent-initiated request, via markdown image URLs carrying extracted data in a base64 query parameter. Egress monitoring alone does not observe this path."
+      strength: primary
+
 tags:
   category: context-exfiltration
   subcategory: markdown-url-injection

--- a/rules/context-exfiltration/ATR-2026-01457-sysprompt-completion-clone-attack.yaml
+++ b/rules/context-exfiltration/ATR-2026-01457-sysprompt-completion-clone-attack.yaml
@@ -60,6 +60,11 @@ compliance:
       context: "ISO/IEC 42001 Clause 6.2 requires treatment of clone/completion attack patterns for system prompt extraction."
       strength: secondary
 
+  cen_jtc21:
+    - standard: "prEN 18282"
+      context: "Detection evidence for a confidentiality attack on operator-supplied system instructions, framed as authoring or configuration assistance so that no extraction verb appears in the request. Article 15(5) names confidentiality attacks explicitly."
+      strength: primary
+
 tags:
   category: context-exfiltration
   subcategory: system-prompt-extraction

--- a/rules/context-exfiltration/ATR-2026-01459-variable-clone-sysprompt-technique.yaml
+++ b/rules/context-exfiltration/ATR-2026-01459-variable-clone-sysprompt-technique.yaml
@@ -53,6 +53,11 @@ compliance:
       context: "ISO/IEC 42001 Clause 8.1 (operational planning and control) is operationalised by detecting variable-clone system prompt extraction."
       strength: primary
 
+  cen_jtc21:
+    - standard: "prEN 18282"
+      context: "Detection evidence for an evasion of detection: the variable-clone technique reaches the same disclosure through pseudo-variable assignment syntax rather than an explicit request. This is the property an outcome-based detection requirement most needs demonstrated — that filter-bypass variants are themselves in scope."
+      strength: primary
+
 tags:
   category: context-exfiltration
   subcategory: system-prompt-extraction

--- a/rules/excessive-autonomy/ATR-2026-00709-ipi-disable-auth-mfa.yaml
+++ b/rules/excessive-autonomy/ATR-2026-00709-ipi-disable-auth-mfa.yaml
@@ -48,6 +48,11 @@ compliance:
       context: "ISO/IEC 42001 Clause 8.1: control of externally-provided processes containing MFA/auth disable directives."
       strength: primary
 
+  cen_jtc21:
+    - standard: "prEN 18282"
+      context: "Detection evidence for attacks whose target is the security control layer itself — disabling MFA or account protection. Detection matters most here because a successful attack removes the controls that would otherwise produce evidence of what follows."
+      strength: primary
+
 tags:
   category: excessive-autonomy
   subcategory: disable-auth-mfa

--- a/rules/excessive-autonomy/ATR-2026-00711-ipi-system-sabotage-destructive-command.yaml
+++ b/rules/excessive-autonomy/ATR-2026-00711-ipi-system-sabotage-destructive-command.yaml
@@ -49,6 +49,11 @@ compliance:
       context: "ISO/IEC 42001 Clause 8.1: control of externally-provided processes containing system sabotage commands."
       strength: primary
 
+  cen_jtc21:
+    - standard: "prEN 18282"
+      context: "Detection evidence for sabotage executed through a computer-use agent's shell access, where the destructive command is well-formed and the agent stays within its granted permissions."
+      strength: primary
+
 tags:
   category: excessive-autonomy
   subcategory: system-sabotage-destructive

--- a/rules/excessive-autonomy/ATR-2026-00722-ipi-account-manipulation-emergency-pretext.yaml
+++ b/rules/excessive-autonomy/ATR-2026-00722-ipi-account-manipulation-emergency-pretext.yaml
@@ -50,6 +50,11 @@ compliance:
       context: "ISO/IEC 42001 Clause 8.1: control of externally-provided processes containing emergency pretext manipulation directives."
       strength: primary
 
+  cen_jtc21:
+    - standard: "prEN 18282"
+      context: "Detection evidence for fabricated-urgency pretexts that drive physical-world consequences such as emergency dispatch. Included because an AI-specific attack surface can terminate outside the information system."
+      strength: primary
+
 tags:
   category: excessive-autonomy
   subcategory: emergency-pretext-manipulation

--- a/rules/model-abuse/ATR-2026-00517-model-extraction-distillation.yaml
+++ b/rules/model-abuse/ATR-2026-00517-model-extraction-distillation.yaml
@@ -67,6 +67,11 @@ compliance:
       context: "ISO/IEC 42001 Clause 8.1 (operational planning and control, including control of externally provided processes) is operationalised by this rule's detection of the model-abuse / harmful-content elicitation attempt (Model Extraction / Distillation Attack via Systematic API Probing)."
       strength: primary
 
+  cen_jtc21:
+    - standard: "prEN 18282"
+      context: "Detection evidence for a model-confidentiality attack by systematic bulk probing intended to yield a functional equivalent. Detection is necessarily behavioural: no single query is anomalous, only the extraction pattern across them."
+      strength: primary
+
 tags:
   category: model-abuse
   subcategory: model-distillation

--- a/rules/prompt-injection/ATR-2026-00511-mcp-web-context-poisoning.yaml
+++ b/rules/prompt-injection/ATR-2026-00511-mcp-web-context-poisoning.yaml
@@ -68,6 +68,11 @@ compliance:
       context: "ISO/IEC 42001 Clause 8.1 (operational planning and control, including control of externally provided processes) is operationalised by this rule's detection of the prompt-injection attempt (MCP Web-Fetch Context Poisoning via Embedded Agent Instructions)."
       strength: primary
 
+  cen_jtc21:
+    - standard: "prEN 18282"
+      context: "prEN 18282 covers the detection side of Article 15 cybersecurity; this rule supplies evidence at the retrieval boundary, where content fetched by an MCP tool re-enters the agent as trusted context. The attack works only because a fetch result is handled as data, so the detection point is the result itself rather than the prompt."
+      strength: primary
+
 tags:
   category: prompt-injection
   subcategory: mcp-context-poisoning

--- a/rules/prompt-injection/ATR-2026-00700-structured-data-payload-injection.yaml
+++ b/rules/prompt-injection/ATR-2026-00700-structured-data-payload-injection.yaml
@@ -62,6 +62,11 @@ compliance:
       context: "ISO/IEC 42001 Clause 8.1 requires control of externally-provided processes; this rule detects attacker-controlled content in consumed structured data."
       strength: primary
 
+  cen_jtc21:
+    - standard: "prEN 18282"
+      context: "Detection evidence for payloads concealed inside structured data an agent consumes as records — reviews, notes, repository metadata. This addresses the prEN 18282 case where no prompt boundary is crossed at all, so boundary-based controls see nothing."
+      strength: primary
+
 tags:
   category: prompt-injection
   subcategory: indirect-structured-data

--- a/rules/tool-poisoning/ATR-2026-00714-tool-camouflage-forced-tool-call.yaml
+++ b/rules/tool-poisoning/ATR-2026-00714-tool-camouflage-forced-tool-call.yaml
@@ -48,6 +48,11 @@ compliance:
       context: "ISO/IEC 42001 Clause 8.1: control of externally-provided processes containing forced tool invocation directives."
       strength: primary
 
+  cen_jtc21:
+    - standard: "prEN 18282"
+      context: "Detection evidence for attacks on the agent's tool-selection logic rather than on its instructions: content masquerading as a completed task result while forcing a specific downstream invocation."
+      strength: primary
+
 tags:
   category: tool-poisoning
   subcategory: tool-camouflage-forced-call

--- a/rules/tool-poisoning/ATR-2026-00715-tool-knowledge-hijack-identity-injection.yaml
+++ b/rules/tool-poisoning/ATR-2026-00715-tool-knowledge-hijack-identity-injection.yaml
@@ -48,6 +48,11 @@ compliance:
       context: "ISO/IEC 42001 Clause 8.1: control of externally-provided processes containing tool argument injection."
       strength: primary
 
+  cen_jtc21:
+    - standard: "prEN 18282"
+      context: "Detection evidence for adversarial content that supplies both a false identity claim and exact arguments for a privileged tool call, so the authorisation check passes on well-formed input."
+      strength: primary
+
 tags:
   category: tool-poisoning
   subcategory: tool-knowledge-hijack

--- a/rules/tool-poisoning/ATR-2026-00720-tool-misuse-privilege-escalation-social.yaml
+++ b/rules/tool-poisoning/ATR-2026-00720-tool-misuse-privilege-escalation-social.yaml
@@ -46,6 +46,11 @@ compliance:
       context: "ISO/IEC 42001 Clause 8.1: control of externally-provided social engineering attack patterns in access management."
       strength: primary
 
+  cen_jtc21:
+    - standard: "prEN 18282"
+      context: "Detection evidence for user-originated social engineering of an agent holding access-control tools. Distinct from the indirect-injection cases because the adversarial instruction arrives through the legitimate operator channel."
+      strength: primary
+
 tags:
   category: tool-poisoning
   subcategory: privilege-escalation-social


### PR DESCRIPTION
ATR rules already cite EU AI Act articles. The layer between an article and an executable check — the harmonised standard that operationalises it — had no allowlist, so no rule could cite it. This adds that layer and demonstrates it on a first batch.

## What is here

- `data/compliance-frameworks/cen_jtc21.json` — allowlist for the JTC 21 deliverables under standardisation request M/593
- 14 stable rules mapped to `prEN 18282` (AI cybersecurity, supporting Article 15)

## Standard-level identifiers only, on purpose

prEN drafts are paywalled. The allowlist therefore admits only designations verifiable in public standards registries. Outcome- and clause-level identifiers are deliberately not offered until the published EN can be checked.

A rule describes which outcome it serves in its `context` prose, where it reads as the author's assessment rather than as a machine-readable identifier that downstream consumers might treat as canonical. This matters because `validate-compliance.ts` can only check an identifier against the allowlist in this repo — if the allowlist itself asserted unverifiable structure, the check would be circular.

## Citation boundaries

Citing a JTC 21 deliverable here does **not** create a presumption of conformity. As of 2026-08 none has been cited in the Official Journal, including the published EN 18286:2026. ATR rules remain detection evidence, not a compliance guarantee — the same boundary the `eu_ai_act` allowlist already states.

## Why 14 and not 780

The batch was chosen for distinct detection modes, not count — the point is whether the mapping method holds up, and a reviewer can read 14 rationales. Every one of the 780 rules with an Article 15 primary mapping is a candidate for a later batch once the method is settled.

Spans all five categories that had stable Article 15 primary mappings: prompt-injection (2), context-exfiltration (5), excessive-autonomy (3), tool-poisoning (3), model-abuse (1).

The one worth reading first is `ATR-2026-01459` — it detects an evasion of detection, which is the property an outcome-based detection requirement most needs demonstrated.

## Validation

- `validate-compliance.ts`: PASS, 0 violations across 780 mapped rules
- rule schema: 780 passed, 0 failed
- additive only: 70 insertions in rule files, no deletions, no rule logic touched

## Noted, not addressed here

The validator reports three frameworks used in rules with no allowlist, so they are not validated: `nist_csf` (6 rules), `etsi_ts_104223` (6 rules), `safe_mcp` (2 rules). Out of scope for this PR.