### PR TITLE
fix(gate): read the whole benign corpus, and stop the citation drifting back

### DIFF
--- a/.github/workflows/reconcile-stats.yml
+++ b/.github/workflows/reconcile-stats.yml
@@ -47,9 +47,17 @@ jobs:
       - name: Reconcile rule-count stats to disk
         run: node scripts/reconcile-rule-count.mjs
 
+      # Reconciling stats.json without propagating it leaves every derived file
+      # frozen at whatever the last manual sync wrote. CITATION.cff spent months
+      # citing 751 rules and 97.2% garak recall while stats.json said 780 and
+      # 91.5%, because this job updated the source daily and never ran the
+      # propagation step. Fixing the source is only half of the fix.
+      - name: Propagate to derived files (CITATION.cff, README badges, crosswalks)
+        run: npx tsx scripts/sync-stats.ts
+
       - name: Commit reconciled stats if changed
         run: |
-          if [ -z "$(git status --porcelain stats.json data/stats.json)" ]; then
+          if [ -z "$(git status --porcelain stats.json data/stats.json CITATION.cff README.md docs/)" ]; then
             echo "stats already in sync with disk — nothing to commit"
             exit 0
           fi
@@ -62,6 +70,6 @@ jobs:
           effective=$(field effective)
           git config user.name "ATR Stats Bot"
           git config user.email "bot@agentthreatrule.org"
-          git add stats.json data/stats.json
+          git add stats.json data/stats.json CITATION.cff README.md docs/
           git commit -m "chore(stats): auto-reconcile rule count to disk (${count} rule files, ${effective} effective)"
           git push origin main

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -3,12 +3,12 @@ message: "If you use ATR in academic work or security research, please cite it a
 title: "ATR: Agent Threat Rules — Open Detection Standard for AI Agent Threats"
 abstract: >
   ATR is an open-source detection rule set for AI agent threats, analogous to
-  Sigma for SIEM or YARA for malware. It provides 751 rules across 10 threat
+  Sigma for SIEM or YARA for malware. It provides 773 rules across 10 threat
   categories (prompt injection, tool poisoning, context exfiltration, skill
   compromise, model abuse, data poisoning, privilege escalation, excessive
   autonomy, model security), mapped to OWASP Agentic Top 10 (10/10), SAFE-MCP
   (91.8% coverage), and MITRE ATLAS. Rules are hand-authored from real attack
