### PR TITLE
fix(harness): route every FP harness through the canonical event shapes

### DIFF
--- a/scripts/audit-draft-revival.ts
+++ b/scripts/audit-draft-revival.ts
@@ -18,10 +18,13 @@
  *   5. classify: REVIVE / TESTCASE-FAIL / FP-DIRTY / NO-TESTCASES
  *
  * Measurement fidelity notes (both are places this repo has been burned before):
- *   - The benign event shape is copied verbatim from scripts/gate-promotion-fp.ts
- *     (`asTextEvent` + the same three corpora + evaluate() ∪ scanSkill()). The same
- *     corpus scored with a different event shape yields wildly different FP counts,
- *     so do not "simplify" the event here.
+ *   - The benign event shape comes from scripts/lib/corpus-event.ts (`matchedRuleIds`
+ *     + the same three corpora), the single module every FP harness shares. It used
+ *     to be a verbatim COPY of gate-promotion-fp.ts's builder, and copying is how the
+ *     defect spread: when that gate moved to the canonical shape set, this copy did
+ *     not, and kept scoring rules on a narrower presentation than production. The
+ *     same corpus scored with a different event shape yields wildly different FP
+ *     counts, so import the shared module — never mirror it.
  *   - Measuring a draft rule WITHOUT flipping it returns 0 FP and 0 test-case hits
  *     for every rule — the engine skipped it. That zero is an artefact, not a
  *     result. The flip is what makes the numbers real; `--no-flip` exists only to
@@ -54,6 +57,7 @@ import { fileURLToPath } from "node:url";
 import yaml from "js-yaml";
 import { ATREngine } from "../src/engine.js";
 import type { ATRRule, AgentEvent } from "../src/types.js";
+import { matchedRuleIds } from "./lib/corpus-event.js";
 
 const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const RULES_DIR = join(REPO_ROOT, "rules");
@@ -233,26 +237,16 @@ async function buildEngine(rules: readonly ATRRule[]): Promise<ATREngine> {
   return engine;
 }
 
-/** Event shape copied verbatim from scripts/gate-promotion-fp.ts. */
-function asTextEvent(content: string): AgentEvent {
-  return {
-    type: "mcp_exchange",
-    timestamp: new Date().toISOString(),
-    content,
-    fields: {
-      tool_name: "corpus-sample",
-      tool_input: content,
-      tool_response: content,
-      user_input: content,
-    },
-  };
-}
-
+/**
+ * Every rule id a sample matches, via the canonical shape set.
+ *
+ * This used to be a copy of gate-promotion-fp.ts's event builder. Copying is how
+ * the defect spread: when that gate moved to the canonical shapes, the copies did
+ * not, and each one silently kept scoring rules on a presentation narrower than
+ * production. Import the shared module rather than mirroring it.
+ */
 function matchedIds(engine: ATREngine, content: string): ReadonlySet<string> {
-  const ids = new Set<string>();
-  for (const m of engine.evaluate(asTextEvent(content))) ids.add(m.rule.id);
-  for (const m of engine.scanSkill(content)) ids.add(m.rule.id);
-  return ids;
+  return matchedRuleIds(engine, content);
 }
 
 // ---------------------------------------------------------------------------

--- a/scripts/check-rules-safety.ts
+++ b/scripts/check-rules-safety.ts
@@ -56,7 +56,7 @@ import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
 import { load as yamlLoad } from "js-yaml";
 import { ATREngine } from "../src/engine.js";
-import type { AgentEvent } from "../src/types.js";
+import { matchedRuleIds } from "./lib/corpus-event.js";
 import { lintRuleDoc } from "./lint-rule-patterns.js";
 
 const MAX_NEW_PER_PR = Number(process.env.MAX_NEW_PER_PR ?? 10);
@@ -353,31 +353,19 @@ function checkMetadata(
   return null;
 }
 
