### PR TITLE
chore(npm): drop hardcoded rule count and stale benchmark from the package description

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "3.5.11",
   "mcpName": "io.github.Agent-Threat-Rule/agent-threat-rules",
   "type": "module",
-  "description": "Open detection standard -- like Sigma, but for AI agents. 751 rules for prompt injection, tool poisoning, context exfiltration, and MCP attacks. Shipped in Cisco AI Defense. 97.2% recall on NVIDIA garak.",
+  "description": "Open detection standard -- like Sigma, but for AI agents. Executable rules for prompt injection, tool poisoning, context exfiltration, and MCP attacks. Shipped in Cisco AI Defense. MIT-licensed.",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "bin": {


### PR DESCRIPTION
The published npm description reads:

> "Open detection standard -- like Sigma, but for AI agents. **751 rules** for prompt injection, tool poisoning, context exfiltration, and MCP attacks. Shipped in Cisco AI Defense. **97.2% recall on NVIDIA garak**."

Both numbers are wrong on the registry right now. The corpus is at 780 on `main` (770 effective), and garak was re-measured to 91.5% on 2026-07-28.

Neither can be kept correct by updating it. The rule count moves most days via auto-crystallize and ecosystem PRs, while the registry description only refreshes on publish — so any number written here is stale between releases by construction. The benchmark has the same problem plus a worse failure mode: a recall figure that drifts upward in a reader's memory while the measured value goes down.

This removes both rather than refreshing them. `data/stats.json` and the README badges stay the place where a current number lives, and they move with the corpus.

Note: the registry listing only changes on the next publish, so this PR fixes the source, not the live description.
