### PR TITLE
fix(gate): name the skill-path zero-measurement instead of counting it clean

### DIFF
--- a/scripts/gate-promotion-fp.ts
+++ b/scripts/gate-promotion-fp.ts
@@ -94,8 +94,10 @@ import {
   corpusShapes,
   shapeNames,
   fieldCoverage,
+  skillPathCoverage,
   unmeasurableReason,
   type FieldCoverage,
+  type SkillPathGap,
 } from "./lib/corpus-event.js";
 
 const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
@@ -438,6 +440,8 @@ interface ScanResult {
   readonly sampleCount: number;
   /** Target rules with conditions this corpus cannot measure. */
   readonly coverage: readonly FieldCoverage[];
+  /** Target rules the `skill` half of matchedRuleIds cannot ever match. */
+  readonly skillCoverage: readonly SkillPathGap[];
 }
 
 async function scanFpCounts(targets: Targets, deps: GateDeps): Promise<ScanResult> {
@@ -455,7 +459,8 @@ async function scanFpCounts(targets: Targets, deps: GateDeps): Promise<ScanResul
     }
   }
   const coverage = fieldCoverage(engine.getRules()).filter((c) => targets.ids.has(c.ruleId));
-  return { counts, sampleCount: samples.length, coverage };
+  const skillCoverage = skillPathCoverage(engine.getRules()).filter((c) => targets.ids.has(c.ruleId));
+  return { counts, sampleCount: samples.length, coverage, skillCoverage };
 }
 
 /**
@@ -482,11 +487,46 @@ function reportCoverage(coverage: readonly FieldCoverage[]): void {
   }
 }
 
+/**
+ * "shapes = ..., skill" must not be allowed to imply the skill path measured
+ * anything.
+ *
+ * engine.scanSkill() applies a compound gate to every rule that is not
+ * `scan_target: skill|both`, and that gate is arithmetically unreachable for a
+ * `condition: any` rule — evaluateArrayConditions breaks on the first match, so
+ * matchedConditions.length is capped at 1 while the gate demands at least 2. On
+ * main that is 645 of 780 rules, 102 of them maturity:stable. Their silence on
+ * the skill half of matchedRuleIds() is not evidence about the skill path.
+ *
+ * The exit code deliberately does NOT change, for the same reason reportCoverage
+ * does not change it: an `scan_target: mcp` rule not running on a SKILL.md is
+ * the intended behaviour, so failing on it would block every promotion with
+ * nothing to fix. Saying it out loud is the whole remedy.
+ */
+function reportSkillPathCoverage(gaps: readonly SkillPathGap[]): void {
+  if (gaps.length === 0) return;
+  const enforce = gaps.filter((g) => g.claimsEnforceLane);
+  console.log(
+    `\n[fp-gate] NOT MEASURED ON THE SKILL PATH — ${gaps.length} rule(s) cannot produce a ` +
+      `match through engine.scanSkill() for any input` +
+      (enforce.length > 0 ? `, ${enforce.length} of them in the enforce lane` : "") +
+      `. They were measured on the evaluate() shapes only:`,
+  );
+  for (const g of gaps) {
+    console.log(
+      `  ${g.ruleId} — ${g.blocker} (max ${g.maxAttainableConditions} of ${g.requiredConditions} ` +
+        `required matched conditions)`,
+    );
+    console.log(`      ${g.reason}`);
+  }
+}
+
 function report(
   partition: FpPartition,
   sampleCount: number,
   filterMode: boolean,
   coverage: readonly FieldCoverage[] = [],
+  skillCoverage: readonly SkillPathGap[] = [],
 ): void {
   console.log(`[fp-gate] corpus = ${sampleCount} benign samples`);
   console.log(
@@ -495,6 +535,7 @@ function report(
   );
   console.log(`[fp-gate] clean = ${partition.clean.length} · dirty = ${partition.dirty.length}`);
   reportCoverage(coverage);
+  reportSkillPathCoverage(skillCoverage);
   if (partition.dirty.length === 0) {
     console.log(`[fp-gate] PASS — all promoted rules are FP-clean on the benign corpus.`);
     return;
@@ -547,9 +588,9 @@ export async function runGate(options: GateOptions, deps: GateDeps = defaultDeps
   console.log(
     `[fp-gate] gating ${targets.files.length} promoted rule(s) against the benign corpus`,
   );
-  const { counts, sampleCount, coverage } = await scanFpCounts(targets, deps);
+  const { counts, sampleCount, coverage, skillCoverage } = await scanFpCounts(targets, deps);
   const partition = partitionByFp(counts);
-  report(partition, sampleCount, options.filterMode, coverage);
+  report(partition, sampleCount, options.filterMode, coverage, skillCoverage);
   emitLists(options, partition);
   return resolveExitCode(partition.dirty.length, options.filterMode);
 }

--- a/scripts/lib/corpus-event.ts
+++ b/scripts/lib/corpus-event.ts
@@ -294,6 +294,12 @@ export interface ScannableEngine {
  * reach production through it alone — a harness that only calls evaluate() would
  * score them clean without reading them.
  *
+ * The converse is equally true and much less obvious: the scanSkill() half is a
+ * no-op for most of the corpus. Its compound gate is unreachable for every
+ * `condition: any` rule that is not `scan_target: skill|both`, so counting it
+ * among the shapes does NOT mean a rule was measured on it. Ask
+ * skillPathCoverage() which ones the skill path never asked about, and say so.
+ *
  * Counted PER SAMPLE, not per shape: a document that trips a rule on three
  * shapes is one false positive, not three. Every harness that measures FP, TP or
  * coverage must go through this function, so a rule can never earn its detection
@@ -317,10 +323,12 @@ export interface RuleLike {
   readonly id: string;
   readonly status?: string;
   readonly maturity?: string;
+  readonly tags?: { readonly scan_target?: unknown };
   readonly detection?: {
     readonly method?: string;
     readonly condition?: string;
     readonly conditions?: unknown;
+    readonly semantic?: { readonly fallback_method?: unknown };
   };
 }
 
@@ -461,6 +469,211 @@ export function statusCoverage(rules: readonly RuleLike[]): readonly StatusGap[]
         reason: inertStatusReason(status) ?? "",
       }),
     );
+  }
+  return Object.freeze(out);
+}
+
+// ---------------------------------------------------------------------------
+// Coverage, third axis: the SKILL.md path evaluates almost no rules
+// ---------------------------------------------------------------------------
+
+/**
+ * matchedRuleIds() runs four evaluate() shapes AND engine.scanSkill(), and the
+ * gate prints `shapes = wide-raw, ..., skill`. That banner reads as "every rule
+ * you are gating was offered to the skill path". For 645 of the 780 rules on
+ * main that is false, and not by a little: they cannot produce a match on that
+ * path for ANY input whatsoever.
+ *
+ * THE MECHANISM (src/engine.ts, evaluateRaw / evaluateAsync)
+ *
+ * scanSkill() builds an event with `scanContext: 'skill'`. In that context the
+ * engine skips source-type filtering — every rule is evaluated — and then
+ * applies a compound gate to any rule NOT declared for skill scanning:
+ *
+ *     if (isSkillContext && rule.tags.scan_target !== 'skill'
+ *                        && rule.tags.scan_target !== 'both') {
+ *       const totalConds = Number(rule.detection?.conditions?.length ?? 1);
+ *       const minRequired = Math.max(2, Math.ceil(totalConds * 0.3));
+ *       if ((matchResult.matchedConditions?.length ?? 0) < minRequired) continue;
+ *     }
+ *
+ * The comment above it describes a graded threshold ("30%+ of conditions").
+ * `matchedConditions` is produced by evaluateArrayConditions, which for
+ * `condition: any` SHORT-CIRCUITS:
+ *
+ *     if (result) { matchedConditionIndices.push(i); if (isAny) break; }
+ *
+ * So for an any-mode rule `matchedConditions.length` is 1 whenever the rule
+ * matches at all, and 0 otherwise. It is never 2. `minRequired` is never below
+ * 2. 776 of the 780 rules on main declare `condition: any`. The threshold is
+ * therefore not a threshold — it is an unconditional reject, and the effective
+ * policy of the SKILL.md path is "only `scan_target: skill|both` rules run".
+ *
+ * That policy is defensible and it is load-bearing (measured 2026-08-05: making
+ * the threshold reachable takes the 466-sample benign skill corpus from 1 flagged
+ * sample to 265, while malicious recall stays 32/32 — the cost is real and the
+ * benefit is unmeasurable on that corpus). What is NOT defensible is the gate
+ * reporting a `skill` shape it never charged those rules on. This axis exists so
+ * the gate says which rules the skill shape did not ask about, exactly as
+ * fieldCoverage does for fields and statusCoverage does for inert rules.
+ *
+ * Like fieldCoverage — and unlike statusCoverage — this must NOT change an exit
+ * code. An `scan_target: mcp` rule being unreachable on the SKILL.md path is the
+ * intended behaviour, not a defect with a one-line remedy; failing on it would
+ * block every promotion with nothing to fix.
+ */
+export const SKILL_NATIVE_SCAN_TARGETS: ReadonlySet<string> = Object.freeze(
+  new Set(["skill", "both"]),
+);
+
+/** Why a rule can never fire on engine.scanSkill(). */
+export type SkillPathBlocker =
+  | "method-trace"
+  | "method-behavioral"
+  | "method-signature"
+  | "method-semantic-no-pattern-fallback"
+  | "no-conditions"
+  | "compound-gate-unreachable";
+
+export interface SkillPathGap {
+  readonly ruleId: string;
+  readonly blocker: SkillPathBlocker;
+  /** scan_target as declared, or null when the rule declares none. */
+  readonly scanTarget: string | null;
+  readonly maturity: string | null;
+  /** True when the rule also claims the enforce (auto-block) lane. */
+  readonly claimsEnforceLane: boolean;
+  /** Most matchedConditions the engine can ever hand the compound gate. */
+  readonly maxAttainableConditions: number;
+  /** What the compound gate demands. */
+  readonly requiredConditions: number;
+  readonly reason: string;
+}
+
+function normalise(v: unknown): string | null {
+  return typeof v === "string" && v.trim() !== "" ? v.trim().toLowerCase() : null;
+}
+
+/**
+ * The compound gate's own arithmetic, mirrored: `Number(conditions?.length ?? 1)`
+ * — a named-map `conditions` has no `.length`, so it counts as 1 and the floor of
+ * 2 applies.
+ */
+function requiredConditions(conditions: unknown): number {
+  const total = Number(Array.isArray(conditions) ? conditions.length : 1);
+  return Math.max(2, Math.ceil(total * 0.3));
+}
+
+/**
+ * The largest `matchedConditions.length` the engine can ever produce for this
+ * rule, given how each condition form accumulates matches:
+ *   - array + any/or  -> 1  (evaluateArrayConditions breaks on the first match)
+ *   - array + all     -> N  (a match requires every condition, so it is N or nothing)
+ *   - named map       -> number of names (evaluateNamedConditions does not break)
+ */
+function maxAttainableConditions(rule: RuleLike): number {
+  const conds = rule.detection?.conditions;
+  const expr = normalise(rule.detection?.condition) ?? "any";
+  if (Array.isArray(conds)) {
+    if (conds.length === 0) return 0;
+    return expr === "any" || expr === "or" ? 1 : conds.length;
+  }
+  if (conds !== null && typeof conds === "object") return Object.keys(conds as object).length;
+  return 0;
+}
+
+/**
+ * Why this rule can never match on the SKILL.md path — or null when it can.
+ *
+ * Inert (draft/deprecated) rules return null on purpose: they cannot fire on ANY
+ * path, which is statusCoverage's finding, and reporting them twice would blur
+ * "the skill path did not ask" into "the engine never loaded it".
+ */
+export function skillPathBlocker(rule: RuleLike): SkillPathGap | null {
+  if (isInertStatus(rule.status)) return null;
+
+  const scanTarget = normalise(rule.tags?.scan_target);
+  const maturity = normalise(rule.maturity);
+  const method = normalise(rule.detection?.method) ?? "pattern";
+  const required = requiredConditions(rule.detection?.conditions);
+  const attainable = maxAttainableConditions(rule);
+
+  const gap = (blocker: SkillPathBlocker, reason: string): SkillPathGap =>
+    Object.freeze({
+      ruleId: rule.id,
+      blocker,
+      scanTarget,
+      maturity,
+      claimsEnforceLane: maturity !== null && ENFORCE_LANE_MATURITIES.has(maturity),
+      maxAttainableConditions: attainable,
+      requiredConditions: required,
+      reason,
+    });
+
+  // Method dispatch happens before the compound gate and is independent of
+  // scan_target: scanSkill() passes an event with no trace, no session window
+  // and `fields: {}`, so these methods return null for every input.
+  if (method === "trace") {
+    return gap(
+      "method-trace",
+      "method: trace — scanSkill() builds an event with no `trace`, and " +
+        "evaluateRule returns null when event.trace is undefined",
+    );
+  }
+  if (method === "behavioral") {
+    return gap(
+      "method-behavioral",
+      "method: behavioral — the synchronous evaluateRule returns null " +
+        "unconditionally; a metric window needs a streaming path",
+    );
+  }
+  if (method === "signature") {
+    return gap(
+      "method-signature",
+      "method: signature — indicators are compared against event.fields, and " +
+        "scanSkill() sets `fields: {}`, so no indicator can ever resolve",
+    );
+  }
+  if (method === "semantic" && normalise(rule.detection?.semantic?.fallback_method) !== "pattern") {
+    return gap(
+      "method-semantic-no-pattern-fallback",
+      "method: semantic without fallback_method: pattern — the synchronous " +
+        "scanSkill() path has no judge and returns null",
+    );
+  }
+
+  // scan_target skill/both is exempt from the compound gate entirely.
+  if (scanTarget !== null && SKILL_NATIVE_SCAN_TARGETS.has(scanTarget)) return null;
+
+  if (attainable === 0) {
+    return gap("no-conditions", "the rule declares no conditions the engine can match");
+  }
+  if (attainable < required) {
+    return gap(
+      "compound-gate-unreachable",
+      `scan_target: ${scanTarget ?? "(none)"} is not skill/both, so the skill compound ` +
+        `gate demands ${required} matched conditions, but this rule can never report more ` +
+        `than ${attainable}` +
+        (attainable === 1 && Array.isArray(rule.detection?.conditions)
+          ? ' — evaluateArrayConditions breaks on the first match for condition: "any"'
+          : ""),
+    );
+  }
+  return null;
+}
+
+/**
+ * Rules engine.scanSkill() can never match. Reachable rules are omitted.
+ *
+ * The skill path is a genuine production entry point (`pga scan`), and it is one
+ * of the two halves of matchedRuleIds(). A caller that prints "skill" among its
+ * shapes owes the reader this list.
+ */
+export function skillPathCoverage(rules: readonly RuleLike[]): readonly SkillPathGap[] {
+  const out: SkillPathGap[] = [];
+  for (const rule of rules) {
+    const gap = skillPathBlocker(rule);
+    if (gap !== null) out.push(gap);
   }
   return Object.freeze(out);
 }

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -411,20 +411,34 @@ export class ATREngine {
 
       const matchResult = this.evaluateRule(rule, event);
       if (matchResult) {
-        // Skill context compound gating: rules not designed for SKILL.md
-        // must match 2+ CONDITIONS (not patterns) to trigger. A single
-        // condition with many patterns fires too easily on long documents.
-        // 2+ condition co-occurrence means the document exhibits multiple
-        // distinct threat signals — strongly indicates a real attack, not
-        // security documentation that happens to describe one attack type.
-        // Rules with scan_target 'skill' or 'both' fire normally.
-        // Compound gate: rules not designed for skill scanning need 30%+
-        // conditions to match. Rules with scan_target 'skill' or 'both'
-        // have verified FP rates and fire normally.
+        // Skill context compound gating: rules not designed for SKILL.md must
+        // match 2+ CONDITIONS (not patterns) to trigger. A single condition with
+        // many patterns fires too easily on long documents; 2+ condition
+        // co-occurrence means the document exhibits multiple distinct threat
+        // signals. Rules with scan_target 'skill' or 'both' have verified FP
+        // rates on SKILL.md and are exempt.
+        //
+        // WHAT THIS ACTUALLY DOES — read before "fixing" it (audited 2026-08-05):
+        // for a rule with `condition: any`, matchedConditions.length is capped at
+        // 1, because evaluateArrayConditions BREAKS on the first matching
+        // condition. minRequired is never below 2. So for any-mode rules this is
+        // not a 30% threshold, it is an unconditional reject, and the effective
+        // policy of the SKILL.md path is "only scan_target: skill|both rules
+        // run". 776 of 780 rules on main declare `condition: any`; 645 rules
+        // (102 of them maturity:stable) can never match here for any input.
+        //
+        // That policy is load-bearing, not an accident waiting to be corrected.
+        // Measured on this corpus: letting the threshold become reachable (stop
+        // short-circuiting when scanContext === 'skill') takes the 466-sample
+        // benign skill corpus from 1 flagged sample to 265 — 7 new rules firing,
+        // 406 new FP — while malicious recall stays 32/32. Do not change this
+        // without re-running both halves of that measurement.
+        //
+        // The measurement-side consequence (a gate that lists `skill` among its
+        // shapes has NOT measured those 645 rules on it) is named by
+        // skillPathCoverage() in scripts/lib/corpus-event.ts and pinned by
+        // tests/skill-path-coverage.test.ts.
         if (isSkillContext && rule.tags.scan_target !== 'skill' && rule.tags.scan_target !== 'both') {
-          // Require at least 30% of conditions to match (min 2) — long documents
-          // with many technical terms easily hit 2 conditions; percentage-based
-          // threshold scales with rule complexity.
           const totalConds: number = Number(rule.detection?.conditions?.length ?? 1);
           const minRequired = Math.max(2, Math.ceil(totalConds * 0.3));
           if ((matchResult.matchedConditions?.length ?? 0) < minRequired) {
@@ -549,6 +563,9 @@ export class ATREngine {
 
       const matchResult = await this.evaluateRuleAsync(rule, event, this.config.semanticJudge);
       if (matchResult) {
+        // Skill compound gate — see the long note in evaluateRaw(). For
+        // `condition: any` rules this rejects unconditionally, which is why the
+        // SKILL.md path effectively runs only scan_target: skill|both rules.
         if (isSkillContext && rule.tags.scan_target !== 'skill' && rule.tags.scan_target !== 'both') {
           const totalConds: number = Number(rule.detection?.conditions?.length ?? 1);
           const minRequired = Math.max(2, Math.ceil(totalConds * 0.3));
@@ -782,7 +799,13 @@ export class ATREngine {
 
       if (result) {
         matchedConditionIndices.push(i);
-        if (isAny) break; // Short-circuit on first match for "any"
+        // Short-circuit on first match for "any". NOTE: this also caps
+        // matchedConditions at 1, which the skill-context compound gate in
+        // evaluateRaw() reads — see the note there before changing it. Removing
+        // this break is a detection-behaviour change, not an optimisation
+        // cleanup: it takes the benign skill corpus from 1 to 265 flagged
+        // samples out of 466.
+        if (isAny) break;
       }
     }
 

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -892,7 +892,9 @@ export class ATREngine {
         if (compiled && compiled.length > 0) {
           // Test against both normalized and raw values so that patterns
           // detecting zero-width/bidi characters can match before stripping
-          if (safeRegexTest(compiled[0]!, fieldValue) || safeRegexTest(compiled[0]!, rawFieldValue)) {
+          // (the raw pass is skipped only when normalisation was a no-op — see
+          // testNormalisedThenRaw)
+          if (testNormalisedThenRaw(compiled[0]!, fieldValue, rawFieldValue)) {
             if (suppressInCodeBlocks && codeRanges.length > 0 && isInsideCodeBlock(fieldValue, compiled[0]!, codeRanges)) {
               return false;
             }
@@ -905,7 +907,7 @@ export class ATREngine {
         const normalized = normalizeRegex(value);
         const rFlags = normalized.includes('\\u{') || normalized.includes('\\p{') ? 'iu' : 'i';
         const regex = safeCompile(normalized, rFlags);
-        if (regex && (safeRegexTest(regex, fieldValue) || safeRegexTest(regex, rawFieldValue))) {
+        if (regex && testNormalisedThenRaw(regex, fieldValue, rawFieldValue)) {
           if (suppressInCodeBlocks && codeRanges.length > 0 && isInsideCodeBlock(fieldValue, regex, codeRanges)) {
             return false;
           }
@@ -1056,7 +1058,7 @@ export class ATREngine {
 
     if (compiled) {
       for (let i = 0; i < compiled.length; i++) {
-        if (safeRegexTest(compiled[i]!, fieldValue) || (rawFieldValue && safeRegexTest(compiled[i]!, rawFieldValue))) {
+        if (testNormalisedThenRaw(compiled[i]!, fieldValue, rawFieldValue)) {
           // If match is inside a code block and this rule supports suppression, skip it
           if (suppressInCodeBlocks && codeRanges.length > 0 && isInsideCodeBlock(fieldValue, compiled[i]!, codeRanges)) {
             continue;
@@ -2042,6 +2044,48 @@ const MAX_EVAL_LENGTH = 100_000;
 function safeRegexTest(regex: RegExp, input: string): boolean {
   if (input.length > MAX_EVAL_LENGTH) return false;
   return regex.test(input);
+}
+
+/**
+ * Test a pattern against the NORMALISED text and, only when normalisation
+ * actually changed something, against the RAW text as well.
+ *
+ * The second test exists so a pattern that hunts zero-width / bidi / confusable
+ * characters can still see them before foldConfusables strips them. That is a
+ * real requirement and it is unchanged here.
+ *
+ * WHAT THE GUARD DOES: `fieldValue` is `foldConfusables(normalizeUnicode(raw))`.
+ * When that returns a string equal to `raw` — every pure-ASCII document, which
+ * is nearly the whole SKILL.md corpus — the two calls are literally the same
+ * call: same compiled RegExp, same input, no `g`/`y` flag and therefore no
+ * lastIndex state. Skipping the second one cannot change any verdict; it only
+ * stops the engine paying for the identical scan twice.
+ *
+ * WHY IT IS WORTH A HELPER: the cost is not marginal on long inputs. Profiled
+ * 2026-08-05 (node --cpu-prof, three scanSkill() calls over a 26,635-byte benign
+ * SKILL.md with 780 rules loaded), 80.5% of all CPU sat in ONE rule's unanchored
+ * double-lookahead pattern — ATR-2026-00063's
+ * `(?=[\s\S]*\.env)(?=[\s\S]*(base64|...))` — which is O(n^2) in document length
+ * because it retries both lookaheads at every start position, and it was being
+ * paid twice per condition. Measured on this branch, same box, same rules:
+ *
+ *   3x scanSkill() on that 26,635-byte file : 7227ms -> 4010ms  (-44.5%)
+ *   whole 498-file skill benchmark corpus   : 67451ms -> 47558ms (-29.5%)
+ *
+ * with the matched-rule-id set for all 498 files byte-identical before and after
+ * (verified per file across all four evaluate() shapes and scanSkill()).
+ *
+ * The O(n^2) rule pattern itself is NOT touched here — changing a rule's regex
+ * is a detection change and needs its own re-measurement.
+ */
+function testNormalisedThenRaw(
+  regex: RegExp,
+  fieldValue: string,
+  rawFieldValue: string,
+): boolean {
+  if (safeRegexTest(regex, fieldValue)) return true;
+  if (rawFieldValue === fieldValue) return false;
+  return safeRegexTest(regex, rawFieldValue);
 }
 
 /**

--- a/tests/skill-path-coverage.test.ts
+++ b/tests/skill-path-coverage.test.ts
@@ -167,12 +167,14 @@ function ruleFileCount(dir = join(REPO_ROOT, "rules")): number {
  *
  * WHAT IT STILL CATCHES. It is a catastrophe deadline, deliberately. Readings
  * of THIS test, 780 rules, 149 strided samples:
- *   - CI, loaded, before the duplicate-regex fix in src/engine.ts : 1.906 ms/rule/sample
- *     (221,525ms — the run that produced the false red)
- *   - this box, quiet, after that fix                             : 0.172
- *     (19,969ms, in the 881-test suite run that verified this commit)
- * So 3.0 is 1.57x the worst reading ever taken here — a loaded runner on the
- * slower engine — and 17.4x a quiet one. Removing the `if (isAny) break;`
+ *   - CI, before the duplicate-regex fix in src/engine.ts : 1.906 ms/rule/sample
+ *     (221,525ms — run 30997081920, the one that produced the false red)
+ *   - CI, after it                                        : 1.004
+ *     (116,653ms — run 31004061103, green)
+ *   - this box, quiet, after it                           : 0.172
+ *     (19,969ms, in the full-suite run that verified this commit)
+ * So 3.0 is 1.57x the worst reading ever taken here, 2.99x what the CI runner
+ * now produces, and 17.4x a quiet box. Removing the `if (isAny) break;`
  * short-circuit, the change these tests exist to catch, takes the benign corpus
  * from 1 flagged sample to 265 and multiplies the matching work far past that.
  *

--- a/tests/skill-path-coverage.test.ts
+++ b/tests/skill-path-coverage.test.ts
@@ -1,0 +1,404 @@
+/**
+ * Tests for skillPathCoverage() — the third axis of "clean must never mean
+ * never looked at it".
+ *
+ * THE DEFECT THESE TESTS PIN
+ *
+ * matchedRuleIds() runs four evaluate() shapes AND engine.scanSkill(), and
+ * gate-promotion-fp prints `shapes = wide-raw, ..., skill`. That reads as "every
+ * rule you are gating was offered to the SKILL.md path". It is false for 645 of
+ * the 780 rules on main.
+ *
+ * scanSkill() sets `scanContext: 'skill'`, which makes the engine apply a
+ * compound gate to every rule that is not `scan_target: skill|both`:
+ *
+ *     const totalConds = Number(rule.detection?.conditions?.length ?? 1);
+ *     const minRequired = Math.max(2, Math.ceil(totalConds * 0.3));
+ *     if ((matchResult.matchedConditions?.length ?? 0) < minRequired) continue;
+ *
+ * The comment beside it describes a graded "30% of conditions" threshold. It is
+ * not one. `matchedConditions` comes from evaluateArrayConditions, which BREAKS
+ * on the first matching condition when `condition: any` — so its length is 1
+ * whenever the rule matched at all, and minRequired is never below 2. 776 of the
+ * 780 rules declare `condition: any`. For them the gate is an unconditional
+ * reject.
+ *
+ * WHY THIS IS NOT "FIXED" HERE
+ *
+ * Measured 2026-08-05 on this branch: stop short-circuiting in skill context and
+ * the 466-sample benign skill corpus goes from 1 flagged sample to 265 (7 new
+ * rules, 406 new false positives) while malicious recall stays 32/32. The
+ * runtime behaviour is load-bearing; what was wrong was the claim that the gate
+ * measured it. So the fix is a coverage dimension, and these tests keep it
+ * honest — every assertion below is proved through the REAL engine, not against
+ * a hand-written expectation of what the engine does.
+ */
+
+import { describe, it, expect } from "vitest";
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join, resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { ATREngine } from "../src/engine.js";
+import {
+  skillPathBlocker,
+  skillPathCoverage,
+  SKILL_NATIVE_SCAN_TARGETS,
+  type RuleLike,
+  type SkillPathGap,
+} from "../scripts/lib/corpus-event.js";
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+/**
+ * Counts on main at 70bd9cabb, re-derived by this file from the rules on disk.
+ * They are a RATCHET, not a specification: the corpus grows daily, so the
+ * assertions below are bounds and invariants, and this block exists so a reader
+ * can tell whether a change moved the number and by how much.
+ */
+const MEASURED_ON_MAIN = Object.freeze({
+  rules: 780,
+  skillPathUnreachable: 645,
+  unreachableInEnforceLane: 102,
+  reachable: 128,
+  inertStatus: 7,
+});
+
+let cachedEngine: ATREngine | null = null;
+async function engine(): Promise<ATREngine> {
+  if (cachedEngine === null) {
+    const e = new ATREngine({ rulesDir: join(REPO_ROOT, "rules") });
+    await e.loadRules();
+    cachedEngine = e;
+  }
+  return cachedEngine;
+}
+
+/** Flatten a test-case object into the most favourable single SKILL.md body. */
+function flattenTestCase(v: unknown): string {
+  if (v === null || v === undefined) return "";
+  if (typeof v === "string") return v;
+  if (Array.isArray(v)) return v.map(flattenTestCase).join("\n");
+  if (typeof v === "object") {
+    return Object.values(v as Record<string, unknown>).map(flattenTestCase).join("\n");
+  }
+  return String(v);
+}
+
+/**
+ * Best-case skill documents for a rule: its OWN declared true positives, every
+ * field value poured into one body. In skill context resolveField() returns
+ * event.content for every field name, so this is the most generous input the
+ * rule can possibly receive on that path. If it still cannot fire, nothing can
+ * make it fire.
+ */
+function ownTruePositiveDocuments(
+  rule: { test_cases?: { true_positives?: unknown[] } },
+  limit = Number.POSITIVE_INFINITY,
+): string[] {
+  const out: string[] = [];
+  for (const tp of rule.test_cases?.true_positives ?? []) {
+    if (out.length >= limit) break;
+    const text = flattenTestCase(tp);
+    if (text.trim() !== "") out.push(text);
+  }
+  return out;
+}
+
+function corpusFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) out.push(...corpusFiles(full));
+    else if (full.endsWith(".md")) out.push(full);
+  }
+  return out.sort();
+}
+
+/**
+ * scanSkill() over a whole SKILL.md costs ~240ms with 780 rules loaded, so the
+ * full 498-file benchmark is a two-minute test on its own. These suites take
+ * every malicious sample and a deterministic stride through the benign ones —
+ * enough to catch a predicate that has drifted, cheap enough to run per PR. The
+ * exhaustive sweep (all 466 benign, all true positives of all 780 rules, 4507
+ * documents) was run once by hand on this branch and agreed with the predicate
+ * on every rule; these bounds keep it that way without paying for it each time.
+ */
+const BENIGN_STRIDE = 4;
+const MAX_TP_DOCS_PER_RULE = 2;
+
+describe("skillPathCoverage — the skill half of matchedRuleIds asks almost nothing", () => {
+  it("reports a gap for every rule that cannot match on the skill path, and none for the rest", async () => {
+    const e = await engine();
+    const rules = e.getRules() as unknown as RuleLike[];
+    const gaps = skillPathCoverage(rules);
+    const gapIds = new Set(gaps.map((g) => g.ruleId));
+
+    expect(rules.length).toBeGreaterThanOrEqual(MEASURED_ON_MAIN.rules);
+    expect(gaps.length).toBeGreaterThan(0);
+    // Every rule is in exactly one bucket: gap, inert status, or reachable.
+    const inert = rules.filter((r) => r.status === "draft" || r.status === "deprecated");
+    for (const r of inert) {
+      expect(gapIds.has(r.id), `${r.id} is inert — statusCoverage owns it, not this axis`).toBe(
+        false,
+      );
+    }
+  });
+
+  it(
+    "NO rule it calls unreachable can be made to fire on the skill path by its own true positives",
+    async () => {
+      const e = await engine();
+      const rules = e.getRules() as unknown as (RuleLike & {
+        test_cases?: { true_positives?: unknown[] };
+      })[];
+      const gapIds = new Set(skillPathCoverage(rules).map((g) => g.ruleId));
+
+      const falsified: string[] = [];
+      for (const rule of rules) {
+        if (!gapIds.has(rule.id)) continue;
+        for (const doc of ownTruePositiveDocuments(rule, MAX_TP_DOCS_PER_RULE)) {
+          if (e.scanSkill(doc).some((m) => m.rule.id === rule.id)) {
+            falsified.push(rule.id);
+            break;
+          }
+        }
+      }
+      expect(
+        falsified,
+        "these rules were reported as structurally unable to fire on engine.scanSkill(), " +
+          "but they fired on their own declared attack samples. skillPathBlocker() no longer " +
+          "mirrors src/engine.ts — fix the predicate before trusting any coverage report.",
+      ).toEqual([]);
+    },
+    170_000,
+  );
+
+  it(
+    "the benign and malicious skill corpora trip ONLY rules it calls reachable",
+    async () => {
+      const e = await engine();
+      const gapIds = new Set(
+        skillPathCoverage(e.getRules() as unknown as RuleLike[]).map((g) => g.ruleId),
+      );
+      const benign = corpusFiles(join(REPO_ROOT, "data/skill-benchmark/benign"));
+      const malicious = corpusFiles(join(REPO_ROOT, "data/skill-benchmark/malicious"));
+      expect(benign.length + malicious.length).toBeGreaterThan(400);
+      const files = [...malicious, ...benign.filter((_, i) => i % BENIGN_STRIDE === 0)];
+
+      const fired = new Set<string>();
+      for (const file of files) {
+        for (const m of e.scanSkill(readFileSync(file, "utf-8"))) fired.add(m.rule.id);
+      }
+      expect(fired.size).toBeGreaterThan(0);
+      expect(
+        [...fired].filter((id) => gapIds.has(id)),
+        "a rule reported as unreachable on the skill path fired on the skill benchmark",
+      ).toEqual([]);
+    },
+    170_000,
+  );
+
+  it("names the enforce-lane rules the skill path never asks about", async () => {
+    const e = await engine();
+    const gaps = skillPathCoverage(e.getRules() as unknown as RuleLike[]);
+    const enforce = gaps.filter((g) => g.claimsEnforceLane);
+    // Not zero, and that is the finding. Every one of them is measured on the
+    // evaluate() shapes; none of them is measured on the skill shape.
+    expect(enforce.length).toBeGreaterThan(0);
+    for (const g of enforce) {
+      expect(g.maturity).toBe("stable");
+      expect(g.reason).not.toBe("");
+    }
+  });
+
+  it("every enforce-lane rule the skill path cannot reach IS measurable on the evaluate() shapes", async () => {
+    const e = await engine();
+    const rules = e.getRules() as unknown as (RuleLike & {
+      maturity?: string;
+      test_cases?: { true_positives?: unknown[] };
+    })[];
+    const gapIds = new Set(skillPathCoverage(rules).map((g) => g.ruleId));
+
+    const { corpusShapes } = await import("../scripts/lib/corpus-event.js");
+    const blindEverywhere: string[] = [];
+    for (const rule of rules) {
+      if (rule.maturity !== "stable" || !gapIds.has(rule.id)) continue;
+      const docs = ownTruePositiveDocuments(rule, MAX_TP_DOCS_PER_RULE);
+      if (docs.length === 0) continue;
+      const firesSomewhere = docs.some((doc) =>
+        corpusShapes(doc).some((s) => e.evaluate(s.event).some((m) => m.rule.id === rule.id)),
+      );
+      if (!firesSomewhere) blindEverywhere.push(rule.id);
+    }
+    expect(
+      blindEverywhere,
+      "these enforce-lane rules cannot fire on the skill path AND cannot fire on any " +
+        "evaluate() shape with their own attack samples — their 0 FP is a zero measurement " +
+        "on every path the gate has, which is a promotion that must not stand",
+    ).toEqual([]);
+  }, 170_000);
+});
+
+describe("the predicate mirrors src/engine.ts rather than restating it", () => {
+  const engineSource = (): string => readFileSync(join(REPO_ROOT, "src/engine.ts"), "utf-8");
+
+  it("the skill compound gate still exempts exactly scan_target skill and both", () => {
+    const src = engineSource();
+    const occurrences = [
+      ...src.matchAll(
+        /isSkillContext\s*&&\s*rule\.tags\.scan_target\s*!==\s*'([a-z]+)'\s*&&\s*rule\.tags\.scan_target\s*!==\s*'([a-z]+)'/g,
+      ),
+    ];
+    expect(
+      occurrences.length,
+      "the skill compound gate moved or changed shape — re-derive skillPathBlocker()",
+    ).toBe(2); // evaluateRaw + evaluateAsync
+    for (const m of occurrences) {
+      expect(new Set([m[1] as string, m[2] as string])).toEqual(SKILL_NATIVE_SCAN_TARGETS);
+    }
+  });
+
+  it("the compound gate still demands max(2, ceil(0.3 * conditions))", () => {
+    const src = engineSource();
+    expect(src).toContain("Math.max(2, Math.ceil(totalConds * 0.3))");
+    expect(src).toContain("Number(rule.detection?.conditions?.length ?? 1)");
+  });
+
+  it("evaluateArrayConditions still short-circuits, which is what caps matchedConditions at 1", () => {
+    const src = engineSource();
+    const start = src.indexOf("private evaluateArrayConditions(");
+    expect(start).toBeGreaterThan(0);
+    const body = src.slice(start, src.indexOf("\n  }", start));
+    expect(
+      /if\s*\(isAny\)\s*break;/.test(body),
+      "the any-mode short-circuit is gone. matchedConditions can now exceed 1, so the " +
+        "skill compound gate has become reachable and rules that were structurally silent " +
+        "on SKILL.md will start firing. Re-measure the benign skill corpus before shipping.",
+    ).toBe(true);
+  });
+});
+
+describe("skillPathBlocker — the individual mechanisms", () => {
+  const base = (over: Partial<RuleLike> = {}): RuleLike => ({
+    id: "ATR-2026-90001",
+    status: "experimental",
+    maturity: "test",
+    tags: { scan_target: "mcp" },
+    detection: {
+      condition: "any",
+      conditions: [{ field: "content", operator: "regex", value: "x" }],
+    },
+    ...over,
+  });
+
+  const blockerOf = (rule: RuleLike): SkillPathGap | null => skillPathBlocker(rule);
+
+  it("an any-mode rule is unreachable no matter how many conditions it declares", () => {
+    for (const n of [1, 2, 5, 13]) {
+      const rule = base({
+        detection: {
+          condition: "any",
+          conditions: Array.from({ length: n }, () => ({ field: "content", operator: "regex", value: "x" })),
+        },
+      });
+      const gap = blockerOf(rule);
+      expect(gap?.blocker, `${n} conditions`).toBe("compound-gate-unreachable");
+      expect(gap?.maxAttainableConditions).toBe(1);
+      expect(gap?.requiredConditions).toBeGreaterThanOrEqual(2);
+    }
+  });
+
+  it("an all-mode rule with 2+ conditions is reachable", () => {
+    const rule = base({
+      detection: {
+        condition: "all",
+        conditions: [
+          { field: "content", operator: "regex", value: "x" },
+          { field: "content", operator: "regex", value: "y" },
+        ],
+      },
+    });
+    expect(blockerOf(rule)).toBeNull();
+  });
+
+  it("an all-mode rule with one condition is unreachable — it can never report 2", () => {
+    const rule = base({
+      detection: {
+        condition: "all",
+        conditions: [{ field: "content", operator: "regex", value: "x" }],
+      },
+    });
+    expect(blockerOf(rule)?.blocker).toBe("compound-gate-unreachable");
+  });
+
+  it.each([...SKILL_NATIVE_SCAN_TARGETS])("scan_target %s is exempt from the gate", (target) => {
+    expect(blockerOf(base({ tags: { scan_target: target } }))).toBeNull();
+  });
+
+  it.each([
+    ["trace", "method-trace"],
+    ["behavioral", "method-behavioral"],
+    ["signature", "method-signature"],
+  ])("method %s is unreachable on the skill path even with scan_target: skill", (method, blocker) => {
+    const rule = base({
+      tags: { scan_target: "skill" },
+      detection: { method, condition: "any", conditions: [{ field: "content" }] },
+    });
+    expect(blockerOf(rule)?.blocker).toBe(blocker);
+  });
+
+  it("a semantic rule is unreachable unless it falls back to pattern", () => {
+    const noFallback = base({
+      tags: { scan_target: "skill" },
+      detection: { method: "semantic", condition: "any", conditions: [{ field: "content" }] },
+    });
+    expect(blockerOf(noFallback)?.blocker).toBe("method-semantic-no-pattern-fallback");
+
+    const withFallback = base({
+      tags: { scan_target: "skill" },
+      detection: {
+        method: "semantic",
+        semantic: { fallback_method: "pattern" },
+        condition: "any",
+        conditions: [{ field: "content" }],
+      },
+    });
+    expect(blockerOf(withFallback)).toBeNull();
+  });
+
+  it("a named-map with a single condition is unreachable (conditions.length is undefined -> 1)", () => {
+    const rule = base({
+      detection: {
+        condition: "only_one",
+        conditions: { only_one: { field: "content", patterns: ["x"] } },
+      },
+    });
+    const gap = blockerOf(rule);
+    expect(gap?.blocker).toBe("compound-gate-unreachable");
+    expect(gap?.maxAttainableConditions).toBe(1);
+    expect(gap?.requiredConditions).toBe(2);
+  });
+
+  it("an inert rule is left to statusCoverage rather than double-reported", () => {
+    expect(blockerOf(base({ status: "draft" }))).toBeNull();
+    expect(blockerOf(base({ status: "deprecated" }))).toBeNull();
+  });
+
+  it("records the numbers measured on main so a change is visible, not silent", async () => {
+    const e = await engine();
+    const rules = e.getRules() as unknown as RuleLike[];
+    const gaps = skillPathCoverage(rules);
+    // Bounds, not equalities: the corpus grows. A DROP means the skill path just
+    // started evaluating rules it never did — that is a detection-behaviour
+    // change and must be deliberate.
+    expect(
+      gaps.length,
+      `skill-path-unreachable count fell below the ${MEASURED_ON_MAIN.skillPathUnreachable} ` +
+        `measured on main@70bd9cabb. If that was intended, re-run the benign skill corpus ` +
+        `(466 samples, 1 flagged before) and update this ratchet with the new number.`,
+    ).toBeGreaterThanOrEqual(MEASURED_ON_MAIN.skillPathUnreachable);
+    expect(gaps.filter((g) => g.claimsEnforceLane).length).toBeGreaterThanOrEqual(
+      MEASURED_ON_MAIN.unreachableInEnforceLane,
+    );
+  });
+});

--- a/tests/skill-path-coverage.test.ts
+++ b/tests/skill-path-coverage.test.ts
@@ -115,8 +115,8 @@ function corpusFiles(dir: string): string[] {
 }
 
 /**
- * scanSkill() over a whole SKILL.md costs ~240ms with 780 rules loaded, so the
- * full 498-file benchmark is a two-minute test on its own. These suites take
+ * scanSkill() over a whole SKILL.md is expensive with 780 rules loaded, so the
+ * full 498-file benchmark is a multi-minute test on its own. These suites take
  * every malicious sample and a deterministic stride through the benign ones —
  * enough to catch a predicate that has drifted, cheap enough to run per PR. The
  * exhaustive sweep (all 466 benign, all true positives of all 780 rules, 4507
@@ -125,6 +125,65 @@ function corpusFiles(dir: string): string[] {
  */
 const BENIGN_STRIDE = 4;
 const MAX_TP_DOCS_PER_RULE = 2;
+
+/** Malicious samples are all swept; benign are strided. Fixed at collection. */
+const SWEPT_CORPUS_FILES: readonly string[] = Object.freeze([
+  ...corpusFiles(join(REPO_ROOT, "data/skill-benchmark/malicious")),
+  ...corpusFiles(join(REPO_ROOT, "data/skill-benchmark/benign")).filter(
+    (_, i) => i % BENIGN_STRIDE === 0,
+  ),
+]);
+
+/** Rule files on disk, counted rather than remembered. */
+function ruleFileCount(dir = join(REPO_ROOT, "rules")): number {
+  let n = 0;
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) n += ruleFileCount(full);
+    else if (full.endsWith(".yaml")) n += 1;
+  }
+  return n;
+}
+
+/**
+ * DEADLINE FOR A scanSkill() SWEEP — derived, not chosen.
+ *
+ * This test first shipped with a flat `170_000`. On CI it needed 221,525ms and
+ * was reported as a failure, which is the worst possible way for it to fail:
+ * the assertion inside it had in fact been satisfied (re-run by hand on the FULL
+ * 498-file corpus, not just the strided 149: zero rules called unreachable
+ * fired), so a green predicate was showing up in the log as a red ratchet. A
+ * flat millisecond deadline over work that grows with both the corpus and the
+ * rule set measures the runner, which is the defect #418 removed from
+ * tests/eval-harness.test.ts and tests/skill-benchmark.test.ts.
+ *
+ * So the deadline is expressed in the SAME unit its sibling already uses. The
+ * catastrophe ceiling in tests/skill-benchmark.test.ts is 3.0ms per rule per
+ * sample over this identical corpus and this identical scanSkill() call —
+ * ~9.5x the quiet reading that test records, and the number #418 derived. This
+ * sweep scans a known number of samples against a known number of rules, so its
+ * deadline is that ceiling times the work assigned to it, and rule growth (the
+ * point of the project) can never walk into it.
+ *
+ * WHAT IT STILL CATCHES. It is a catastrophe deadline, deliberately. Readings
+ * of THIS test, 780 rules, 149 strided samples:
+ *   - CI, loaded, before the duplicate-regex fix in src/engine.ts : 1.906 ms/rule/sample
+ *     (221,525ms — the run that produced the false red)
+ *   - this box, quiet, after that fix                             : 0.172
+ *     (19,969ms, in the 881-test suite run that verified this commit)
+ * So 3.0 is 1.57x the worst reading ever taken here — a loaded runner on the
+ * slower engine — and 17.4x a quiet one. Removing the `if (isAny) break;`
+ * short-circuit, the change these tests exist to catch, takes the benign corpus
+ * from 1 flagged sample to 265 and multiplies the matching work far past that.
+ *
+ * Sanity check on the absolute size: tests/skill-benchmark.test.ts already gives
+ * its beforeAll 600,000ms on CI to sweep all 498 samples the same way. This
+ * deadline is smaller than that for a smaller sweep.
+ */
+const CATASTROPHE_MS_PER_RULE_PER_SAMPLE = 3.0;
+const CORPUS_SWEEP_TIMEOUT_MS = Math.ceil(
+  SWEPT_CORPUS_FILES.length * ruleFileCount() * CATASTROPHE_MS_PER_RULE_PER_SAMPLE,
+);
 
 describe("skillPathCoverage — the skill half of matchedRuleIds asks almost nothing", () => {
   it("reports a gap for every rule that cannot match on the skill path, and none for the rest", async () => {
@@ -183,7 +242,10 @@ describe("skillPathCoverage — the skill half of matchedRuleIds asks almost not
       const benign = corpusFiles(join(REPO_ROOT, "data/skill-benchmark/benign"));
       const malicious = corpusFiles(join(REPO_ROOT, "data/skill-benchmark/malicious"));
       expect(benign.length + malicious.length).toBeGreaterThan(400);
-      const files = [...malicious, ...benign.filter((_, i) => i % BENIGN_STRIDE === 0)];
+      // Same list the deadline was derived from, so the budget and the work
+      // cannot drift apart.
+      const files = SWEPT_CORPUS_FILES;
+      expect(files.length).toBe(malicious.length + Math.ceil(benign.length / BENIGN_STRIDE));
 
       const fired = new Set<string>();
       for (const file of files) {
@@ -195,7 +257,7 @@ describe("skillPathCoverage — the skill half of matchedRuleIds asks almost not
         "a rule reported as unreachable on the skill path fired on the skill benchmark",
       ).toEqual([]);
     },
-    170_000,
+    CORPUS_SWEEP_TIMEOUT_MS,
   );
 
   it("names the enforce-lane rules the skill path never asks about", async () => {


### PR DESCRIPTION
The number in the brief was 68. Counted properly, it is **645 of 780 rules that can never fire on the `scanSkill()` path**, 102 of them `maturity: stable`.

## The verdict: the design is right, the measurement was wrong

The instinct on finding 645 unreachable rules is to make them reachable. That would be a disaster, and this PR does not do it.

`scanSkill()` reads a static SKILL.md manifest. A rule keyed on `tool_response` has no tool response to read; a rule keyed on runtime behaviour has no runtime. Firing them against manifest text would not add detection, it would add false positives to the path that gates what gets installed. **The rules are correctly excluded.**

What was wrong is that nothing said so. The FP gate ran the `skill` shape across all 780 rules and reported clean, and for 645 of them "clean" meant "not asked". Same disease as the narrow event shape (#414), the truncated id list (#417) and the non-recursive corpus loader (#419) — a gate reporting a pass it never earned.

## The fix is a third coverage dimension

`scripts/lib/corpus-event.ts` already had two:

- `fieldCoverage()` — this rule reads a field no shape presents
- `statusCoverage()` — this rule's status keeps the engine from evaluating it at all

Added `skillPathCoverage()` — this rule cannot reach the `scanSkill()` entry point, so the `skill` shape's verdict on it is silence, not evidence. The gate now **says** that instead of folding it into the clean count.

## The 102 enforce-lane rules, individually accounted for

They are the ones that would matter if this were a real gap: `maturity: stable` is the auto-block lane. Each was checked against the `evaluate()` shapes, and **all 102 are genuinely measured there** — their FP-clean status rests on real measurement, just not on the skill path. Listed in the PR thread.

This is also the counterpart to #420, which discloses that the enforce lane scores 0% on the SKILL.md corpus. #420 says the gap exists; this says the gap is a design boundary and makes the tooling stop pretending otherwise. Neither closes it — closing it means promoting skill-scanning rules to `stable`, which needs wild-corpus evidence that #417 showed nothing currently has.

## The ratchet bites

Same pattern as `tests/corpus-event-shapes.test.ts`: the conclusion is written as an assertion, not a comment. The test was verified to fail when the coverage dimension is removed — a ratchet that cannot fail is decoration, so it was checked rather than assumed.
