### PR TITLE
fix(compliance): grade the Article 50 mappings secondary, not primary

### DIFF
--- a/rules/model-abuse/ATR-2026-02411-ai-provenance-metadata-stripping.yaml
+++ b/rules/model-abuse/ATR-2026-02411-ai-provenance-metadata-stripping.yaml
@@ -62,8 +62,12 @@ compliance:
         therefore does not detect a breach of 50(2). What it detects is
         targeted destruction of exactly the marking 50(2) mandates, which is
         runtime evidence bearing on whether the robustness condition in that
-        paragraph actually holds in deployment.
-      strength: primary
+        paragraph actually holds in deployment. Graded secondary rather than
+        primary for that reason: a consumer filtering this framework on
+        article and strength alone, without reading this context, would
+        otherwise be led to treat the rule as evidence of an Article 50 breach.
+        It is not. The primary mapping for this rule is Article 15.
+      strength: secondary
     - article: "15"
       context: >
         Article 15 requires accuracy, robustness and cybersecurity. An agent

--- a/rules/model-abuse/ATR-2026-02412-generative-watermark-removal-tooling.yaml
+++ b/rules/model-abuse/ATR-2026-02412-generative-watermark-removal-tooling.yaml
@@ -54,7 +54,11 @@ compliance:
         this rule does not detect a breach of it. It detects use of tooling
         built specifically to defeat that marking, which is the direct evidence
         of whether the robustness condition holds once a system is deployed.
-      strength: primary
+        Graded secondary rather than primary for that reason: a consumer
+        filtering this framework on article and strength alone, without reading
+        this context, would otherwise be led to treat the rule as evidence of
+        an Article 50 breach. It is not. The primary mapping is Article 15.
+      strength: secondary
     - article: "15"
       context: >
         Detecting attempts to defeat an integrity control on generated output is


### PR DESCRIPTION
Follow-up to #422, narrowing a claim it made too strongly.

#422 mapped ATR-2026-02411 and ATR-2026-02412 to `article: "50"` with `strength: primary`. The `context` prose on both was already explicit that Article 50(2) binds **providers to mark** and contains no prohibition on anyone removing a marking, so the rules do not detect a breach of it.

But `strength` is the machine-readable field, and `context` is prose. A downstream consumer filtering this framework on `article` + `strength` — which is exactly how these blocks get consumed — would read `primary` as "this rule detects an Article 50 violation". The prose disclaiming it never reaches them.

`secondary` states the relationship correctly at the level that is actually parsed. The rules genuinely do bear on Article 50: they produce runtime evidence about whether the *robustness* condition in 50(2) holds in deployment. That is a real relationship and worth keeping mapped — it is just not primary evidence for the article.

**Article 15 remains `primary`** on both. Resisting an attack on an integrity control is what Article 15 is, and that mapping was never in question.

ATR-2026-02413 already carried Article 50 as `secondary` and is unchanged. All three rules are now consistent.

## Diff

Two files, 11 insertions, 3 deletions. Only the Article 50 sub-block moves: `strength` flips, and each context gains a sentence stating why it is graded secondary so the next reader does not have to reconstruct this reasoning.

## Checks run locally

```
tests/validate-rules.ts        783 passed, 0 failed
scripts/validate-compliance.ts 0 violations across 783 mapped rules
generate-attack-crosswalk.py --check   OK
generate-ast-crosswalk.py --check      OK
```

No detection logic, test case or reference is touched, so the FP, inert, regex-cost and RE2 gates see no change in what they measure.