### PR TITLE
feat(rules): detect evasion of EU AI Act Article 50(2) synthetic-content marking

### DIFF
--- a/docs/crosswalks/atr-ast-crosswalk.md
+++ b/docs/crosswalks/atr-ast-crosswalk.md
@@ -11,13 +11,13 @@ This is a **curated thematic mapping**, not an id-equality join. ATR carries no 
 
 Regenerate with `python3 scripts/generate-ast-crosswalk.py`. CI runs `--check` so a stale copy fails the build.
 
-Rules in corpus at generation time: **780**.
+Rules in corpus at generation time: **783**.
 
 ## Coverage by AST control
 
 | AST | Title | ATR rules | Top supporting ASI (evidence) |
 |-----|-------|-----------|-------------------------------|
-| AST01 | Malicious Skills | 194 | ASI01 (57), ASI05 (51), ASI04 (48) |
+| AST01 | Malicious Skills | 197 | ASI01 (57), ASI05 (51), ASI04 (48) |
 | AST02 | Supply Chain Compromise | 54 | ASI04 (21), ASI01 (12), ASI05 (9) |
 | AST03 | Over-Privileged Skills | 224 | ASI01 (92), ASI03 (88), ASI06 (39) |
 | AST04 | Insecure Metadata | 110 | ASI05 (42), ASI06 (34), ASI04 (28) |
@@ -41,7 +41,7 @@ Rules in corpus at generation time: **780**.
 | privilege-escalation (62) | 62 | AST03 Over-Privileged Skills | Privilege escalation is the direct consequence of over-privileged skills. |
 | skill-compromise (44) | 44 | AST01 Malicious Skills | A compromised skill is a malicious skill. |
 |  |  | AST02 Supply Chain Compromise | Skill compromise via a tampered upstream is supply-chain compromise. |
-| model-abuse (40) | 40 | AST01 Malicious Skills | Coercing the model into attacker-chosen behaviour manifests as a malicious skill action. |
+| model-abuse (43) | 43 | AST01 Malicious Skills | Coercing the model into attacker-chosen behaviour manifests as a malicious skill action. |
 | excessive-autonomy (37) | 37 | AST03 Over-Privileged Skills | Unbounded action authority is an over-privilege condition. |
 |  |  | AST09 No Governance | Autonomy without checks is the AST09 governance gap. |
 | data-poisoning (10) | 10 | AST02 Supply Chain Compromise | Poisoned training/reference data enters through the supply chain. |

--- a/docs/crosswalks/atr-attack-crosswalk.md
+++ b/docs/crosswalks/atr-attack-crosswalk.md
@@ -28,12 +28,12 @@ columns are still extracted from ATR metadata, not authored here.
 
 ## Coverage
 
-- ATR rules total: 780
-- Rules carrying an enterprise ATT&CK id (`references.mitre_attack` Txxxx): 194
-- Distinct enterprise ATT&CK techniques referenced: 79
-- Rules carrying a MITRE ATLAS id (`references.mitre_atlas`): 780
+- ATR rules total: 783
+- Rules carrying an enterprise ATT&CK id (`references.mitre_attack` Txxxx): 197
+- Distinct enterprise ATT&CK techniques referenced: 80
+- Rules carrying a MITRE ATLAS id (`references.mitre_atlas`): 783
 - Distinct MITRE ATLAS techniques referenced: 42
-- Rules carrying an OWASP Agentic id (`references.owasp_agentic`): 780
+- Rules carrying an OWASP Agentic id (`references.owasp_agentic`): 783
 - ATR categories (distinct `tags.category` values): 9
 
 Categories are keyed on each rule's `tags.category` metadata, not on its
@@ -50,7 +50,7 @@ against.
 | ATT&CK technique | Name | ATR rules | ATR categories |
 |---|---|---|---|
 | T1005 | Data from Local System | `ATR-2026-01988`, `ATR-2026-02250` | context-exfiltration |
-| T1027 | Obfuscated Files or Information | `ATR-2026-00535`, `ATR-2026-02004`, `ATR-2026-02006`, `ATR-2026-02010`, `ATR-2026-02016`, `ATR-2026-02018`, `ATR-2026-02374` | prompt-injection |
+| T1027 | Obfuscated Files or Information | `ATR-2026-00535`, `ATR-2026-02004`, `ATR-2026-02006`, `ATR-2026-02010`, `ATR-2026-02016`, `ATR-2026-02018`, `ATR-2026-02374`, `ATR-2026-02411`, `ATR-2026-02412`, `ATR-2026-02413` | model-abuse, prompt-injection |
 | T1036 | Masquerading | `ATR-2026-00117`, `ATR-2026-00204`, `ATR-2026-00572`, `ATR-2026-01932`, `ATR-2026-02350` | agent-manipulation, privilege-escalation, tool-poisoning |
 | T1036.005 | Masquerading: Match Legitimate Name or Location | `ATR-2026-02410` | skill-compromise |
 | T1036.008 | Masquerading: Masquerade File Type | `ATR-2026-02405` | skill-compromise |
@@ -66,6 +66,7 @@ against.
 | T1059.006 | Python | `ATR-2026-00432`, `ATR-2026-00440`, `ATR-2026-00539`, `ATR-2026-00544`, `ATR-2026-01935`, `ATR-2026-02101`, `ATR-2026-02145`, `ATR-2026-02408` | agent-manipulation, data-poisoning, privilege-escalation, tool-poisoning |
 | T1059.007 | JavaScript | `ATR-2026-00415`, `ATR-2026-00436` | privilege-escalation, tool-poisoning |
 | T1068 | Exploitation for Privilege Escalation | `ATR-2026-00417`, `ATR-2026-01933`, `ATR-2026-01934`, `ATR-2026-01981`, `ATR-2026-02407` | agent-manipulation, privilege-escalation |
+| T1070 | Indicator Removal | `ATR-2026-02411` | model-abuse |
 | T1070.004 | Indicator Removal on Host: File Deletion | `ATR-2026-00858` | context-exfiltration |
 | T1071 | Application Layer Protocol | `ATR-2026-00010`, `ATR-2026-00013`, `ATR-2026-00212` | context-exfiltration, tool-poisoning |
 | T1071.003 | Application Layer Protocol: Mail Protocols | `ATR-2026-02401` | excessive-autonomy |
@@ -245,17 +246,19 @@ OWASP Agentic categories ATR adds: ASI01:2026, ASI02:2026, ASI03:2026, ASI04:202
 
 ### model-abuse
 
-Rules in category: 40
+Rules in category: 43
 
 ATT&CK techniques (join key):
 
 | ATT&CK technique | Name | ATR rules |
 |---|---|---|
+| T1027 | Obfuscated Files or Information | `ATR-2026-02411`, `ATR-2026-02412`, `ATR-2026-02413` |
 | T1059 | Command and Scripting Interpreter | `ATR-2026-00433` |
+| T1070 | Indicator Removal | `ATR-2026-02411` |
 | T1195.002 | Compromise Software Supply Chain | `ATR-2026-00433` |
 | T1587.001 | Develop Capabilities: Malware | `ATR-2026-02211` |
 