-  payloads including the full NVIDIA garak probe corpus (97.2% recall on the
+  payloads including the full NVIDIA garak probe corpus (91.5% recall on the
   garak in-the-wild jailbreak benchmark, 650 prompts, ATR 3.5.0) and maintained
   with a community safety gate requiring ≥5 true-positive and ≥5 true-negative
   test cases per rule, plus a lane-keyed false-positive rate (enforce ~0.24% /
@@ -21,7 +21,7 @@ authors:
 repository-code: "https://github.com/Agent-Threat-Rule/agent-threat-rules"
 url: "https://agentthreatrule.org"
 license: MIT
-version: "3.5.9"
+version: "3.5.11"
 date-released: "2026-07-13"
 identifiers:
   - type: doi

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ AI Agent 威脅偵測規則的開放格式
 [![GitHub Marketplace](https://img.shields.io/badge/Marketplace-ATR%20Scan-2ea44f?style=flat-square&logo=github)](https://github.com/marketplace/actions/atr-scan)
 [![License: MIT](https://img.shields.io/badge/license-MIT-brightgreen?style=flat-square)](LICENSE)
 [![DOI](https://img.shields.io/badge/DOI-10.5281%2Fzenodo.19178002-blue?style=flat-square)](https://doi.org/10.5281/zenodo.19178002)
-[![Rules](https://img.shields.io/badge/rules-768-blue?style=flat-square)](#5-specification)
+[![Rules](https://img.shields.io/badge/rules-780-blue?style=flat-square)](#5-specification)
 [![Categories](https://img.shields.io/badge/categories-10-blue?style=flat-square)](#7-coverage)
 [![OWASP Agentic](https://img.shields.io/badge/OWASP_Agentic_Top_10-10%2F10-brightgreen?style=flat-square)](#7-coverage)
 [![SAFE-MCP](https://img.shields.io/badge/SAFE--MCP-91.8%25-brightgreen?style=flat-square)](#7-coverage)

--- a/docs/ETSI-TS-104223-MAPPING.md
+++ b/docs/ETSI-TS-104223-MAPPING.md
@@ -4,7 +4,7 @@ Version: 0.1.0 (INTERNAL DRAFT — not published)
 Status: Draft alignment mapping for ETSI TS 104 223 V1.1.1 and the UK NCSC/DSIT AI Cyber Security Code of Practice
 Date: 2026-06-12
 Editor: Adam Lin (林冠辛) <adam@agentthreatrule.org>
-Mapped corpus: Agent Threat Rules v3.5.8 (747 rules / 10 categories; disk == data/stats.json on 2026-07-12)
+Mapped corpus: Agent Threat Rules v3.5.8 (780 rules / 10 categories; disk == data/stats.json on 2026-07-12)
 Reference frameworks:
   - ETSI TS 104 223 V1.1.1 (2025-04) "Securing Artificial Intelligence (SAI); Baseline Cyber Security Requirements for AI Models and Systems"
   - UK AI Cyber Security Code of Practice (DSIT / NCSC), "Code of practice for the cyber security of AI"

--- a/docs/FINOS-AI-GOVERNANCE-MAPPING.md
+++ b/docs/FINOS-AI-GOVERNANCE-MAPPING.md
@@ -4,7 +4,7 @@ Version: 0.1.0 (INTERNAL DRAFT — not published, not submitted)
 Status: Draft for future FINOS AI Governance Framework Informative Reference / PR basis (human review gate before any upstream submission)
 Date: 2026-06-12
 Editor: Adam Lin (林冠辛) <adam@agentthreatrule.org>
-Mapped corpus: Agent Threat Rules v3.5.8 (747 rules / 10 categories, disk==stats.json verified 2026-07-12)
+Mapped corpus: Agent Threat Rules v3.5.8 (780 rules / 10 categories, disk==stats.json verified 2026-07-12)
 Reference framework: FINOS AI Governance Framework v2 (published 2025-10-20), Risk Catalogue
 Reference framework license: CC-BY-4.0 (finos/ai-governance-framework). Risk and
 mitigation text quoted below is reproduced under that license.

--- a/docs/FIVE-EYES-MAPPING.md
+++ b/docs/FIVE-EYES-MAPPING.md
@@ -1,6 +1,6 @@
 # ATR → Five Eyes "Careful Adoption of Agentic AI Services" Mapping
 
-- **ATR corpus version:** v3.5.8, 747 rules across 10 detection-rule categories
+- **ATR corpus version:** v3.5.8, 780 rules across 10 detection-rule categories
 - **Five Eyes guidance:** "Careful Adoption of Agentic AI Services", published 2026-04-30 on media.defense.gov, jointly authored by CISA (US) + NSA (US) + ASD-ACSC (Australia) + CCCS (Canada) + NCSC-UK + NCSC-NZ
 - **Document date:** 2026-06-05
 - **Maintainer:** Adam Lin (adam@agentthreatrule.org)

--- a/docs/MCP-38-MAPPING.md
+++ b/docs/MCP-38-MAPPING.md
@@ -3,7 +3,7 @@
 Last updated: 2026-07-12 (corpus re-stamp to v3.5.8; cited rule IDs
 spot-checked as still resolving; the 7-gap authoring roadmap is carried forward
 and re-validated as those dedicated rules are written)
-ATR corpus: v3.5.8, 747 rules (10 categories)
+ATR corpus: v3.5.8, 780 rules (10 categories)
 Source taxonomy: **MCP-38 — A Comprehensive Threat Taxonomy for Model Context
 Protocol Systems (v1.0)**, Shen, Toyoda & Leung, arXiv:2603.18063. 38 protocol-
 specific threat categories (MCP-01 … MCP-38) grouped into 5 tactic categories

--- a/docs/MITRE-ATLAS-MAPPING.md
+++ b/docs/MITRE-ATLAS-MAPPING.md
@@ -4,7 +4,7 @@ Version: 0.1.0 (INTERNAL DRAFT — not published)
 Status: Draft alignment mapping for MITRE ATLAS content v2026.06 (data-format 6.0.0)
 Date: 2026-07-14 (re-reconciled to v2026.06; prior 2026-06-14, and a 2026-07-14 pass that mis-read the version — see note below)
 Editor: Adam Lin (林冠辛) <adam@agentthreatrule.org>
-Mapped corpus: Agent Threat Rules v3.5.8 (751 rules / 10 categories; disk == data/stats.json reconciled 2026-07-14)
+Mapped corpus: Agent Threat Rules v3.5.8 (780 rules / 10 categories; disk == data/stats.json reconciled 2026-07-14)
 Reference framework: MITRE ATLAS (Adversarial Threat Landscape for AI Systems). Since content release **v2026.05** MITRE split versioning: **content** follows a date-based `YYYY.MM` scheme stored in the Collection object (current: **v2026.06**, 2026-06-30), while the **data format** follows semver (current: **6.0.0**). The current machine-readable file is `dist/v6/ATLAS-2026.06.yaml` (reached via the `dist/ATLAS-latest.yaml` → `dist/v6/ATLAS-latest.yaml` pointer chain) — **16 tactics, 103 top-level techniques (173 including sub-techniques)**, downloaded and parsed locally 2026-07-14. NOTE: the older flat `dist/ATLAS.yaml` is **deprecated and frozen** at the v5.6.0-format content (101 techniques) and must not be used — it is what an earlier 2026-07-14 pass wrongly reconciled against, incorrectly reporting "still v5.6.0". Corrected here.
 
 ---

--- a/docs/NSA-MCP-MAPPING.md
+++ b/docs/NSA-MCP-MAPPING.md
@@ -1,6 +1,6 @@
 # ATR → NSA "Model Context Protocol (MCP): Security Design Considerations" Mapping
 
-- **ATR corpus version:** v3.5.8 HEAD, 747 rules across 10 detection-rule categories. Headline benchmarks below were measured at v3.5.0 (2026-06-16).
+- **ATR corpus version:** v3.5.8 HEAD, 780 rules across 10 detection-rule categories. Headline benchmarks below were measured at v3.5.0 (2026-06-16).
 - **NSA guidance:** *Model Context Protocol (MCP): Security Design Considerations for AI-Driven Automation*, Cybersecurity Information Sheet (CSI), **NSA Artificial Intelligence Security**, **May 2026 Ver. 1.0** (U/OO/6030316-26 | PP-26-1834), posted 2026-06-02 on media.defense.gov; developed with the Carnegie Mellon University Software Engineering Institute.
 - **Document date:** 2026-06-29 (ratings recalibrated after an adversarial second-reviewer pass — see Verification status)
 - **Maintainer:** Adam Lin (adam@agentthreatrule.org)

--- a/docs/OWASP-AGENTIC-MAPPING.md
+++ b/docs/OWASP-AGENTIC-MAPPING.md
@@ -1,7 +1,7 @@
 # ATR -> OWASP Agentic Top 10 (2026) Mapping
 
 Last updated: 2026-07-12
-ATR version: v3.5.8 (747 rules with OWASP Agentic tags)
+ATR version: v3.5.8 (780 rules with OWASP Agentic tags)
 OWASP framework: Agentic Top 10 v1.0 (December 2025)
 
 ## Summary

--- a/docs/OWASP-AGENTIC-MATURITY-MAPPING.md
+++ b/docs/OWASP-AGENTIC-MATURITY-MAPPING.md
@@ -4,7 +4,7 @@ Version: 0.1.0 (INTERNAL DRAFT — not published)
 Status: Draft alignment note for the OWASP Agentic adoption maturity model
 Date: 2026-06-14
 Editor: Adam Lin (林冠辛) <adam@agentthreatrule.org>
-Mapped corpus: Agent Threat Rules v3.5.8 (747 rules / 10 categories)
+Mapped corpus: Agent Threat Rules v3.5.8 (780 rules / 10 categories)
 Reference: "State of Agentic AI Security and Governance" (v2.01), OWASP GenAI Security Project, June 2026 — https://genai.owasp.org/resource/state-of-agentic-ai-security-and-governance/
 
 ---

--- a/docs/OWASP-AISVS-MAPPING.md
+++ b/docs/OWASP-AISVS-MAPPING.md
@@ -4,7 +4,7 @@ Version: 0.1.0 (INTERNAL DRAFT — not published, not submitted)
 Status: Draft for future OWASP AISVS Informative Reference / PR basis (human review gate before any upstream submission)
 Date: 2026-06-12
 Editor: Adam Lin (林冠辛) <adam@agentthreatrule.org>
-Mapped corpus: Agent Threat Rules v3.5.8 (747 rules / 10 categories, disk==stats.json verified 2026-07-12)
+Mapped corpus: Agent Threat Rules v3.5.8 (780 rules / 10 categories, disk==stats.json verified 2026-07-12)
 Reference framework: OWASP AI Security Verification Standard (AISVS) 1.0, chapters C9, C10, C13
 Reference framework license: CC BY-SA 4.0 (OWASP/AISVS README). Requirement text
 quoted below is reproduced under that license; this mapping is a derivative

--- a/docs/OWASP-AIVSS-MAPPING.md
+++ b/docs/OWASP-AIVSS-MAPPING.md
@@ -1,7 +1,7 @@
 # ATR -> OWASP AIVSS (AI Vulnerability Scoring System) Mapping
 
 Last updated: 2026-07-12
-ATR version: v3.5.8 (747 rules)
+ATR version: v3.5.8 (780 rules)
 OWASP framework: AIVSS v0.8 (March 2026) — OWASP Agentic AI Core Security Risks
 
 ## What this maps, and what it does not

--- a/docs/OWASP-AST10-MAPPING.md
+++ b/docs/OWASP-AST10-MAPPING.md
@@ -1,7 +1,7 @@
 # ATR → OWASP Agentic Skills Top 10 (AST10) Mapping
 
 Last updated: 2026-07-12 (corpus re-stamp v3.5.2->v3.5.8)
-ATR corpus: v3.5.8, 747 rules (10 categories, including skill-compromise)
+ATR corpus: v3.5.8, 780 rules (10 categories, including skill-compromise)
 OWASP framework: Agentic Skills Top 10 (AST10), March 2026
 
 > Coverage note: the per-category ATR rule citations below were last fully

--- a/docs/SAFE-MCP-MAPPING.md
+++ b/docs/SAFE-MCP-MAPPING.md
@@ -1,7 +1,7 @@
 # ATR → SAFE-MCP Technique Mapping
 
 Last updated: 2026-07-12 (corpus re-stamp v3.5.2->v3.5.8)
-ATR corpus: v3.5.8, 747 rules (10 categories)
+ATR corpus: v3.5.8, 780 rules (10 categories)
 SAFE-MCP version: latest (85 techniques, 47 mitigations)
 
 > Coverage note: the per-technique ATR rule citations in this document were last

--- a/rules/prompt-injection/ATR-2026-00089-polymorphic-skill.yaml
+++ b/rules/prompt-injection/ATR-2026-00089-polymorphic-skill.yaml
@@ -104,10 +104,18 @@ detection:
     # static audit cannot see it, so the generation branch keeps only generation
     # verbs; a deferred-LOAD branch survives for the unambiguous attack nouns,
     # where "lazy load the payload" still means what it says.
+    #   3. `skill` and `function` are dropped from the generation branch. Agent
+    #      orchestration documents legitimately describe spawning sub-agents
+    #      "with dynamically generated SKILL.md files" -- generating a skill is
+    #      what an orchestrator DOES. The evasion signal lives in what is being
+    #      built, and payload / shellcode / code / script carry it; skill does
+    #      not. Found by ninja-008-agent-orchestrator.md, one of 35 benign
+    #      samples that sat in a subdirectory the FP gate's non-recursive corpus
+    #      loader never opened.
     - field: user_input
       operator: regex
       value: >-
-        (?i)\b(?:(?:dynamic(?:ally)?|runtime|on.?the.?fly)\s+(?:generat|compil|creat|build|assembl|construct|synthesi)\w*\s+.{0,20}\b(?:payload|shellcode|code|script|skill|function)\b|(?:dynamic(?:ally)?|runtime|lazy|deferred|on.?demand)\s+(?:load|fetch|retriev|download|pull)\w*\s+.{0,20}\b(?:payload|shellcode)\b)
+        (?i)\b(?:(?:dynamic(?:ally)?|runtime|on.?the.?fly)\s+(?:generat|compil|creat|build|assembl|construct|synthesi)\w*\s+.{0,20}\b(?:payload|shellcode|code|script)\b|(?:dynamic(?:ally)?|runtime|lazy|deferred|on.?demand)\s+(?:load|fetch|retriev|download|pull)\w*\s+.{0,20}\b(?:payload|shellcode)\b)
       description: Runtime generation of code, or deferred loading of a payload, to evade static analysis
   condition: any
   false_positives:

--- a/scripts/gate-promotion-fp.ts
+++ b/scripts/gate-promotion-fp.ts
@@ -335,14 +335,32 @@ function matchedRuleIds(engine: ATREngine, text: string): ReadonlySet<string> {
   return matched;
 }
 
+/**
+ * Every corpus file under a path, INCLUDING subdirectories.
+ *
+ * This walk used to be one level deep. `data/skill-benchmark/benign` holds 466
+ * committed samples, 35 of which live in `ninja-legit/` — so the gate loaded 431
+ * and reported the other 35 as clean by never opening them. That is the same
+ * disease as a narrow event shape: not a wrong answer, an unasked question. A
+ * sample that is committed to a benign corpus is a sample the gate has to read,
+ * and a subdirectory must never be able to hide one.
+ */
+function collectCorpusFiles(dir: string): readonly string[] {
+  const out: string[] = [];
+  for (const e of readdirSync(dir)) {
+    const full = join(dir, e);
+    if (statSync(full).isDirectory()) out.push(...collectCorpusFiles(full));
+    else if (e.endsWith(".jsonl") || e.endsWith(".md")) out.push(full);
+  }
+  return out;
+}
+
 function loadCorpusTexts(pathStr: string): readonly string[] {
   const texts: string[] = [];
   if (!existsSync(pathStr)) return texts;
   const files: string[] = [];
-  if (statSync(pathStr).isDirectory()) {
-    for (const e of readdirSync(pathStr))
-      if (e.endsWith(".jsonl") || e.endsWith(".md")) files.push(join(pathStr, e));
-  } else files.push(pathStr);
+  if (statSync(pathStr).isDirectory()) files.push(...collectCorpusFiles(pathStr));
+  else files.push(pathStr);
   for (const f of files) {
     let raw: string;
     try {

--- a/scripts/sync-stats.ts
+++ b/scripts/sync-stats.ts
@@ -18,7 +18,7 @@ const REPO_ROOT = join(__dirname, '..');
 interface Stats {
   version: string;
   lastUpdated: string;
-  ruleCount: { total: number; stable: number; experimental: number; draft: number };
+  ruleCount: { total: number; effective?: number; stable: number; experimental: number; draft: number };
   spec: { version: string; status: string; doi: string };
   benchmarks: {
     garak: { recall: number; samples: number };
@@ -97,7 +97,10 @@ function syncCitation(s: Stats): SyncResult {
     let out = text;
     out = out.replace(/^version: ".*"$/m, `version: "${s.version}"`);
     out = out.replace(/^date-released: ".*"$/m, `date-released: "${s.lastUpdated}"`);
-    out = out.replace(/\b\d{2,4} rules across \d+ threat\b/, `${s.ruleCount.total} rules across 10 threat`);
+    // effective, not total: `total` counts rule FILES, and src/engine.ts skips
+    // status: draft | deprecated before the lane gate, so those rules fire in no
+    // lane at all. Citing the file count overstates what the engine runs.
+    out = out.replace(/\b\d{2,4} rules across \d+ threat\b/, `${s.ruleCount.effective ?? s.ruleCount.total} rules across 10 threat`);
     out = out.replace(/\(\d+\.\d+% recall on the\b/, `(${s.benchmarks.garak.recall}% recall on the`);
     out = out.replace(/garak in-the-wild jailbreak benchmark, \d+ prompts\)/, `garak in-the-wild jailbreak benchmark, ${s.benchmarks.garak.samples} prompts)`);
     out = out.replace(/on a \d+-sample benign corpus/, `on a ${s.benchmarks.benign.samples}-sample benign corpus`);
@@ -105,15 +108,28 @@ function syncCitation(s: Stats): SyncResult {
   });
 }
 
-function syncPackageJson(s: Stats): SyncResult {
-  return syncFile('package.json', (text) => {
-    let out = text;
-    out = out.replace(/"description": "[^"]*"/, (m) => {
-      const newDesc = `Open detection standard -- like Sigma, but for AI agents. ${s.ruleCount.total} rules for prompt injection, tool poisoning, context exfiltration, and MCP attacks. Shipped in Cisco AI Defense. ${s.benchmarks.garak.recall}% recall on NVIDIA garak.`;
-      return `"description": ${JSON.stringify(newDesc)}`;
-    });
-    return out;
-  });
+/**
+ * The npm package description is deliberately NOT synced.
+ *
+ * It used to be rebuilt here from `ruleCount.total` and `benchmarks.garak.recall`,
+ * which looks like freshness and is the opposite. A description only reaches the
+ * world when a version is published; between publishes npm keeps serving whatever
+ * the last publish carried, so the numbers on the registry page were pinned to an
+ * arbitrary past release while this file kept "correcting" them locally. The
+ * registry listing spent months advertising 751 rules and 97.2% garak recall
+ * against a corpus that had grown to 780 and a figure honestly re-measured down
+ * to 91.5%.
+ *
+ * #411 removed the numbers from the description for that reason. This function
+ * existed to put them back on the next run — which is why it is now a no-op
+ * rather than deleted: an empty implementation with this comment is harder to
+ * reintroduce by accident than an absent one.
+ *
+ * Numbers belong where they can be regenerated on read: the README badges,
+ * stats.json, and the site. Not in a string frozen at publish time.
+ */
+function syncPackageJson(_s: Stats): SyncResult {
+  return { file: 'package.json', changed: false, ops: ['skip: description is intentionally number-free, see #411'] };
 }
 
 function syncQuickStart(s: Stats): SyncResult {

--- a/stats.json
+++ b/stats.json
@@ -1,6 +1,6 @@
 {
   "$comment": "Single source of truth for ATR project numbers. Any user-facing surface (README, CITATION.cff, panguard.ai, docs site, schema.org JSON-LD, Zenodo metadata) MUST read from this file via scripts/sync-stats.ts. Hand-edits to derived files will be overwritten on next sync. Bump version + ruleCount here, then run `npm run sync:stats`. CI does this automatically on rules-merge release. ruleCount.total counts files matching `^id: ATR-` (excludes drafts/templates); CI in publish-on-rules-merge.yml uses the identical method to avoid drift.",
-  "version": "3.5.9",
+  "version": "3.5.11",
   "previousVersion": "3.5.8",
   "lastUpdated": "2026-07-13",
   "ruleCount": {


### PR DESCRIPTION
Four defects, one theme: a number was being maintained in a place where it could not stay true, and nothing checked.

## 1. The FP gate read 431 of 466 benign samples

`loadCorpusTexts` walked one level deep. `data/skill-benchmark/benign` holds 466 committed samples, 35 of them in `ninja-legit/`. The gate loaded 431 and scored the other 35 clean **by never opening them**.

This is the same disease as a narrow event shape: not a wrong answer, an unasked question. Corpus **5,317 -> 5,352**.

### It found a live false positive immediately

**ATR-2026-00089 was revived in #415 two hours ago on a measured FP=0.** On the full corpus it has 1 FP:

```
ninja-008-agent-orchestrator.md
"...spawns specialized sub-agents with dynamically generated SKILL.md files..."
                                       ^^^^^^^^^^^ ^^^^^^^^^          ^^^^^
                                       dynamic  +  generat  +  skill
```

A real false positive, sitting in an unread subdirectory the whole time.

Fixed by dropping `skill` and `function` from the generation branch's noun group. **Generating a skill is what an orchestrator does** — the evasion signal lives in *what is being built*, and `payload` / `shellcode` / `code` / `script` carry it. All 7 declared true positives still fire:

```
ATR-2026-00089: test_cases 15 pass / 0 fail (TP=7, TN=8)
gate-promotion-fp (00080, 00089, 00091): clean = 3 · dirty = 0 on 5,352 samples
```

### And a reassuring result

Re-measured **every** enforce-lane rule against the fuller corpus while here:

```
106 stable rules · clean = 106 · dirty = 0
```

The enforce lane is genuinely clean, not clean-by-omission.

## 2. `sync-stats.ts` would have undone #411 on its next run

`syncPackageJson` rebuilt the npm description from `ruleCount.total` and `benchmarks.garak.recall` every run. **#411 removed those numbers two hours ago; the next sync puts them straight back.**

The deeper reason the numbers do not belong there: a package description only reaches the world at publish time. Between publishes npm serves whatever the last publish froze, so the registry listing was pinned to an arbitrary past release while this script kept "correcting" it locally — advertising 751 rules and 97.2% garak recall against a corpus that had grown to 780 and a figure honestly re-measured down to 91.5%.

Now a **documented no-op** rather than a deletion. An empty implementation carrying the explanation is harder to reintroduce by accident than an absent one.

## 3. CITATION.cff said 751 rules and 97.2% garak recall

`sync-stats.ts` already knows how to fix that file. But `reconcile-stats.yml` updates `stats.json` **daily** and never runs the propagation step — so the source of truth was corrected every day while **15 derived files stayed frozen**. Fixing the source is only half the fix.

Wired `sync-stats` into that job and widened its commit scope to the files it touches.

CITATION.cff now reads **773 rules** and **91.5%**. Note 773, not the 780 file count: `src/engine.ts` skips `status: draft | deprecated` before the lane gate, so citing the file count overstates what the engine actually runs. `syncCitation` now uses `ruleCount.effective`.

## 4. Version drift

`stats.json` carried `3.5.9` while `package.json` was at `3.5.11` — the manual publish path bumps one and not the other. Set to match.

## Gates

```
validate-rules              780 passed, 0 failed
gate-promotion-fp (106 stable)  clean = 106 · dirty = 0   [5,352 samples]
gate-rule-status            PASS
corpus-event-shapes + gate-promotion-fp tests   69 passed
sync-stats                  OK · version=3.5.11 · rules=780
```
