### PR TITLE
chore(maturity): promote the 21 verified rules from #403, hold the other 167

### DIFF
--- a/rules/context-exfiltration/ATR-2026-00578-zen-mcp-path-traversal-blacklist-bypass.yaml
+++ b/rules/context-exfiltration/ATR-2026-00578-zen-mcp-path-traversal-blacklist-bypass.yaml
@@ -18,7 +18,7 @@ author: "ATR Community (vulnerablemcp sync)"
 date: 2026/06/12
 schema_version: '0.1'
 detection_tier: pattern
-maturity: experimental
+maturity: test
 severity: high
 references:
   owasp_llm:

--- a/rules/context-exfiltration/ATR-2026-00580-mcp-session-id-token-in-url-query.yaml
+++ b/rules/context-exfiltration/ATR-2026-00580-mcp-session-id-token-in-url-query.yaml
@@ -24,7 +24,7 @@ author: "ATR Community (vulnerablemcp sync)"
 date: 2026/06/12
 schema_version: '0.1'
 detection_tier: pattern
-maturity: experimental
+maturity: test
 severity: high
 references:
   owasp_llm:

--- a/rules/context-exfiltration/ATR-2026-00583-mcp-env-secret-file-read-without-consent.yaml
+++ b/rules/context-exfiltration/ATR-2026-00583-mcp-env-secret-file-read-without-consent.yaml
@@ -28,7 +28,7 @@ author: "ATR Community (mcp-security-db sync)"
 date: 2026/06/12
 schema_version: '0.1'
 detection_tier: pattern
-maturity: experimental
+maturity: test
 severity: high
 references:
   owasp_llm:

--- a/rules/context-exfiltration/ATR-2026-01452-obfuscated-javascript-xss.yaml
+++ b/rules/context-exfiltration/ATR-2026-01452-obfuscated-javascript-xss.yaml
@@ -21,7 +21,7 @@ author: "ATR Community"
 date: "2026/06/12"
 schema_version: "0.1"
 detection_tier: pattern
-maturity: experimental
+maturity: test
 severity: high
 
 references:

--- a/rules/context-exfiltration/ATR-2026-01461-foreign-language-sysprompt-request.yaml
+++ b/rules/context-exfiltration/ATR-2026-01461-foreign-language-sysprompt-request.yaml
@@ -22,7 +22,7 @@ author: "ATR Community"
 date: "2026/06/12"
 schema_version: "0.1"
 detection_tier: semantic
-maturity: experimental
+maturity: test
 severity: medium
 
 references:

--- a/rules/context-exfiltration/ATR-2026-01464-indirect-pi-sysprompt-action-hijack.yaml
+++ b/rules/context-exfiltration/ATR-2026-01464-indirect-pi-sysprompt-action-hijack.yaml
@@ -19,7 +19,7 @@ author: "ATR Community"
 date: "2026/06/12"
 schema_version: "0.1"
 detection_tier: pattern
-maturity: experimental
+maturity: test
 severity: critical
 
 references:

--- a/rules/context-exfiltration/ATR-2026-01770-semantic-pii-credential-extraction.yaml
+++ b/rules/context-exfiltration/ATR-2026-01770-semantic-pii-credential-extraction.yaml
@@ -34,7 +34,7 @@ author: "ATR Community"
 date: "2026/06/13"
 schema_version: "0.1"
 detection_tier: semantic
-maturity: experimental
+maturity: test
 severity: high
 
 references:

--- a/rules/context-exfiltration/ATR-2026-01772-semantic-internal-state-recon.yaml
+++ b/rules/context-exfiltration/ATR-2026-01772-semantic-internal-state-recon.yaml
@@ -31,7 +31,7 @@ author: "ATR Community"
 date: "2026/06/13"
 schema_version: "0.1"
 detection_tier: semantic
-maturity: experimental
+maturity: test
 severity: high
 
 references:

--- a/rules/context-exfiltration/ATR-2026-01929-mcp-unauthenticated-transport-token-fallback.yaml
+++ b/rules/context-exfiltration/ATR-2026-01929-mcp-unauthenticated-transport-token-fallback.yaml
@@ -23,7 +23,7 @@ author: "ATR Community"
 date: 2026/06/14
 schema_version: '0.1'
 detection_tier: pattern
-maturity: experimental
+maturity: test
 severity: high
 references:
   owasp_llm:

--- a/rules/excessive-autonomy/ATR-2026-01809-semantic-insider-manipulation-process-corruption.yaml
+++ b/rules/excessive-autonomy/ATR-2026-01809-semantic-insider-manipulation-process-corruption.yaml
@@ -35,7 +35,7 @@ author: "ATR Community"
 date: "2026/06/13"
 schema_version: "0.1"
 detection_tier: semantic