-ATLAS techniques ATR adds: AML.T0010, AML.T0011.000, AML.T0024, AML.T0040, AML.T0044, AML.T0046, AML.T0048, AML.T0051, AML.T0057, AML.T0102
+ATLAS techniques ATR adds: AML.T0010, AML.T0011.000, AML.T0024, AML.T0040, AML.T0044, AML.T0046, AML.T0048, AML.T0051, AML.T0054, AML.T0057, AML.T0102
 
 OWASP Agentic categories ATR adds: ASI01:2026, ASI04:2026, ASI05:2026, ASI08:2026
 

--- a/rules/model-abuse/ATR-2026-02411-ai-provenance-metadata-stripping.yaml
+++ b/rules/model-abuse/ATR-2026-02411-ai-provenance-metadata-stripping.yaml
@@ -1,0 +1,262 @@
+title: "Targeted Stripping of C2PA / IPTC AI-Provenance Metadata from Generated Media"
+id: ATR-2026-02411
+rule_version: 1
+status: experimental
+description: >
+  Detects an agent performing targeted removal of the machine-readable
+  provenance markings that identify media as artificially generated: deletion
+  of the JUMBF/CBOR container holding a C2PA manifest, blanking of the IPTC
+  `DigitalSourceType` field (whose AI value is the URI ending
+  `trainedAlgorithmicMedia`), or blanking of the PNG `parameters` / XMP
+  generation fields written by diffusion tooling. The signal is
+  SELECTIVITY. An attacker who wants a file to pass as camera-original does
+  not run a blanket wipe — a blanket wipe is itself conspicuous. They delete
+  only the provenance group and leave EXIF, GPS and the ICC profile intact,
+  producing a file that looks ordinary in every viewer while carrying no
+  trace of having been generated. This rule therefore deliberately does NOT
+  cover generic metadata clearing (`-all=`, `-gps:all=`, ImageMagick
+  `-strip`, `ffmpeg -map_metadata -1`): those are the daily tools of
+  photographers protecting sources, of privacy workflows, and of image
+  optimisation CI, and matching them would punish the legitimate majority to
+  catch the rare attacker. Two further layers cover the paths that leave no
+  suspicious command string at all — platform re-upload, canvas redraw,
+  online removal services — by matching the stated intent instead.
+  Scope limit stated plainly: every technique here removes only the METADATA
+  layer. Pixel-domain watermarks (SynthID, TrustMark) survive all of it and
+  are covered by ATR-2026-02412. Stripped metadata does not mean provenance
+  is unrecoverable.
+author: "ATR Community"
+date: "2026/08/05"
+schema_version: "0.1"
+detection_tier: pattern
+maturity: test
+severity: medium
+
+references:
+  owasp_llm:
+    - "LLM09:2025 - Misinformation"
+  owasp_agentic:
+    - "ASI08:2026 - Output Handling"
+  mitre_atlas:
+    - "AML.T0054 - LLM Jailbreak"
+  mitre_attack:
+    - "T1070.009 - Indicator Removal: Clear Persistence"
+    - "T1027 - Obfuscated Files or Information"
+  cwe:
+    - "CWE-345"
+  external:
+    - "https://exiftool.org/"
+    - "https://spec.c2pa.org/specifications/specifications/2.1/specs/C2PA_Specification.html"
+    - "https://cv.iptc.org/newscodes/digitalsourcetype/"
+
+compliance:
+  eu_ai_act:
+    - article: "50"
+      context: >
+        Article 50(2) requires providers of AI systems generating synthetic
+        audio, image, video or text to mark the output in a machine-readable
+        format, and requires that marking to be 'effective, interoperable,
+        robust and reliable as far as this is technically feasible'. Read the
+        boundary precisely: 50(2) places a marking duty on the PROVIDER and
+        contains no prohibition on a third party removing a marking. This rule
+        therefore does not detect a breach of 50(2). What it detects is
+        targeted destruction of exactly the marking 50(2) mandates, which is
+        runtime evidence bearing on whether the robustness condition in that
+        paragraph actually holds in deployment.
+      strength: primary
+    - article: "15"
+      context: >
+        Article 15 requires accuracy, robustness and cybersecurity. An agent
+        that can be steered into erasing content-authenticity metadata is an
+        integrity failure of the deployed system, and detection of the attempt
+        is the evidence Article 15 conformity assessment needs.
+      strength: primary
+    - article: "9"
+      context: >
+        Facilitating removal of content-provenance markings is a foreseeable
+        misuse risk that the Article 9 risk management system must identify and
+        treat.
+      strength: secondary
+  nist_ai_rmf:
+    - subcategory: "MP.5.1"
+      context: >
+        Instructions to strip AI-provenance metadata are adversarial inputs that
+        MP.5.1 requires to be identified and tracked.
+      strength: primary
+    - subcategory: "MS.2.6"
+      context: >
+        MEASURE 2.6 safety evaluation is supported by runtime detection of
+        attempts to defeat content-authenticity marking.
+      strength: secondary
+  iso_42001:
+    - clause: "8.1"
+      context: >
+        ISO/IEC 42001 Clause 8.1 operational control over an agent action that
+        destroys content-provenance evidence.
+      strength: primary
+
+tags:
+  category: model-abuse
+  subcategory: ai-provenance-metadata-stripping
+  scan_target: both
+  confidence: medium
+
+agent_source:
+  type: tool_call
+  framework: [any]
+  provider: [any]
+
+detection:
+  condition: any
+  method: pattern
+  false_positives:
+    - "Photojournalists and human-rights workers removing GPS to protect a source (`exiftool -gps:all=`). Same tool, same syntax family — this rule is scoped to provenance group names and never matches gps or a blanket wipe."
+    - "Legal or compliance de-identification and pre-press cleaning (`exiftool -all= file.pdf`). The bare `-all=` flag is deliberately NOT matched by any layer."
+    - "C2PA verification and diagnostic tooling: `exiftool -jumbf:all -G3 -b -j -u -struct`, `c2patool inspect`, `c2pa.Reader.from_file()`. ExifTool's READ syntax has no trailing `=`; every artifact layer here requires the `=` that makes it a delete."
+    - "Image optimisation CI: `convert -strip`, `mogrify -strip`, `jpegoptim --strip-all`, `optipng -strip all`. Not covered — imagemin ships `-strip all` by default and the developer never typed it."
+    - "Node.js sharp strips metadata unless `.withMetadata()` is called, and Pillow drops EXIF unless `exif=` is passed. Behaviourally equivalent to stripping, but the artifact is an ABSENCE and regex cannot match an absence. Not covered by design."
+    - "CDN image layers (Cloudflare Polish, Cloudflare Images `metadata=copyright`) strip on delivery as infrastructure default, not as anyone's decision."
+    - "mat2 and the Tails/Whonix privacy workflow. mat2 is deliberately not treated as an indicator — it is the standard privacy tool of an entire community."
+    - "FFmpeg transcode normalisation and reproducible builds (`-map_metadata -1`, `-fflags +bitexact`). Not covered."
+    - "Legitimate C2PA authoring projects using `c2patool --sidecar` / `--remote`."
+    - "Security education, detection-vendor documentation and standards commentary that enumerate these techniques will match the intent layers (4 and 5). A pattern matcher cannot separate teaching from doing."
+  conditions:
+    # -- Layer 1: exiftool deletion of the JUMBF / C2PA / CBOR group --
+    # Real payload: exiftool -jumbf:all= -overwrite_original render.jpg
+    # ExifTool's own docs: C2PA "may be Deleted ... by deleting the JUMBF group
+    # (ie. -JUMBF:all=)". Read syntax is `-jumbf:all` with NO trailing `=`;
+    # delete syntax has it. That `=` is the single character separating
+    # inspection from destruction, so the layer requires it.
+    - field: content
+      operator: regex
+      value: "(?i)-\\s*(?:jumbf|c2pa|cbor)\\s*:\\s*all\\s*="
+      description: "Deletion of the JUMBF/C2PA/CBOR metadata group — the container a C2PA manifest lives in. Nothing but content credentials is stored there, so naming this group specifically is not incidental to a privacy wipe"
+
+    # -- Layer 2: blanking the IPTC/XMP DigitalSourceType field --
+    # Real payload: exiftool "-XMP-iptcExt:DigitalSourceType=" -overwrite_original out.jpg
+    # DigitalSourceType is the ONE standard field that declares content as AI
+    # generated (value trainedAlgorithmicMedia). `=` followed by whitespace,
+    # end of string or a shell delimiter means blank it; `=http://cv.iptc.org/...`
+    # is a WRITE and is excluded because `h` is not in the trailing class.
+    - field: content
+      operator: regex
+      value: "(?i)-\\s*(?:iptc|xmp)[\\w:.-]{0,24}:digitalsourcetype\\s*=(?:\\s|$|[\"';&|])"
+      description: "Blanking IPTC DigitalSourceType, the standard field carrying the trainedAlgorithmicMedia marker. Writing the field is excluded; only clearing it matches"
+
+    # -- Layer 3: blanking diffusion-tool generation parameters --
+    # Real payload: exiftool -PNG:parameters= -XMP:prompt= -overwrite_original gen.png
+    # These fields are written only by Stable Diffusion / ComfyUI style tools.
+    # There is no privacy argument for clearing them — the content is the
+    # operator's own prompt — leaving "erase the evidence of generation" as
+    # the only reading.
+    - field: content
+      operator: regex
+      value: "(?i)-\\s*(?:png(?:-text)?:parameters|xmp:(?:prompt|negativeprompt|aiprompt|cfgscale|steps|sampler|scheduler|lora|controlnet|vae))\\s*=(?:\\s|$|[\"';&|-])"
+      description: "Clearing PNG `parameters` or XMP generation fields written by diffusion tooling — removal of the record that the asset was synthesised"
+
+    # -- Layer 4: stated intent to remove provenance (covers artifact-free paths) --
+    # Real payload: "Strip the C2PA manifest from each render before we post it."
+    # Needed because platform re-upload, canvas redraw, screenshotting and a
+    # missing sharp .withMetadata() all destroy provenance while emitting no
+    # suspicious string. Only the intent is observable.
+    - field: content
+      operator: regex
+      value: "(?i)\\b(?:remov|strip|delet|eras|scrub|wipe|bypass|circumvent|suppress)\\w*\\b[\\s\\S]{0,60}\\b(?:c2pa|content credentials?|jumbf|provenance manifest|digitalsourcetype|trainedalgorithmicmedia)\\b"
+      description: "Removal verb within 60 characters of a content-provenance noun — catches the paths that leave no command-line artifact. The narrow window suppresses accidental cross-sentence pairing"
+
+    # -- Layer 5: stated intent to defeat a platform AI-content label --
+    # Real payload: "strip the AI-generated label so Instagram does not flag the upload"
+    - field: content
+      operator: regex
+      value: "(?i)\\b(?:remove|strip|erase|bypass|hide)\\b[\\s\\S]{0,40}\\b(?:ai[- ]generated (?:label|tag|marker|badge)|made with ai (?:label|tag)|ai (?:content )?credentials?)\\b"
+      description: "Stated intent to defeat a platform's AI-content label — the observable signal for re-upload and remux laundering"
+
+    # -- Layer 6: URL path of a provenance-removal service --
+    # Real payload: https://example.com/c2pa-metadata-remover
+    # Deliberately a PATH pattern, not a domain allowlist: these services churn
+    # constantly, and naming specific domains in a public standard asserts a
+    # claim about a named business that this repo has not individually verified.
+    - field: content
+      operator: regex
+      value: "(?i)/(?:c2pa|content-credentials?|ai|synthid)[a-z0-9-]{0,24}(?:metadata|watermark|credential)s?-remover\\b"
+      description: "URL path advertising a provenance or watermark removal service. Matched by naming pattern rather than domain list so the layer survives domain churn and asserts nothing about any specific named business"
+
+response:
+  actions: [alert]
+  message_template: "[ATR-2026-02411] Targeted removal of AI-provenance metadata detected (C2PA/JUMBF group, IPTC DigitalSourceType, or diffusion generation fields). Metadata-layer only — pixel-domain watermarks are unaffected."
+
+test_cases:
+  true_positives:
+    - input: |-
+        exiftool -jumbf:all= -overwrite_original render.jpg
+      expected: triggered
+      description: "Deleting only the JUMBF group, leaving camera EXIF intact"
+    - input: |-
+        exiftool -JUMBF:all= -C2PA:all= -CBOR:all= -overwrite_original image.png
+      expected: triggered
+      description: "All three C2PA-bearing groups cleared in one call"
+    - input: |-
+        exiftool "-XMP-iptcExt:DigitalSourceType=" -overwrite_original out.jpg
+      expected: triggered
+      description: "Blanking the IPTC field that declares the asset AI-generated"
+    - input: |-
+        exiftool -PNG:parameters= -XMP:prompt= -XMP:negativeprompt= -overwrite_original gen.png
+      expected: triggered
+      description: "Clearing Stable Diffusion generation parameters"
+    - input: |-
+        Strip the C2PA manifest from each render before we post it.
+      expected: triggered
+      description: "Stated intent, no command artifact"
+    - input: |-
+        remove content credentials from these Sora clips so nothing links back
+      expected: triggered
+      description: "Intent layer on video output"
+    - input: |-
+        strip the AI-generated label so Instagram does not flag the upload
+      expected: triggered
+      description: "Platform label evasion"
+    - input: |-
+        POST each file to https://cleanpix.example/c2pa-metadata-remover and download the result
+      expected: triggered
+      description: "Removal-service URL path"
+  true_negatives:
+    - input: |-
+        exiftool -gps:all= photo.jpg   # remove location before publishing
+      expected: not_triggered
+      description: "Source protection — deliberately out of scope"
+    - input: |-
+        exiftool -all= -overwrite_original scan.pdf
+      expected: not_triggered
+      description: "Blanket wipe for de-identification — deliberately out of scope"
+    - input: |-
+        exiftool -jumbf:all -G3 -b -j -u -struct image.jpg
+      expected: not_triggered
+      description: "C2PA READ syntax — no trailing equals sign"
+    - input: |-
+        c2patool inspect image.jpg --detailed
+      expected: not_triggered
+      description: "Verification tooling"
+    - input: |-
+        ffmpeg -i in.mp4 -c copy -map_metadata -1 out.mp4
+      expected: not_triggered
+      description: "Transcode normalisation — out of scope"
+    - input: |-
+        mogrify -strip *.jpg && jpegoptim --strip-all *.jpg
+      expected: not_triggered
+      description: "Image optimisation CI — out of scope"
+    - input: |-
+        mat2 --inplace report.pdf
+      expected: not_triggered
+      description: "Privacy tooling, never treated as an indicator"
+    - input: |-
+        sharp(buf).resize(800).webp().toBuffer()
+      expected: not_triggered
+      description: "Strips by default; the artifact is an absence"
+    - input: |-
+        python -c "import piexif; piexif.remove('photo.jpg')"  # privacy scrub before upload
+      expected: not_triggered
+      description: "Generic EXIF removal, no provenance group named"
+    - input: |-
+        Cloudflare Images metadata=copyright is the default for our delivery URLs
+      expected: not_triggered
+      description: "Infrastructure default"