-/** Build a single AgentEvent from arbitrary text content. */
-function asTextEvent(content: string): AgentEvent {
-  return {
-    type: "mcp_exchange",
-    timestamp: new Date().toISOString(),
-    content,
-    fields: {
-      tool_name: "corpus-sample",
-      tool_input: content,
-      tool_response: content,
-      user_input: content,
-    },
-  };
-}
-
 /**
- * Run an ATR engine over a sample and return the set of rule IDs that
- * matched (across both event evaluation and skill scanning, to mirror
- * the production engine's two paths).
+ * Run an ATR engine over a sample and return the set of rule IDs that matched.
+ *
+ * Delegates to the canonical shape set in scripts/lib/corpus-event.ts. This gate
+ * used to hand-roll a single mcp_exchange event with four fields, which left
+ * `tool_args` (and every other field the production hook actually populates)
+ * unresolvable — conditions keyed on it could not fire, so rules built on them
+ * were scored FP-clean without ever being read. A rule must not earn its
+ * detection credit on a wider presentation than the one it pays its false
+ * positives on.
  */
-function matchAllRuleIds(engine: ATREngine, content: string): Set<string> {
-  const matched = new Set<string>();
-  for (const m of engine.evaluate(asTextEvent(content))) matched.add(m.rule.id);
-  for (const m of engine.scanSkill(content)) matched.add(m.rule.id);
-  return matched;
+function matchAllRuleIds(engine: ATREngine, content: string): ReadonlySet<string> {
+  return matchedRuleIds(engine, content);
 }
 
 /**

--- a/scripts/lib/corpus-event.ts
+++ b/scripts/lib/corpus-event.ts
@@ -273,12 +273,50 @@ export function shapeNames(): readonly string[] {
 }
 
 // ---------------------------------------------------------------------------
+// The one way a harness turns a sample into matched rule ids
+// ---------------------------------------------------------------------------
+
+/**
+ * The slice of ATREngine a corpus scan needs. Structural on purpose: this module
+ * stays free of a concrete engine import so the shape set can be reasoned about
+ * (and unit-tested) without loading the engine.
+ */
+export interface ScannableEngine {
+  evaluate(event: AgentEvent): readonly { readonly rule: { readonly id: string } }[];
+  scanSkill(text: string): readonly { readonly rule: { readonly id: string } }[];
+}
+
+/**
+ * Every rule id a sample matches: the canonical shape set PLUS scanSkill().
+ *
+ * Both halves are mandatory. scanSkill() is a separate engine entry point (the
+ * `pga scan` path), not an event shape, and rules with `scan_target: skill`
+ * reach production through it alone — a harness that only calls evaluate() would
+ * score them clean without reading them.
+ *
+ * Counted PER SAMPLE, not per shape: a document that trips a rule on three
+ * shapes is one false positive, not three. Every harness that measures FP, TP or
+ * coverage must go through this function, so a rule can never earn its detection
+ * credit on a wider presentation than the one it pays its false positives on.
+ */
+export function matchedRuleIds(engine: ScannableEngine, text: string): ReadonlySet<string> {
+  const matched = new Set<string>();
+  for (const shape of corpusShapes(text)) {
+    for (const m of engine.evaluate(shape.event)) matched.add(m.rule.id);
+  }
+  for (const m of engine.scanSkill(text)) matched.add(m.rule.id);
+  return matched;
+}
+
+// ---------------------------------------------------------------------------
 // Coverage: which of a rule's conditions this harness can actually measure
 // ---------------------------------------------------------------------------
 
 /** Minimal view of a rule — avoids importing the full ATRRule type surface. */
 export interface RuleLike {
   readonly id: string;
+  readonly status?: string;
+  readonly maturity?: string;
   readonly detection?: {
     readonly method?: string;
     readonly condition?: string;
@@ -332,6 +370,95 @@ export function fieldCoverage(rules: readonly RuleLike[]): readonly FieldCoverag
         ruleId: rule.id,
         unmeasured: Object.freeze(unmeasured),
         zeroMeasurement: methodBlind || measurable === 0 || (!anyOf && unmeasured.length > 0),
+      }),
+    );
+  }
+  return Object.freeze(out);
+}
+
+// ---------------------------------------------------------------------------
+// Coverage, second axis: a rule the engine refuses to run at all
+// ---------------------------------------------------------------------------
+
+/**
+ * Statuses src/engine.ts drops BEFORE the lane gate, on both evaluation paths:
+ *
+ *     if (rule.status === 'deprecated' || rule.status === 'draft') continue;
+ *     if (!this.passesLane(rule)) continue;
+ *
+ * The order is the whole problem. `maturity` decides the lane; `status` decides
+ * whether the rule exists at all. A rule can therefore carry `maturity: stable`
+ * — the enforce lane, auto-block, no human in the loop — while `status: draft`
+ * keeps the engine from ever evaluating it. Seven rules on main are in exactly
+ * that state today.
+ *
+ * For an FP harness the consequence is the same disease fieldCoverage exists to
+ * name: the rule cannot fire, so it cannot be counted as a false positive, so
+ * the gate reports it CLEAN. Nothing in a field-based coverage check can see it,
+ * because every field the rule declares is perfectly measurable — the sample
+ * simply never reaches the rule.
+ *
+ * Kept honest by tests/corpus-event-shapes.test.ts, which parses the status
+ * comparisons out of src/engine.ts rather than trusting this list.
+ */
+export const INERT_STATUSES: ReadonlySet<string> = Object.freeze(
+  new Set(["draft", "deprecated"]),
+);
+
+/** Rule maturities that put a rule in the enforce (auto-block) lane. */
+export const ENFORCE_LANE_MATURITIES: ReadonlySet<string> = Object.freeze(
+  new Set(["stable", "production"]),
+);
+
+/** True when the engine skips this status outright, in every lane. */
+export function isInertStatus(status: string | undefined): boolean {
+  return status !== undefined && INERT_STATUSES.has(status.trim().toLowerCase());
+}
+
+/** Why a status makes a rule unmeasurable — a sentence, or null when it does not. */
+export function inertStatusReason(status: string | undefined): string | null {
+  if (!isInertStatus(status)) return null;
+  const s = String(status).trim().toLowerCase();
+  return (
+    `status: ${s} — src/engine.ts skips this status on both evaluation paths, ` +
+    `before the lane gate, so the rule cannot fire on any sample. Its 0 FP is ` +
+    `the absence of a measurement, not the presence of precision.`
+  );
+}
+
+export interface StatusGap {
+  readonly ruleId: string;
+  /** The normalised inert status that stopped the rule from being evaluated. */
+  readonly status: string;
+  /** The rule's declared maturity, so a caller can say how bad this is. */
+  readonly maturity: string | null;
+  /** True when the rule also claims the enforce (auto-block) lane. */
+  readonly claimsEnforceLane: boolean;
+  readonly reason: string;
+}
+
+/**
+ * Rules the engine will not evaluate at all. Measurable rules are omitted.
+ *
+ * Unlike an unmeasurABLE field (no benign corpus can supply a tool_name; a text
+ * corpus has no span DAG), this one has a remedy that is always available and is
+ * one line long: flip the status, or drop the maturity out of the enforce lane.
+ * That difference is why callers are expected to FAIL on this rather than merely
+ * print it — see the exit-code note in scripts/gate-promotion-fp.ts.
+ */
+export function statusCoverage(rules: readonly RuleLike[]): readonly StatusGap[] {
+  const out: StatusGap[] = [];
+  for (const rule of rules) {
+    if (!isInertStatus(rule.status)) continue;
+    const status = String(rule.status).trim().toLowerCase();
+    const maturity = typeof rule.maturity === "string" ? rule.maturity.trim().toLowerCase() : null;
+    out.push(
+      Object.freeze({
+        ruleId: rule.id,
+        status,
+        maturity,
+        claimsEnforceLane: maturity !== null && ENFORCE_LANE_MATURITIES.has(maturity),
+        reason: inertStatusReason(status) ?? "",
       }),
     );
   }

--- a/scripts/promote-to-stable.ts
+++ b/scripts/promote-to-stable.ts
@@ -40,7 +40,7 @@ import { fileURLToPath } from "node:url";
 import { load as yamlLoad } from "js-yaml";
 import { MATURITIES, type Maturity } from "../src/quality/rule-contract.js";
 import { ATREngine } from "../src/engine.js";
-import type { AgentEvent } from "../src/types.js";
+import { matchedRuleIds } from "./lib/corpus-event.js";
 
 const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const RULES_DIR = join(REPO_ROOT, "rules");
@@ -73,26 +73,16 @@ function parseArgs(): Args {
   };
 }
 
