### PR TITLE
fix(rules): revive three rules the engine could never fire

### DIFF
--- a/rules/prompt-injection/ATR-2026-00080-encoding-evasion.yaml
+++ b/rules/prompt-injection/ATR-2026-00080-encoding-evasion.yaml
@@ -1,7 +1,7 @@
 title: Encoding-Based Prompt Injection Evasion
 id: ATR-2026-00080
 rule_version: 1
-status: draft
+status: experimental
 description: >
   Detects prompt injection attempts that use encoding techniques to bypass text-based detection rules. Attackers encode
   malicious payloads using base64, hex, Unicode escapes, Punycode, or RTL override characters to smuggle instructions

--- a/rules/prompt-injection/ATR-2026-00089-polymorphic-skill.yaml
+++ b/rules/prompt-injection/ATR-2026-00089-polymorphic-skill.yaml
@@ -1,7 +1,7 @@
 title: Polymorphic Skill and Capability Aliasing Attack
 id: ATR-2026-00089
 rule_version: 1
-status: draft
+status: experimental
 description: >
   Detects injection attempts that use polymorphic techniques to disguise malicious capabilities under benign aliases.
   Attackers register or invoke tool functions using misleading names, redefine existing capability names, or use dynamic

--- a/rules/prompt-injection/ATR-2026-00091-nested-payload.yaml
+++ b/rules/prompt-injection/ATR-2026-00091-nested-payload.yaml
@@ -1,7 +1,7 @@
 title: Advanced Structured Data Injection with Nested Payloads
 id: ATR-2026-00091
 rule_version: 1
-status: draft
+status: experimental
 description: >
   Detects advanced structured data injection where malicious prompts are deeply nested within complex JSON objects,
   multi-level CSV structures, or encoded within data serialization formats. These attacks exploit parser differences


### PR DESCRIPTION
`src/engine.ts:382` and `:533` skip `status: draft` **before** the lane gate, on both evaluation paths:

```ts
if (rule.status === 'deprecated' || rule.status === 'draft') continue;
if (!this.passesLane(rule)) continue;
```

A draft rule therefore fires in **no** lane -- not even `hunt` -- however good it is. These three validate, pass their own `test_cases` under tooling that flips status in memory, count toward the 780-rule total, and have never fired once.

## Measured, then revived

5,317-sample benign corpus, canonical five-shape event set, `status` flipped:

| rule | FP | test cases | maturity | lane it enters |
|---|---:|---|---|---|
| ATR-2026-00080 | 0 | TP 5/5 · TN 5/5 | `stable` | enforce (auto-block) |
| ATR-2026-00089 | 0 | TP 7/7 · TN 8/8 | `test` | alert |
| ATR-2026-00091 | 0 | TP 5/5 · TN 8/8 | `test` | alert |

Status flip only -- no detection change in this PR.

**ATR-2026-00080** is the last rule on `main` carrying the `draft` + `maturity: stable` combination. That pairing is the dangerous one: the rule reads as enforce-lane in every report while the engine never evaluates it, so every gate scores it clean by default. It measures genuinely clean, so it goes live on evidence rather than on the accident of a status field.

**ATR-2026-00089 and ATR-2026-00091** were repaired and demoted out of the enforce lane in #412 -- 8 and 3,897 false positives respectively before that work. They come alive here into the **alert** lane, not the auto-block one.

## Supersedes #388

#388 proposed reviving ATR-2026-00080 and ATR-2026-00089 while both kept `maturity: stable`. #412 has since rewritten 00089's `conditions[3]` and demoted it to `maturity: test`, so that premise no longer holds and the branch conflicts. This PR carries 00080 forward unchanged, revives 00089 at its corrected maturity, and adds 00091 which measures equally clean. #388 can be closed.

## Gates

```
validate-rules      780/780 PASS
gate-promotion-fp   clean=3 dirty=0
```

Inert rules on `main`: **10 -> 7**.