--- a/rules/model-abuse/ATR-2026-02411-ai-provenance-metadata-stripping.yaml
+++ b/rules/model-abuse/ATR-2026-02411-ai-provenance-metadata-stripping.yaml
@@ -40,7 +40,7 @@ references:
   mitre_atlas:
     - "AML.T0054 - LLM Jailbreak"
   mitre_attack:
-    - "T1070.009 - Indicator Removal: Clear Persistence"
+    - "T1070 - Indicator Removal"
     - "T1027 - Obfuscated Files or Information"
   cwe:
     - "CWE-345"

--- a/rules/model-abuse/ATR-2026-02412-generative-watermark-removal-tooling.yaml
+++ b/rules/model-abuse/ATR-2026-02412-generative-watermark-removal-tooling.yaml
@@ -1,0 +1,224 @@
+title: "Generative Watermark Removal Tooling (SynthID / StableSignature / TreeRing / StegaStamp)"
+id: ATR-2026-02412
+rule_version: 1
+status: experimental
+description: >
+  Detects an agent installing or invoking tooling whose stated purpose is the
+  removal of imperceptible generative watermarks: purpose-built removal CLIs
+  and packages, published attack implementations, and scheme-targeted attack
+  invocations that name a watermarking system as their parameter.
+  Kept deliberately separate from ATR-2026-02411 because the two attack the
+  same obligation through incompatible physics. A C2PA manifest lives in a
+  metadata container and one exiftool invocation removes it. SynthID and
+  StableSignature are woven into the pixel values themselves, where metadata
+  stripping has no effect at all and removal requires regeneration,
+  adversarial perturbation or a dedicated attack implementation. The
+  artifacts differ, the false-positive structure differs, and merging them
+  would force the near-zero-FP package-name layers here to inherit the
+  broader intent layers there.
+  Honest limitation: the published-attack layer cannot distinguish an
+  attacker from a watermark robustness researcher, a standards evaluator, or
+  this project's own red team, because they run identical code. That is why
+  this rule alerts and never blocks, and why it is scoped to the hunt lane.
+author: "ATR Community"
+date: "2026/08/05"
+schema_version: "0.1"
+detection_tier: pattern
+maturity: test
+severity: medium
+
+references:
+  owasp_llm:
+    - "LLM09:2025 - Misinformation"
+  owasp_agentic:
+    - "ASI08:2026 - Output Handling"
+  mitre_atlas:
+    - "AML.T0054 - LLM Jailbreak"
+  mitre_attack:
+    - "T1027 - Obfuscated Files or Information"
+  cwe:
+    - "CWE-345"
+  external:
+    - "https://deepmind.google/technologies/synthid/"
+    - "https://github.com/adobe/trustmark"
+
+compliance:
+  eu_ai_act:
+    - article: "50"
+      context: >
+        Article 50(2) requires the machine-readable marking of synthetic output
+        to be 'effective, interoperable, robust and reliable as far as this is
+        technically feasible'. Pixel-domain watermarking is the technique that
+        requirement contemplates for image and video. Note the boundary: 50(2)
+        binds the provider to mark and says nothing about removal by others, so
+        this rule does not detect a breach of it. It detects use of tooling
+        built specifically to defeat that marking, which is the direct evidence
+        of whether the robustness condition holds once a system is deployed.
+      strength: primary
+    - article: "15"
+      context: >
+        Detecting attempts to defeat an integrity control on generated output is
+        Article 15 robustness and cybersecurity evidence.
+      strength: primary
+    - article: "9"
+      context: >
+        Watermark defeat is a foreseeable misuse pathway that the Article 9 risk
+        management system must identify and treat.
+      strength: secondary
+  nist_ai_rmf:
+    - subcategory: "MP.5.1"
+      context: >
+        Invocation of watermark-removal tooling is an adversarial action that
+        MP.5.1 requires to be identified and tracked.
+      strength: primary
+    - subcategory: "MS.2.6"
+      context: >
+        MEASURE 2.6 safety evaluation is supported by runtime detection of
+        watermark defeat attempts.
+      strength: secondary
+  iso_42001:
+    - clause: "8.1"
+      context: >
+        ISO/IEC 42001 Clause 8.1 operational control over agent use of tooling
+        built to defeat content-authenticity marking.
+      strength: primary
+
+tags:
+  category: model-abuse
+  subcategory: generative-watermark-removal
+  scan_target: both
+  confidence: medium
+
+agent_source:
+  type: tool_call
+  framework: [any]
+  provider: [any]
+
+detection:
+  condition: any
+  method: pattern
+  false_positives:
+    - "Watermark robustness researchers, standards evaluators and this project's own red team run the published attack implementations by design. Layer 2 cannot separate them from an attacker — the code is the same. This is the primary reason the rule alerts rather than blocks."
+    - "Adobe TrustMark's `remove_watermark()` is a legitimate API for a content owner clearing an old payload before re-marking their own asset. No layer matches that function call; layer 4 matches natural-language intent only."
+    - "Image restoration and super-resolution (Real-ESRGAN, GFPGAN, img2img denoising) destroy pixel watermarks as a physical side effect with no evasive intent. Not covered."
+    - "Generic ComfyUI nodes (KSampler, LoadImage, SaveImage, denoise) are everyday workflow components. Only removal-specific custom node names match."
+    - "Standard audio pipelines (`ffmpeg -ar 16000`, lowpass filtering, MP3 transcode) are known to weaken AudioSeal, but none of those flags are matched."
+    - "`add_watermarker=False` in diffusers and `\"addWatermark\": false` in Vertex AI are deliberately NOT matched: the first is required when the watermark package is absent, and Google's own documentation states the second is required for deterministic seeded output."
+    - "Educational, defensive and academic text that enumerates attack names will match layer 2. Layer 4 was narrowed specifically to reduce this: research verbs (break, defeat, evade) were removed after they matched defensive sentences, leaving only operational verbs (remove, strip, erase, scrub)."
+  conditions:
+    # -- Layer 1: purpose-built removal packages --
+    # Real payload: uv tool install remove-ai-watermarks
+    # These names declare their own function. A legitimate image pipeline has
+    # no reason to install a package called noai-watermark. Cleanest indicator
+    # in this domain; a name that turns out not to exist costs nothing because
+    # a non-existent package produces no false positives.
+    - field: content
+      operator: regex
+      value: "(?i)\\b(?:remove-ai-watermarks|noai-watermark|gemini-watermark-and-synthid-remover|synthid-bypass)\\b"
+      description: "Installation or invocation of a package whose declared purpose is generative watermark removal"
+
+    # -- Layer 2: published attack implementations --
+    # Real payload: from wmattacker import DiffWMAttacker
+    # Will also match watermark robustness research. Accepted knowingly: this
+    # is an alert, and an agent running watermark attacks is worth surfacing
+    # even when the operator is a researcher.
+    - field: content
+      operator: regex
+      value: "(?i)\\b(?:DiffWMAttacker|VAEWMAttacker|WatermarkAttacker|UnMarker|watermark-stealing)\\b"
+      description: "Import or invocation of a published watermark attack implementation. Matches legitimate robustness research as well — see false_positives"
+
+    # -- Layer 3: scheme-targeted attack invocation --
+    # Real payload: python attack.py -o out/ -a UnMarker -e SynthID --total_imgs 200
+    # The -e flag naming a watermarking scheme is highly specific: ordinary
+    # image tooling has no parameter that takes SynthID or TreeRing as a value.
+    - field: content
+      operator: regex
+      value: "(?i)\\battack\\.py\\b[\\s\\S]{0,80}-e\\s+(?:SynthID|StableSignature|TreeRing|StegaStamp|HiDDeN)\\b"
+      description: "Attack script invoked with a watermarking scheme as its target parameter"
+
+    # -- Layer 4: SynthID-specific removal flags --
+    # Scoped to flags containing the scheme name. Generic strength/regeneration
+    # flags were considered and dropped: they plausibly occur in ordinary image
+    # pipelines and carry no evasive meaning on their own.
+    - field: content
+      operator: regex
+      value: "(?i)--synthid-(?:attack|strength)\\b"
+      description: "Command-line flag naming SynthID as the target of an attack or removal strength parameter"
+
+    # -- Layer 5: operational intent to remove a named watermarking scheme --
+    # Real payload: "remove the SynthID watermark from every render before we publish"
+    # Verb set is operational only. Research verbs (break/defeat/evade/bypass)
+    # were removed after they matched defensive sentences such as
+    # "our detector must not be defeated by simple JPEG compression".
+    - field: content
+      operator: regex
+      value: "(?i)\\b(?:remove|removes|removing|removal|strip|strips|stripping|stripped|erase|erases|erasing|scrub|scrubs|scrubbing|get rid of|clean off|take off)\\b[\\s\\S]{0,60}\\b(?:synthid|stable ?signature|tree ?ring|stegastamp|trustmark|audioseal|invisible watermark|imperceptible watermark)\\b"
+      description: "Operational removal verb within 60 characters of a named watermarking scheme. Research verbs deliberately excluded so that robustness discussion does not match"
+
+response:
+  actions: [alert]
+  message_template: "[ATR-2026-02412] Generative watermark removal tooling detected. Note that watermark robustness research uses the same implementations — treat as a signal to review, not as proof of intent."
+
+test_cases:
+  true_positives:
+    - input: |-
+        uv tool install remove-ai-watermarks && raiw invisible out.png
+      expected: triggered
+      description: "Purpose-built removal package"
+    - input: |-
+        pip install noai-watermark; noai-watermark source.png --remove-ai -o clean.png
+      expected: triggered
+      description: "Self-describing removal package"
+    - input: |-
+        from wmattacker import DiffWMAttacker; att = DiffWMAttacker(pipe, noise_step=60)
+      expected: triggered
+      description: "Published diffusion attack implementation"
+    - input: |-
+        python attack.py -o out/ -a UnMarker -e SynthID --total_imgs 200
+      expected: triggered
+      description: "Scheme-targeted attack invocation"
+    - input: |-
+        wmr synthid image.png --synthid-strength 0.9 -o clean.png
+      expected: triggered
+      description: "SynthID-named removal flag"
+    - input: |-
+        remove the SynthID watermark from every render in ./out before we publish
+      expected: triggered
+      description: "Operational intent against a named scheme"
+    - input: |-
+        script that removes StegaStamp and TreeRing marks from the batch
+      expected: triggered
+      description: "Operational intent, multiple schemes"
+  true_negatives:
+    - input: |-
+        pipe = StableDiffusionXLPipeline.from_pretrained(model, add_watermarker=False)
+      expected: not_triggered
+      description: "Required when the watermark package is absent"
+    - input: |-
+        TrustMark encode/decode round-trip; tm.remove_watermark() then tm.encode() to re-tag our own asset
+      expected: not_triggered
+      description: "Content owner re-marking their own asset"
+    - input: |-
+        Our detector must not be defeated by simple JPEG compression of the invisible watermark.
+      expected: not_triggered
+      description: "Defensive sentence — the reason research verbs were dropped from layer 5"
+    - input: |-
+        Evaluate robustness: does paraphrase attack break the invisible watermark signal?
+      expected: not_triggered
+      description: "Robustness evaluation phrasing"
+    - input: |-
+        AudioSeal is robust to MP3 compression; TPR@1%FPR is close to 1.00.
+      expected: not_triggered
+      description: "Descriptive research prose"
+    - input: |-
+        SynthID embeds an imperceptible watermark into generated pixels.
+      expected: not_triggered
+      description: "Explanatory prose naming the scheme"
+    - input: |-
+        Add a watermark to each PDF page with pypdf before distribution.
+      expected: not_triggered
+      description: "Watermark addition, not removal"
+    - input: |-
+        Upscale with Real-ESRGAN then run GFPGAN face restoration on the batch.
+      expected: not_triggered
+      description: "Restoration destroys watermarks as a side effect, no evasive intent"