-maturity: experimental
+maturity: test
 severity: high
 
 references:

--- a/rules/prompt-injection/ATR-2026-00472-garak-dan-are-going-to.yaml
+++ b/rules/prompt-injection/ATR-2026-00472-garak-dan-are-going-to.yaml
@@ -15,7 +15,7 @@ author: ATR Community (garak-import)
 date: '2026-05-12'
 schema_version: '0.1'
 detection_tier: pattern
-maturity: "experimental"
+maturity: test
 severity: medium
 references:
   owasp_llm:

--- a/rules/prompt-injection/ATR-2026-00485-garak-dan-and-does-not.yaml
+++ b/rules/prompt-injection/ATR-2026-00485-garak-dan-and-does-not.yaml
@@ -14,7 +14,7 @@ author: ATR Community (garak-import)
 date: '2026-05-12'
 schema_version: '0.1'
 detection_tier: pattern
-maturity: "experimental"
+maturity: test
 severity: medium
 references:
   owasp_llm:

--- a/rules/prompt-injection/ATR-2026-00584-indirect-injection-via-tool-response.yaml
+++ b/rules/prompt-injection/ATR-2026-00584-indirect-injection-via-tool-response.yaml
@@ -24,7 +24,7 @@ author: ATR Community (agent-benchmarks sync)
 date: 2026/06/13
 schema_version: "0.1"
 detection_tier: pattern
-maturity: experimental
+maturity: test
 severity: high
 references:
   owasp_llm:

--- a/rules/prompt-injection/ATR-2026-01025-evasion-hypothetical-fictional-execution-framing.yaml
+++ b/rules/prompt-injection/ATR-2026-01025-evasion-hypothetical-fictional-execution-framing.yaml
@@ -17,7 +17,7 @@ author: "ATR Community"
 date: "2026/06/12"
 schema_version: "0.1"
 detection_tier: semantic
-maturity: experimental
+maturity: test
 severity: medium
 
 references:

--- a/rules/prompt-injection/ATR-2026-01771-semantic-jailbreak-framing.yaml
+++ b/rules/prompt-injection/ATR-2026-01771-semantic-jailbreak-framing.yaml
@@ -35,7 +35,7 @@ author: "ATR Community"
 date: "2026/06/13"
 schema_version: "0.1"
 detection_tier: semantic
-maturity: experimental
+maturity: test
 severity: high
 
 references:

--- a/rules/prompt-injection/ATR-2026-01906-content-manipulation.yaml
+++ b/rules/prompt-injection/ATR-2026-01906-content-manipulation.yaml
@@ -7,7 +7,7 @@ author: ATR Community
 date: 2026/06/13
 schema_version: '0.1'
 detection_tier: semantic
-maturity: experimental
+maturity: test
 severity: medium
 references:
   owasp_llm:

--- a/rules/skill-compromise/ATR-2026-01756-backdoor-pot-symbol-emoticon-trigger.yaml
+++ b/rules/skill-compromise/ATR-2026-01756-backdoor-pot-symbol-emoticon-trigger.yaml
@@ -16,7 +16,7 @@ author: "ATR Community"
 date: "2026/06/12"
 schema_version: "0.1"
 detection_tier: semantic
-maturity: experimental
+maturity: test
 severity: critical
 
 references:

--- a/rules/tool-poisoning/ATR-2026-00575-miasma-npm-worm-agent-config-backdoor.yaml
+++ b/rules/tool-poisoning/ATR-2026-00575-miasma-npm-worm-agent-config-backdoor.yaml
@@ -23,7 +23,7 @@ author: "ATR Community"
 date: "2026/06/11"
 schema_version: "0.1"
 detection_tier: pattern
-maturity: experimental
+maturity: test
 severity: critical
 references:
   owasp_llm:

--- a/rules/tool-poisoning/ATR-2026-00581-mcp-tool-rug-pull-post-approval-redefinition.yaml
+++ b/rules/tool-poisoning/ATR-2026-00581-mcp-tool-rug-pull-post-approval-redefinition.yaml
@@ -17,7 +17,7 @@ author: ATR Community (vulnerablemcp sync)
 date: 2026/06/12
 schema_version: "0.1"
 detection_tier: pattern
-maturity: experimental
+maturity: test
 severity: high
 references:
   owasp_llm:

--- a/rules/tool-poisoning/ATR-2026-01775-semantic-mcp-tool-manifest-poisoning.yaml
+++ b/rules/tool-poisoning/ATR-2026-01775-semantic-mcp-tool-manifest-poisoning.yaml
@@ -29,7 +29,7 @@ author: "ATR Community"
 date: "2026/06/13"
 schema_version: "0.1"
 detection_tier: semantic
-maturity: experimental
+maturity: test
 severity: high
 
 references:

--- a/rules/tool-poisoning/ATR-2026-01927-mcp-server-kubernetes-kubectl-command-injection.yaml
+++ b/rules/tool-poisoning/ATR-2026-01927-mcp-server-kubernetes-kubectl-command-injection.yaml
@@ -14,7 +14,7 @@ author: ATR Community (vulnerablemcp sync)
 date: 2026/06/12
 schema_version: '0.1'
 detection_tier: pattern
-maturity: experimental
+maturity: test
 severity: high
 references:
   owasp_llm:


### PR DESCRIPTION
Replaces #403, which is now draft. Same source branch, 21 of the 188 promotions instead of all of them.

## What #403 got wrong

Its promotion workflow builds the id list it hands to `gate-promotion-fp.ts` with

```python
enforce = [p["ruleId"] for p in report.get("promotions", []) if p.get("to") in ("stable", "production")]
```

so only the 157 `test -> stable` transitions were gated. The **31 `experimental -> test` transitions were never run against any benign corpus at all** — and `maturity: test` is not inert, `laneAllows()` puts it in the alert lane.

Re-running the current gate on all 188 against today's `main`:

```
[fp-gate] corpus = 5317 benign samples
[fp-gate] clean = 178 · dirty = 10

  ATR-2026-01610 — 1160 FP     <- 21.8% of the benign corpus
  ATR-2026-00579 — 8 FP
  ATR-2026-00465 — 5 FP
  ATR-2026-00492 — 4 FP
  ATR-2026-01613 — 3 FP
  ATR-2026-01856 — 2 FP
  ATR-2026-01901 — 2 FP
  ATR-2026-00576 — 1 FP
  ATR-2026-01773 — 1 FP
  ATR-2026-01928 — 1 FP
```

All 10 are `experimental -> test`, without exception. Gating only those 31 reproduces the identical split: `clean = 21 · dirty = 10`.

## What this PR contains

The 21 clean `experimental -> test` promotions. Nothing else. One line changed per file, `maturity` only.

## What this PR deliberately does NOT contain

**The 157 `test -> stable` promotions.** They are FP-clean on the public corpus, but `maturity: stable` is the enforce lane — auto-block, no human in the loop — and not one of them carries wild evidence gathered under the current event shape:

- 143 have no `wild_samples` field at all
- the remaining 14 have `wild_validated` dated 2026/04/08, which predates the corpus event-shape fix

`src/quality/rule-contract.ts`'s `canPromote` requires `wild_samples >= 1000` and `confidence >= 80`. **That contract is not wired into any CI gate.** Promoting 157 rules into an auto-block lane on a documented standard that nothing checks is how #305 happened. Either wire `canPromote` in as a gate, or amend `docs/QUALITY-GATE.md` and RFC-001 to state the threshold actually enforced — then re-propose them.

**The 10 dirty rules.** They stay at `experimental`. Three of them (`ATR-2026-01610`, `ATR-2026-00579`, `ATR-2026-01928`) resemble the JSON-envelope artifact from #412, and the obvious fix was tested and **rejected**: adding `\\` to the negated character classes takes ATR-2026-01610 from 1,160 FP to 260, with 241 still firing in `post-tool-json` on samples containing no newline at all. Those need real narrowing. The other 7 are genuinely over-broad — `ATR-2026-00465` fires on `[Your question here]` and `{{prompt}}` template placeholders, `ATR-2026-00492` on `You are [role]` in prompt-engineering tutorials, `ATR-2026-01613` on `List all customers`.

## Follow-ups this exposes (not fixed here)

1. The workflow's id filter — feed every promotion to the gate, not just `to=stable`.
2. `canPromote` is unenforced.
3. The promoter has no `status` awareness: 2 `status: deprecated` rules were among the 188 proposed for `stable`.
4. The PR body field labelled `wild-looking TP(s)` is a string-length-and-punctuation heuristic, not wild evidence, and reads like the latter.

## Gates

```
validate-rules       780 passed, 0 failed
gate-promotion-fp    clean = 21 · dirty = 0
gate-rule-status     PASS
gate-re2-portability PASS (oracle: real Go RE2)
gate-rule-latency    PASS
eval-generalization  PASS (broken 0, self-FP 2)
check-rules-safety   no new/modified rule bodies
```