-/** Build a single AgentEvent from arbitrary text (mirrors the safety gate). */
-function asTextEvent(content: string): AgentEvent {
-  return {
-    type: "mcp_exchange",
-    timestamp: new Date().toISOString(),
-    content,
-    fields: {
-      tool_name: "corpus-sample",
-      tool_input: content,
-      tool_response: content,
-      user_input: content,
-    },
-  };
-}
-
-function matchAllRuleIds(engine: ATREngine, content: string): Set<string> {
-  const matched = new Set<string>();
-  for (const m of engine.evaluate(asTextEvent(content))) matched.add(m.rule.id);
-  for (const m of engine.scanSkill(content)) matched.add(m.rule.id);
-  return matched;
+/**
+ * Every rule id a sample matches, via the canonical shape set.
+ *
+ * This is the gate that decides what enters the enforce (auto-block) lane, so it
+ * is the last place a narrow event shape is affordable: a field this harness
+ * cannot present is a condition it cannot see fire, and the rule gets promoted
+ * on a measurement that never happened.
+ */
+function matchAllRuleIds(engine: ATREngine, content: string): ReadonlySet<string> {
+  return matchedRuleIds(engine, content);
 }
 
 /** Recursively collect *.yaml under a dir. */

--- a/scripts/validate-rule-testcases.ts
+++ b/scripts/validate-rule-testcases.ts
@@ -6,8 +6,9 @@
 import { resolve, dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { ATREngine } from "../src/engine.js";
+import { matchedRuleIds } from "./lib/corpus-event.js";
 import { loadRulesFromDirectory } from "../src/loader.js";
-import type { AgentEvent } from "../src/types.js";
+
 
 const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const RULES_DIR = join(REPO_ROOT, "rules");
@@ -22,33 +23,14 @@ const RULE_ID = process.argv[2] || "ATR-2026-00010";
  * indistinguishable, in the output, from a broken rule. Widened to match the
  * shape scripts/lib/corpus-event.ts blessed for the FP gate, so that a true
  * positive is exercised on the same shape the benign corpus is charged against.
- * tool_name stays pinned to a short constant: production tool_name is an
- * identifier, not a document, and pouring sample text in fabricates FPs.
+ *
+ * That widening was done by copying the gate's builder. This now imports it
+ * instead: a local copy drifts the moment either side is edited, and a rule must
+ * never earn its detection credit on a wider presentation than the one it pays
+ * its false positives on.
  */
-function asTextEvent(content: string): AgentEvent {
-  return {
-    type: "mcp_exchange",
-    timestamp: new Date().toISOString(),
-    content,
-    fields: {
-      tool_name: "corpus-sample",
-      tool_input: content,
-      tool_response: content,
-      user_input: content,
-      agent_output: content,
-      agent_message: content,
-      tool_description: content,
-      tool_args: content,
-      content,
-    },
-  };
-}
-
-function matched(engine: ATREngine, content: string): Set<string> {
-  const s = new Set<string>();
-  for (const m of engine.evaluate(asTextEvent(content))) s.add(m.rule.id);
-  for (const m of engine.scanSkill(content)) s.add(m.rule.id);
-  return s;
+function matched(engine: ATREngine, content: string): ReadonlySet<string> {
+  return matchedRuleIds(engine, content);
 }
 
 async function main(): Promise<void> {

--- a/src/eval/run-pint-benchmark.ts
+++ b/src/eval/run-pint-benchmark.ts
@@ -180,7 +180,12 @@ async function main(): Promise<void> {
     source: 'pint',
     source_version: 'v1',
     source_url: 'https://github.com/lakeraai/pint-benchmark',
-    notes: 'Invariant Labs PINT benchmark — 850-sample adversarial prompt-injection corpus.',
+    notes:
+      'PINT-FORMAT corpus, self-built: 850 samples (deepset/prompt-injections + ' +
+      'Lakera/gandalf_ignore_instructions). NOT a run of Lakera\'s official PINT ' +
+      'benchmark, whose corpus is private and roughly 5x larger. PINT is Lakera\'s; ' +
+      'this note previously credited Invariant Labs, and every measurement file ' +
+      'written before 2026-08 carries that error.',
   });
   console.log(`Measurement: ${measurementPath}`);
   console.log('Done.\n');

--- a/tests/corpus-event-shapes.test.ts
+++ b/tests/corpus-event-shapes.test.ts
@@ -477,3 +477,57 @@ describe("the gate measures a tool_args rule end to end", () => {
     expect(readFileSync(dirty, "utf-8").split("\n").filter(Boolean)).toEqual([TOOL_ARGS_ID]);
   });
 });
+
+// ---------------------------------------------------------------------------
+// The ratchet: no harness gets to hand-roll its own event shape again
+// ---------------------------------------------------------------------------
+
+/**
+ * Every FP/coverage harness in this repo once carried its own `asTextEvent()`,
+ * copied from whichever sibling was newest at the time. When gate-promotion-fp
+ * moved to the canonical shape set the copies stayed behind, and each one kept
+ * scoring rules on a presentation narrower than production — reporting rules
+ * FP-clean that had simply never been read. On ATR-2026-00091 the narrow copy
+ * under-reported its own subject by a factor of ten (372 vs 3,897).
+ *
+ * A comment saying "keep in sync" did not keep them in sync. This does.
+ */
+describe("harnesses import the canonical shape set — they do not mirror it", () => {
+  const HARNESSES = [
+    "scripts/gate-promotion-fp.ts",
+    "scripts/check-rules-safety.ts",
+    "scripts/promote-to-stable.ts",
+    "scripts/audit-draft-revival.ts",
+    "scripts/validate-rule-testcases.ts",
+  ] as const;
+
+  for (const rel of HARNESSES) {
+    it(`${rel} routes matching through scripts/lib/corpus-event.ts`, () => {
+      const src = readFileSync(join(REPO_ROOT, rel), "utf-8");
+      expect(src).toMatch(/from\s+["'](?:\.\/)?lib\/corpus-event\.js["']/);
+    });
+
+    it(`${rel} does not build its own AgentEvent literal`, () => {
+      const src = readFileSync(join(REPO_ROOT, rel), "utf-8");
+      // An event literal is `type:` immediately followed by one of the engine's
+      // event-type strings. Comments and doc blocks are stripped first so that
+      // describing the old defect does not trip the check.
+      const code = src
+        .replace(/\/\*[\s\S]*?\*\//g, "")
+        .replace(/(^|[^:])\/\/.*$/gm, "$1")
+        // One documented exception, and only this one: audit-draft-revival's
+        // fieldAwareEvent() delivers a test case's payload into the engine field
+        // the test case itself names (or parses it as a trace). That is a
+        // deliberate second presentation used ONLY to score declared true
+        // positives -- a rule reading `tool_args` cannot fire on an event that
+        // carries none, and scoring that as a rule failure measures the harness.
+        // The benign-corpus path, which is what this ratchet protects, goes
+        // through matchedRuleIds like everything else.
+        .replace(/function fieldAwareEvent[\s\S]*?\n}\n/, "");
+      const literal =
+        /type:\s*["'](?:mcp_exchange|llm_input|llm_output|tool_call|tool_response|agent_behavior|multi_agent_message)["']/;
+      const offenders = code.split("\n").filter((l) => literal.test(l));
+      expect(offenders).toEqual([]);
+    });
+  }
+});


### PR DESCRIPTION
#387 moved `scripts/gate-promotion-fp.ts` onto the shared shape set in `scripts/lib/corpus-event.ts`. It did not move the four harnesses that had copied that gate's event builder -- and copying is how the defect spread. Each copy kept scoring rules on a presentation narrower than production, so a rule whose conditions read `tool_args` (or `agent_output`, or `tool_description`) could not fire, could not be counted as a false positive, and was reported **CLEAN without ever having been read**.

## What was rewired

| harness | what it decides |
|---|---|
| `scripts/check-rules-safety.ts` | whether a flywheel PR is safe to auto-merge |
| `scripts/promote-to-stable.ts` | what enters the enforce (auto-block) lane |
| `scripts/audit-draft-revival.ts` | what gets revived out of `status: draft` |
| `scripts/validate-rule-testcases.ts` | whether a rule fires on its own declared true positives |

All four now call `matchedRuleIds()`.

## This is not theoretical

Re-measuring the six rules fixed in #412, same 5,317-sample benign corpus, only the event shape differs:

| rule | narrow shape | canonical shapes |
|---|---:|---:|
| ATR-2026-00091 | 372 | **3,897** |
| ATR-2026-00084 | 104 | 110 |
| ATR-2026-00089 | 6 | 8 |
| ATR-2026-00083 | 45 | 45 |
| ATR-2026-00095 | 86 | 86 |
| ATR-2026-00096 | 93 | 93 |

The audit tool was under-reporting its own subject by a factor of ten on the worst rule -- a `severity: critical` rule whose response actions are `kill_agent` and `quarantine_session`.

## Two other pieces of the same problem

**Counting.** `matchedRuleIds()` lives in `corpus-event.ts` rather than in each caller, and counts one false positive **per sample**, not per shape. A document that trips a rule on three shapes is one false positive, not three.

**`statusCoverage()`** names the second blindness. `src/engine.ts` drops `status: draft | deprecated` *before* the lane gate, on both evaluation paths:

```ts
if (rule.status === 'deprecated' || rule.status === 'draft') continue;
if (!this.passesLane(rule)) continue;
```

The order is the whole problem. `maturity` decides the lane; `status` decides whether the rule exists at all. A rule can therefore sit at `maturity: stable` -- enforce lane, auto-block, no human in the loop -- while `status: draft` keeps the engine from ever evaluating it, and every gate reports it clean **because** it cannot fire. Nothing field-based can see that. It needs its own check.

## The ratchet is a test, not a comment

`tests/corpus-event-shapes.test.ts` now asserts that each of the five harnesses imports the shared module and builds no `AgentEvent` literal of its own. Writing it immediately surfaced two offenders beyond the ones this change set out to fix.

One documented exception is carved out by name: `audit-draft-revival`'s `fieldAwareEvent()`, which delivers a test case's payload into the engine field the test case itself names, or parses it as a trace. That is a deliberate second presentation used **only** to score declared true positives -- a rule reading `tool_args` cannot fire on an event carrying none, and scoring that as a rule failure measures the harness, not the rule. The benign-corpus path goes through `matchedRuleIds()` like everything else.

"Keep in sync" comments did not keep these in sync.

## Attribution fix

`src/eval/run-pint-benchmark.ts` was writing `notes: 'Invariant Labs PINT benchmark'` into **every new version-pinned measurement file**. PINT is Lakera's. And what this repo runs is not Lakera's benchmark at all -- it is a self-built 850-sample PINT-*format* corpus (`deepset/prompt-injections` + `Lakera/gandalf_ignore_instructions`); the official PINT corpus is private and roughly 5x larger. Every measurement file written before 2026-08 carries the old note. The note now says all of this, so future records are self-describing.

## Not in scope

`src/eval/eval-harness.ts` is the sixth harness with the same defect: `sampleToEvent()` builds `{type: 'llm_input', content, fields}` and nothing else, so `engine.ts`'s source-type filter discards roughly 388 of 780 rules before matching even begins. Fixing it changes a published benchmark number, so it gets its own PR with its own measurement rather than riding along here.

## Tests

851 passed, 3 skipped. `tests/corpus-event-shapes.test.ts` is 43 tests, up from 33.