--- a/rules/model-abuse/ATR-2026-02413-ai-text-detection-evasion-humanizer.yaml
+++ b/rules/model-abuse/ATR-2026-02413-ai-text-detection-evasion-humanizer.yaml
@@ -1,0 +1,258 @@
+title: "AI Text Detection Evasion via Humanizer Services and Watermark-Scrubbing Paraphrase"
+id: ATR-2026-02413
+rule_version: 1
+status: experimental
+description: >
+  Detects an agent being equipped with, or invoking, a capability whose
+  purpose is to make AI-generated text read as human-written: commercial
+  humanizer API endpoints, MCP servers and skills that expose `humanize_text`
+  and `scan_ai_detection` as first-class tools, paraphrase models trained
+  specifically for detector evasion, rewrite loops that terminate on a
+  detector score, and the prompt-only technique of inserting symbols between
+  words to break k-gram text watermarking.
+  Deliberately distinct from ATR-2026-01842 (plagiarism-detector evasion),
+  which fires only on the AgentHarm fingerprint 'avoid a plagiarism check'
+  and concerns copying another author's work. The target here is the class of
+  AI-generation detectors and LLM text watermarks, not similarity matching
+  against a source corpus. The two rules do not overlap in trigger surface.
+  The tool-name and endpoint layers are the ones with real discriminating
+  power. Rewriting text is overwhelmingly legitimate work — accessibility,
+  ESL editing, tone, localisation — so every intent layer additionally
+  requires a named detector or an explicit undetectability goal before it
+  fires.
+author: "ATR Community"
+date: "2026/08/05"
+schema_version: "0.1"
+detection_tier: pattern
+maturity: test
+severity: medium
+
+references:
+  owasp_llm:
+    - "LLM09:2025 - Misinformation"
+  owasp_agentic:
+    - "ASI08:2026 - Output Handling"
+  mitre_atlas:
+    - "AML.T0054 - LLM Jailbreak"
+  mitre_attack:
+    - "T1027 - Obfuscated Files or Information"
+  cwe:
+    - "CWE-345"
+  external:
+    - "https://arxiv.org/abs/2303.13408"
+
+compliance:
+  eu_ai_act:
+    - article: "50"
+      context: >
+        Article 50(2) covers synthetic TEXT as well as audio, image and video,
+        and requires machine-readable marking that is robust and reliable.
+        The mapping is secondary rather than primary because most of what this
+        rule detects targets third-party AI-generation classifiers, which are
+        not the machine-readable marking 50(2) mandates. Only the symbol-
+        injection layer attacks an actual text watermark. As with the other
+        rules in this family, 50(2) imposes no duty on anyone not to evade a
+        marking, so no breach of it is claimed here.
+      strength: secondary
+    - article: "15"
+      context: >
+        Article 15 robustness requires a deployed system to resist being turned
+        into an evasion instrument against integrity controls on its own
+        output.
+      strength: primary
+    - article: "9"
+      context: >
+        Equipping an agent with detector-evasion capability is a foreseeable
+        misuse risk requiring Article 9 identification and treatment.
+      strength: secondary
+  nist_ai_rmf:
+    - subcategory: "MP.5.1"
+      context: >
+        Detector-evasion instructions and tooling are adversarial inputs that
+        MP.5.1 requires to be identified and tracked.
+      strength: primary
+    - subcategory: "MS.2.6"
+      context: >
+        MEASURE 2.6 safety evaluation is supported by runtime detection of
+        AI-text detection evasion.
+      strength: secondary
+  iso_42001:
+    - clause: "8.1"
+      context: >
+        ISO/IEC 42001 Clause 8.1 operational control over agent capability
+        built to defeat AI-content detection.
+      strength: primary
+
+tags:
+  category: model-abuse
+  subcategory: ai-text-detection-evasion
+  scan_target: both
+  confidence: medium
+
+agent_source:
+  type: llm_io
+  framework: [any]
+  provider: [any]
+
+detection:
+  condition: any
+  method: pattern
+  false_positives:
+    - "Legitimate bulk calls to AI-detector APIs by teachers, journal editors, publishers and recruiters vastly outnumber evasive ones. Layer 6 fires only when a detector endpoint and a humanizer endpoint appear together in the same code."
+    - "Ordinary rewriting and editing: plain-language and WCAG readability work, ESL polishing, brand tone alignment, SEO editing. Every intent layer additionally requires a named detector or an explicit undetectability goal."
+    - "Translation and localisation pipelines using back-translation for quality assurance. Not covered by any layer — back-translation was tested and removed after matching legitimate corpus documents."
+    - "NLP data augmentation and robustness testing (`nlpaug`, `BackTranslationAug`, `SynonymAug`). Not covered."
+    - "Text-watermarking research and red teams: `markllm`, `sok-llm-watermark` and `lm-watermarking` ship attack modules, and layer 5 will match researchers loading the DIPPER paraphraser."
+    - "Detection-vendor documentation and academic-integrity teaching material that enumerate evasion methods can match layers 3 and 4."
+    - "Style-imitation writing exercises ('rewrite this in Hemingway's short sentences') carry no undetectability goal and do not match."
+    - "Routine emoji removal in data cleaning (`emoji.replace_emoji()`) is unaffected: layer 7 matches a request to INSERT symbols between every word, never removal."
+    - "Zero-width character handling was considered as a layer and rejected outright: it matched anti-prompt-injection sanitiser guidance in the benign corpus, meaning this project's own skill auditor would trip it."
+  conditions:
+    # -- Layer 1: commercial humanizer API endpoints --
+    # Only endpoints whose developer documentation was directly verified are
+    # listed. Several other advertised services were found during research with
+    # marketing pages but no developer documentation, and were left out rather
+    # than guessed at.
+    - field: content
+      operator: regex
+      value: "(?i)(?:https?|wss)://(?:humanize|human)\\.undetectable\\.ai/|https?://stealthgpt\\.ai/api/stealthify"
+      description: "Call to a commercial AI-text humanizer API whose product function is defeating AI-content detection"
+
+    # -- Layer 2: humanizer packaged as agent-native capability --
+    # Real payload: an mcp.json server entry, or a .claude/skills/ directory.
+    # This is the asset shape a skill auditor sees before anything runs.
+    - field: content
+      operator: regex
+      value: "(?i)\\b(?:ai-humanizer-mcp-server|@humantext/mcp-server|humanize-text-skill|texthumanizer\\.pro|HUMANTEXT_API_KEY)\\b"
+      description: "Detection-evasion capability installed as an MCP server or agent skill — the supply-chain form of this threat"
+
+    # -- Layer 3: MCP tool-name pairing --
+    # Neither name alone is damning; a tool that rewrites text and a tool that
+    # scores it against detectors, declared in the same schema, describe a
+    # rewrite-until-it-passes loop.
+    - field: content
+      operator: regex
+      value: "(?i)\\bhumanize_text\\b[\\s\\S]{0,200}\\bscan_ai_detection\\b"
+      description: "An MCP schema declaring both a humanizing tool and a detector-scoring tool — the pairing is the evidence, not either name alone"
+
+    # -- Layer 4: explicit intent to defeat a named detector --
+    # Window narrowed to 40 characters after wider windows matched sentences
+    # that merely mention running a detector.
+    - field: content
+      operator: regex
+      value: "(?i)\\b(?:bypass|evad|beat|defeat|fool|trick|circumvent|outsmart)\\w*\\b[\\s\\S]{0,40}\\b(?:ai (?:content |text )?detect(?:ion|ors?)|gptzero|turnitin|originality\\.ai|copyleaks|zerogpt|winston ai)\\b"
+      description: "Evasion verb within 40 characters of a named AI-content detector"
+
+    # -- Layer 5: rewrite with an explicit undetectability goal --
+    # Requires the goal state. A bare paraphrase request does not match.
+    - field: content
+      operator: regex
+      value: "(?i)\\b(?:make|rewrite|rewriting|rephrase|paraphrase|humanize|humanise)\\b[\\s\\S]{0,60}\\b(?:undetectable|100% human score|pass(?:es)? as human[- ]written)\\b"
+      description: "Rewrite request carrying an explicit undetectability goal state, which ordinary editing requests never state"
+
+    # -- Layer 6: evasion-specific paraphrase model --
+    - field: content
+      operator: regex
+      value: "(?i)\\b(?:kalpeshk2011/dipper-paraphraser|dipper-paraphraser-xxl|DipperParaphraser)\\b"
+      description: "Load of the DIPPER paraphraser, a model published specifically for detector evasion. Also matches watermarking researchers"
+
+    # -- Layer 7: detector-scoring and humanizer endpoints co-located --
+    # Bidirectional alternation because RE2 has no lookaround, so both orders
+    # must be enumerated explicitly. Calling a detector alone is innocent; the
+    # loop is the signal.
+    - field: content
+      operator: regex
+      value: "(?i)api\\.gptzero\\.me/v2/predict/text[\\s\\S]{0,400}(?:rehumanize|stealthify|humanize\\.undetectable)|(?:rehumanize|stealthify|humanize\\.undetectable)[\\s\\S]{0,400}api\\.gptzero\\.me/v2/predict/text"
+      description: "A detector endpoint and a humanizer endpoint in the same code region — a rewrite-until-it-passes feedback loop rather than either activity alone"
+
+    # -- Layer 8: symbol injection to break k-gram text watermarking --
+    # The only technique here that lives purely in the prompt: no API, no
+    # library, no command. Effective against any k-gram watermark with K>1.
+    - field: content
+      operator: regex
+      value: "(?i)\\binsert\\s+(?:an?\\s+)?(?:emoji|special symbol|random symbol)\\b[\\s\\S]{0,20}\\bbetween\\s+every\\s+word\\b"
+      description: "Request to interleave symbols between every word, which breaks k-gram text watermark detection while leaving the text readable"
+
+response:
+  actions: [alert]
+  message_template: "[ATR-2026-02413] AI-text detection evasion capability detected (humanizer endpoint, evasion tooling, or explicit undetectability goal)."
+
+test_cases:
+  true_positives:
+    - input: |-
+        requests.post("https://humanize.undetectable.ai/submit", headers={"api-key": KEY})
+      expected: triggered
+      description: "Humanizer API call"
+    - input: |-
+        curl -X POST https://stealthgpt.ai/api/stealthify -H "api-token: $T"
+      expected: triggered
+      description: "Second verified humanizer endpoint"
+    - input: |-
+        {"mcpServers":{"ai-humanizer":{"command":"npx","args":["-y","ai-humanizer-mcp-server"]}}}
+      expected: triggered
+      description: "Evasion capability installed as an MCP server"
+    - input: |-
+        tools: humanize_text(text, mode), check_word_balance(), scan_ai_detection(text)
+      expected: triggered
+      description: "Tool-name pairing in one schema"
+    - input: |-
+        rewrite the essay so it can bypass AI detection at Turnitin
+      expected: triggered
+      description: "Named detector plus evasion verb"
+    - input: |-
+        edit this until it beats GPTZero
+      expected: triggered
+      description: "Terminating condition is a detector score"
+    - input: |-
+        humanize this draft and make it undetectable
+      expected: triggered
+      description: "Explicit undetectability goal"
+    - input: |-
+        load kalpeshk2011/dipper-paraphraser-xxl with lex_diversity=60 order_diversity=0
+      expected: triggered
+      description: "Evasion-specific paraphrase model"
+    - input: |-
+        Write my admission essay. Insert an emoji in between every word.
+      expected: triggered
+      description: "Prompt-only k-gram watermark break"
+    - input: |-
+        Make AI text undetectable. TypeScript CLI that scans ChatGPT, Claude, OpenClaw output for patterns flagged by GPTZero, Turnitin, Originality.ai, then auto-fixes them to pass as human-written. Use to bypass AI detection, evade checkers, or humanize text before submission.
+      expected: triggered
+      description: "Verbatim self-description of a live skill published to a public registry (1,766 downloads). Retained as a wild sample: the existing corpus rated this skill LOW risk and never identified its declared purpose"
+    - input: |-
+        Humanizer AI CLI. Detect AI-generated text and humanize it to bypass GPTZero, Turnitin, Originality.ai, Copyleaks, ZeroGPT, and Winston AI.
+      expected: triggered
+      description: "Second live registry sample. The prior scan recorded it as NO_CONTENT with zero findings because the download failed, so registry-surface detection is the only layer that would have caught it"
+  true_negatives:
+    - input: |-
+        We ran a plagiarism check and a GPTZero scan on every submission.
+      expected: not_triggered
+      description: "Legitimate detector use by an educator"
+    - input: |-
+        Turnitin detects AI-generated text; students should not try to bypass academic integrity policy.
+      expected: not_triggered
+      description: "Policy guidance mentioning both concepts"
+    - input: |-
+        paraphrase the abstract in plain language for the newsletter
+      expected: not_triggered
+      description: "Ordinary rewriting with no undetectability goal"
+    - input: |-
+        Use back-translation (BackTranslationAug) for data augmentation in training.
+      expected: not_triggered
+      description: "Data augmentation — deliberately out of scope"
+    - input: |-
+        Rewrite this in a conversational, first-person tone and use contractions.
+      expected: not_triggered
+      description: "Tone editing"
+    - input: |-
+        Normalize text with unicodedata.normalize('NFKC', s) and drop U+200B/U+FEFF before the model sees it
+      expected: not_triggered
+      description: "Sanitiser guidance — the reason a zero-width layer was rejected"
+    - input: |-
+        Translate EN to DE to EN to verify the localization did not drift.
+      expected: not_triggered
+      description: "Localisation QA"
+    - input: |-
+        model.generate(prompt, max_new_tokens=512)
+      expected: not_triggered
+      description: "Ordinary generation call"


