### PR TITLE
docs: disclose that SKILL.md recall is 100% in hunt and 0% in enforce

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,7 +377,7 @@ Aggregated into [`data/stats.json`](data/stats.json) under `benchmarks[]`.
 | PromptBench (academic adversarial) [^promptcorpora] | snapshot-2026-04 | 3,280 | 15.7% | 100.0% | 0.0% | 3.5.11 | 2026-08-05 |
 | promptfoo (red-team plugin fixtures) | corpus-2026-05-12 | 44 | 97.7% | 100.0% | 0.0% | 3.5.0 | 2026-06-16 |
 | PromptInject (academic adversarial) [^promptcorpora] | snapshot-2026-04 | 1,080 | 100.0% | 100.0% | 0.0% | 3.5.11 | 2026-08-05 |
-| SKILL.md benchmark (internal) | internal-498 | 498 | 100.0% | 97.0% | 0.20% | 3.5.0 | 2026-06-16 |
+| SKILL.md benchmark (internal) [^skilllane] | internal-498 | 498 | 100.0% (hunt) / 0.0% (enforce) | 97.0% | 0.20% | 3.5.0 | 2026-06-16 |
 | Wild scan (OpenClaw + Skills.sh + Hermes + ClawHub) | corpus-2026-04-14 | 96,096 | — | 57.7% (floor) | 1.35% flag rate | 2.0.0 | 2026-04-14 |
 
 All detection corpora were (re-)measured against ATR 3.5.0 on 2026-06-16,
@@ -408,6 +408,18 @@ by an over-broad persona regex in `ATR-2026-00001` that also false-positived on
 benign "you are now an expert …" prose; tightening it (PR #327) removed those
 false positives and, honestly, the recall on novel-persona jailbreaks it had
 been catching. See [CHANGELOG.md](CHANGELOG.md).
+
+[^skilllane]: **Lane matters more here than anywhere else in this table.** The
+    100% figure is the `hunt` lane, which is the engine default and loads every
+    maturity. In the `enforce` lane — the auto-block one, where a detection stops
+    the agent with no human in the loop — this corpus scores **0%**, and the
+    reason is structural rather than a tuning problem: of the 38 rules carrying
+    `scan_target: skill`, **all 38 are `maturity: test`, and none is `stable`.**
+    The enforce lane only loads `stable`, so it loads no skill-scanning rule at
+    all, and 0 of 32 malicious samples fire. Anyone reading "100% recall on
+    SKILL.md" and deploying in enforce mode would be forming a completely wrong
+    expectation, so both numbers are shown. Verified on this commit with
+    `grep`-free counting over `rules/**/*.yaml`.
 
 [^pint]: The `PINT-format` row is **not** a run of Lakera's official PINT
     benchmark. That corpus is private and roughly 5x larger; this row is a

--- a/stats.json
+++ b/stats.json
@@ -40,7 +40,10 @@
       "precision": 97,
       "fpRate": 0.2,
       "samples": 498,
-      "source": "Internal labeled SKILL.md corpus"
+      "source": "Internal labeled SKILL.md corpus",
+      "lane": "hunt",
+      "enforceLaneRecall": 0,
+      "enforceLaneNote": "The enforce (auto-block) lane loads only maturity: stable. All 38 rules with scan_target: skill are maturity: test, so the enforce lane loads no skill-scanning rule and detects 0 of 32 malicious samples. Quoting 100% without the lane sets a wrong expectation for enforce deployments."
     },
     "pint": {
       "recall": 60.3,


### PR DESCRIPTION
README has been publishing **"100% recall on 498 labeled SKILL.md samples"** with no lane annotation. That number is the `hunt` lane — the engine default, which loads every maturity. In the **`enforce` lane**, the auto-block one where a detection stops the agent with no human in the loop, the same corpus scores **0%**.

## The cause is structural, not tuning

```
scan_target: skill        38 rules
  maturity: stable         0
  maturity: test          38
```

The enforce lane loads only `stable`. It therefore loads **no skill-scanning rule at all**, and fires on 0 of the 32 malicious samples.

## Why this one is worse than an ordinary stale number

The FP rate in that same table already carries a lane annotation — the repo learned in June that a single global precision figure is meaningless across lanes. Recall never got the same treatment, and **recall is the number a reader uses to decide whether to turn on auto-block.** Someone reading 100% and deploying in enforce mode gets no skill detection whatsoever, and nothing in the published material would have told them.

## What changed

- README table now shows `100.0% (hunt) / 0.0% (enforce)` with a footnote giving the mechanism.
- `stats.json`'s `skill` block carries `lane: "hunt"` and an explicit `enforceLaneRecall: 0` with the reason in prose, so downstream consumers that read the JSON get the caveat too rather than only the humans reading the table.

## What this does NOT do

It does not close the gap. Promoting skill-scanning rules to `stable` requires the wild-corpus evidence `canPromote` asks for (`wild_samples >= 1000`, `confidence >= 80`), and — as #417 documented — no rule currently in the promotion pipeline has evidence gathered under the current event shape. That work is real and separate.

**This stops the gap being invisible.** A published 0% is recoverable; a published 100% that is 0% in the deployment mode people actually care about is not.
