### PR TITLE
feat(compliance): map four rules to EU AI Act Article 50 (transparency)

### DIFF
--- a/rules/context-exfiltration/ATR-2026-00291-biometric-surveillance-personal-data-request.yaml
+++ b/rules/context-exfiltration/ATR-2026-00291-biometric-surveillance-personal-data-request.yaml
@@ -57,6 +57,9 @@ compliance:
     - article: "10"
       context: "Article 10 (data and data governance) requires control over the data an AI system processes; this rule provides detection evidence for the context-exfiltration attempt (Biometric Surveillance — Personal Biometric Data Request for Named Individual) affecting that data."
       strength: secondary
+    - article: "50"
+      context: "Article 50(3) places a notification duty on deployers of biometric categorisation and emotion recognition systems toward the persons exposed to them. This rule detects requests to identify a named individual from biometric traits, where that individual is by construction not informed. Secondary because the article's duty falls on the deploying operator, while this rule observes the request."
+      strength: secondary
 tags:
   category: context-exfiltration
   subcategory: biometric-surveillance-personal

--- a/rules/context-exfiltration/ATR-2026-00706-ipi-physical-biometric-exfil.yaml
+++ b/rules/context-exfiltration/ATR-2026-00706-ipi-physical-biometric-exfil.yaml
@@ -48,6 +48,9 @@ compliance:
     - article: "15"
       context: "Article 15 robustness: detection of deepfake generation and biometric exfil instructions in AI systems."
       strength: primary
+    - article: "50"
+      context: "Article 50(4) deepfake disclosure duty: the exfiltration this rule detects is instrumental to synthesising audio in a real person's voice. Secondary because the rule's primary object is the exfiltration of the biometric sample rather than the downstream synthetic-media disclosure failure."
+      strength: secondary
   iso_42001:
     - clause: "8.1"
       context: "ISO/IEC 42001 Clause 8.1: control of external processes containing deepfake/biometric exfil directives."

--- a/rules/model-abuse/ATR-2026-01841-deepfake-disinformation.yaml
+++ b/rules/model-abuse/ATR-2026-01841-deepfake-disinformation.yaml
@@ -29,6 +29,9 @@ compliance:
     - article: "9"
       context: "Harmful-task facilitation is a mandatory Article 9 risk category requiring detection and treatment."
       strength: secondary
+    - article: "50"
+      context: "Article 50(4) requires deployers who generate or manipulate deepfake content to disclose that it is artificially generated. This rule detects the instruction to produce a synthetic likeness of a real person and publish it as authentic — the disclosure duty and the attack objective are directly opposed."
+      strength: primary
   nist_ai_rmf:
     - subcategory: "MP.5.1"
       context: "This AgentHarm harmful-task request is an adversarial input that MP.5.1 requires to be identified and tracked."

--- a/rules/prompt-injection/ATR-2026-00238-identity-replacement.yaml
+++ b/rules/prompt-injection/ATR-2026-00238-identity-replacement.yaml
@@ -53,6 +53,9 @@ compliance:
     - article: "14"
       context: "Article 14 (human oversight) requires high-risk AI systems to remain subject to effective human oversight; this rule provides detection evidence where the prompt-injection attempt (AI Identity Denial and Persona Replacement Attack) would bypass or undermine that oversight."
       strength: secondary
+    - article: "50"
+      context: "Article 50(1) requires an AI system interacting with a natural person to inform that person they are dealing with an AI. This attack's stated objective is the inverse: it instructs the model to deny its AI nature, adopt a human identity, and conceal that nature from users. Detecting it is detecting an attempt to defeat the disclosure duty itself."
+      strength: primary
 tags:
   category: prompt-injection
   subcategory: identity-replacement


### PR DESCRIPTION
Article 50 obligations became applicable on **2026-08-02**. The corpus had a single Article 50 mapping before this change. Four more rules genuinely qualify.

| Article | Rule | Strength |
|---|---|---|
| 50(1) inform the person they are interacting with an AI | `ATR-2026-00238` AI Identity Denial and Persona Replacement | primary |
| 50(3) inform persons exposed to biometric categorisation | `ATR-2026-00291` Biometric Surveillance — Named Individual | secondary |
| 50(4) disclose deepfake content | `ATR-2026-01841` Deepfake of Real Person for Disinformation | primary |
| 50(4) disclose deepfake content | `ATR-2026-00706` Physical / Biometric Media Exfiltration | secondary |

## Why only four

Article 50 is a disclosure duty; ATR is a detection layer. The overlap is narrow by construction, and padding it would weaken every other mapping in the corpus.

The two `primary` mappings share a property worth naming: **the attack objective is the transparency duty inverted.** `ATR-2026-00238` instructs a model to deny being an AI and conceal that from users — precisely what 50(1) requires it to disclose. `ATR-2026-01841` instructs generation of a synthetic likeness of a real person published as authentic — precisely what 50(4) requires disclosed. Detection evidence is meaningful here because the rule observes an attempt to defeat the obligation, not merely an adjacent risk.

The two `secondary` mappings are honest about their distance: 50(3) places its duty on the deploying operator while `ATR-2026-00291` observes the request, and `ATR-2026-00706`'s primary object is exfiltration of the biometric sample rather than the downstream disclosure failure.

## Deliberately not mapped

Recorded so the next batch does not re-litigate them:

- `ATR-2026-00338` (PersonGPT hash-prefix) surfaced in an identity search but is a restriction-bypass persona, not identity concealment
- `ATR-2026-00245` (malicious persona) and `ATR-2026-00371` (political bias manipulation) are manipulation, not transparency

## Coverage gap left open

**No rule maps to 50(2)** — machine-readable marking of synthetic output. Nothing in the corpus detects watermark or provenance-metadata stripping. That is a rule-authoring gap rather than a mapping gap, and is out of scope for this PR.

## Validation

- `validate-compliance.ts`: PASS, 0 violations across 780 mapped rules
- rule schema: 780 passed, 0 failed
- additive only: 12 insertions, no deletions, no rule logic touched
- merges cleanly with #410 (verified with `git merge-tree`)