### PR DESCRIPTION
Three rules covering a gap the corpus had no coverage for at all: removal or defeat of the machine-readable markings that identify content as artificially generated.

Verified before writing: `grep -rli` across all 780 rules returns zero hits for `exiftool`, `c2pa`, `jumbf`, `synthid`, `content credential`, `humanize`, `undetectable`, `gptzero` and `digitalsourcetype`. Nothing in the corpus touched this area.

## What the article actually says

Article 50(2) was read in full before any mapping was written, because the framing depends on it:

> Providers of AI systems, including general-purpose AI systems, generating synthetic audio, image, video or text content, shall ensure the outputs of the AI system are marked in a machine-readable format and detectable as artificially generated or manipulated.

Two things follow, and both are reflected in the `context` prose of every mapping here:

1. The duty falls on the **provider**, to mark. Article 50 contains **no prohibition on anyone removing a marking.** These rules therefore do **not** detect a breach of 50(2), and none of them claims to.
2. 50(2) requires the marking to be *"effective, interoperable, robust and reliable as far as this is technically feasible"*. Evidence that markings are being stripped in deployment bears directly on whether that robustness condition holds. That — and only that — is what these rules provide.

The mappings use `article: "50"`, the identifier the allowlist admits, with the sub-paragraph precision carried in `context` prose. Same convention as #413.

## Why three rules and not one

The threat is one thing; the detection physics are three.

| | attack surface | artifact | FP structure |
|---|---|---|---|
| 02411 | metadata container (JUMBF/APP11/caBX/XMP) | CLI flags, where a trailing `=` separates read from delete | shares tooling completely with photography, privacy and optimisation CI |
| 02412 | pixel/waveform itself | package and module names | shares vocabulary with watermark robustness research |
| 02413 | text statistics | HTTP endpoints, MCP tool names, prompt phrasing | shares verbs with translation, editing and academic integrity checking |

Merged into one rule, the near-zero-FP artifact layers of 02412 and 02413 would inherit the broad intent layers of 02411 and the whole thing would be pinned to the loosest layer it contains.

## The two live samples this found

Scanning the 36,394-skill ClawHub registry — on author, name and summary alone — 02413 matched two published skills:

| skill | downloads | what the prior scan said |
|---|---|---|
| `undetectable-ai` | 1,766 | `riskLevel: LOW`, and the only findings were unrelated markup issues |
| `humanizerai` | 118 | `NO_CONTENT`, zero findings — the download failed and nothing else looked at it |

The first one's own summary reads: *"Use to bypass AI detection, evade checkers, or humanize text before submission."*

Both are retained as `true_positives` (summary text only, no author attribution). They are the strongest argument for the registry-surface layer: one was rated low risk by content scanning, and the other was never scanned at all.

## Measurement

```
benign corpora:  5,352 docs  (benign-corpus-extended/*, benign-code, skill-benchmark/benign)
wild registry:  36,394 real published skills (clawhub-registry.json)

false positives: 0 across all 19 layers on both corpora
                 (the 3 wild-registry matches are true positives, listed above)
test cases:      26/26 true positives fire, 26/26 true negatives stay clean
```

Gates run locally on this branch:

- `tests/validate-rules.ts` — 783 passed, 0 failed
- `scripts/validate-compliance.ts` — 0 violations across 783 mapped rules
- `scripts/gate-rule-status.ts` — **GATE PASS, no new inert rule**
- RE2 portability — none of the three flagged; no lookaround, backreference or possessive quantifier
- `scripts/check-rules-safety.ts` — PASS, 3 rules safe

Two advisories on 02413 for `{0,200}` and `{0,400}` bridges. Both are deliberate: those layers exist precisely to detect co-occurrence across a code region (a humanize tool declared alongside a detector-scoring tool; a detector endpoint alongside a humanizer endpoint). Neither token pair means anything on its own.

## The gap this measurement does not close

**The 0-FP result does not validate 02411.** Base rates in both corpora:

```
exiftool  0     c2pa  0     mogrify  0     piexif  0
sharp(    2     imagemagick  7           ffmpeg  18
```

Neither corpus contains an image-metadata processing pipeline. A rule about `exiftool` scoring zero false positives against a corpus with zero `exiftool` is not evidence — it is an absence of evidence, and reporting it as a pass would be the kind of number this repo has spent the last week cleaning up.

What 02411 actually rests on is a structural argument: ExifTool's read syntax is `-jumbf:all` and its delete syntax is `-jumbf:all=`, so requiring the trailing `=` separates inspection from destruction by construction rather than by measurement. That argument is checkable by reading it, which is why it is written out in each layer's comment. It is not a substitute for measurement against a corpus that actually contains this tooling, and 02411 stays at `maturity: test` until it gets one.

## What was deliberately left out

Every one of these had a concrete artifact available. Each was dropped for a stated reason:

- **`exiftool -all=` and `-gps:all=`** — the daily tools of photographers protecting sources and of legal de-identification. Zero discriminating power.
- **ImageMagick `-strip`, `jpegoptim --strip-all`, `optipng -strip all`** — `imagemin` ships `-strip all` by default; the developer never typed it.
- **`ffmpeg -map_metadata -1`** — transcode normalisation and reproducible builds.
- **`mat2`** — the standard privacy tool of the Tails/Whonix community. Treating it as an indicator would classify that entire community as attackers.
- **sharp missing `.withMetadata()`, Pillow `save()` without `exif=`** — behaviourally equivalent to stripping, but the artifact is an *absence*, and regex cannot match an absence.
- **`add_watermarker=False`, Vertex AI `"addWatermark": false`** — Google's own documentation states the latter is required for deterministic seeded output.
- **A hardcoded list of removal-service domains** — replaced with a URL *path* pattern. Naming specific businesses in a public standard asserts a claim about each of them that this repo has not individually verified, and the domains churn anyway.
- **Zero-width character detection (U+200B, U+FEFF)** — matched anti-prompt-injection sanitiser guidance in the benign corpus. This project's own skill auditor would trip it.
- **Back-translation / `BackTranslationAug`** — matched legitimate corpus documents; it is standard localisation QA and data augmentation.
- **Generic removal flags (`--codebook-free`, `--regen-strength`, `--phase-adaptive`)** — plausible in ordinary image pipelines, carrying no evasive meaning alone. Only flags naming SynthID were kept.
- **`TrustMark remove_watermark()` without a following `encode()`** — a sound condition, but RE2 has no negative lookahead. "Later there is no X" is not expressible; it would need engine-level event correlation.
- **BMFF `uuid` box constants, `Content-Credentials` HTTP headers, `.well-known/ai-provenance`** — sourced from a single blog with no C2PA, IPTC or IETF backing, and two research lines gave inconsistent UUID values.
- **Four advertised humanizer services** — marketing pages only, no developer documentation. Only the two with verified parameter tables are in 02413.

One layer in 02412 was rewritten after it failed: the intent layer originally included `break`, `defeat`, `bypass` and `evade`, which matched defensive sentences such as *"our detector must not be defeated by simple JPEG compression"*. Those are research verbs. Restricting the layer to operational verbs (`remove`, `strip`, `erase`, `scrub`) kept every true positive and cleared both failures.

## Lane placement

All three are `status: experimental` / `maturity: test` — engine-loaded, hunt lane, `actions: [alert]` only. None can auto-block.

`status: draft` was considered and rejected: the engine skips draft rules entirely (`engine.ts:382`), so a draft rule is inert on disk. That is the exact class of rule #412 removed yesterday.

02412 will match watermark robustness researchers, standards evaluators and this project's own red team, because they run identical code. That is stated in its `false_positives` and in its `message_template`, and it is the main reason none of these should be promoted to the enforce lane as written. If enforce-lane coverage is wanted later, the correct move is to split the pure artifact layers into their own rule — not to loosen the intent layers.

## Not mapped to CEN JTC 21

Deliberate. `prEN 18282` covers cybersecurity specifications for AI systems, and the marking-robustness question sits closer to transparency than to cybersecurity. Adding a mapping that cannot be defended crisply is how an allowlist stops meaning anything, and that allowlist is four days old.
