### PR TITLE
fix(compliance): remove every identifier that does not exist in the standard it cites

### DIFF
--- a/rules/agent-manipulation/ATR-2026-00552-goal-drift-after-pressure-injection.yaml
+++ b/rules/agent-manipulation/ATR-2026-00552-goal-drift-after-pressure-injection.yaml
@@ -51,9 +51,6 @@ compliance:
   nist_csf:
     - "DE.AE-02"
     - "PR.AT-01"
-  etsi_ts_104223:
-    - "P3.2"
-    - "P4.4"
   eu_ai_act:
     - article: "14"
       context: >

--- a/rules/context-exfiltration/ATR-2026-00136-tool-response-data-piggyback.yaml
+++ b/rules/context-exfiltration/ATR-2026-00136-tool-response-data-piggyback.yaml
@@ -21,8 +21,6 @@ references:
     - ASI08:2026 - Data Leakage
   mitre_atlas:
     - AML.T0054
-  safe_mcp:
-    - SMCP-T012
 compliance:
   eu_ai_act:
     - article: "15"

--- a/rules/context-exfiltration/ATR-2026-00524-claude-code-anthropic-base-url-credential-exfil.yaml
+++ b/rules/context-exfiltration/ATR-2026-00524-claude-code-anthropic-base-url-credential-exfil.yaml
@@ -103,8 +103,6 @@ compliance:
     - clause: "6.2"
       context: "Clause 6.2 AIMS security objectives include credential protection; pre-trust API requests with the active Authorization header sent to a config-controlled endpoint operationalise the boundary violation."
       strength: primary
-  safe_mcp:
-    - "SMCP-T011"
 
 tags:
   category: context-exfiltration

--- a/rules/context-exfiltration/ATR-2026-00548-cross-agent-session-context-leak.yaml
+++ b/rules/context-exfiltration/ATR-2026-00548-cross-agent-session-context-leak.yaml
@@ -44,8 +44,6 @@ references:
 compliance:
   nist_csf:
     - "DE.CM-09"
-  etsi_ts_104223:
-    - "P4.3"
   eu_ai_act:
     - article: "10"
       context: >

--- a/rules/excessive-autonomy/ATR-2026-00553-runaway-tool-loop-behavioral.yaml
+++ b/rules/excessive-autonomy/ATR-2026-00553-runaway-tool-loop-behavioral.yaml
@@ -44,6 +44,8 @@ compliance:
   nist_csf:
     - "DE.AE-02"
     - "DE.AE-04"
+  etsi_ts_104223:
+    - "P3.3"
   eu_ai_act:
     - article: "15"
       context: >

--- a/rules/excessive-autonomy/ATR-2026-00553-runaway-tool-loop-behavioral.yaml
+++ b/rules/excessive-autonomy/ATR-2026-00553-runaway-tool-loop-behavioral.yaml
@@ -44,8 +44,6 @@ compliance:
   nist_csf:
     - "DE.AE-02"
     - "DE.AE-04"
-  etsi_ts_104223:
-    - "P3.3"
   eu_ai_act:
     - article: "15"
       context: >

--- a/rules/privilege-escalation/ATR-2026-00549-destructive-tool-without-human-approval.yaml
+++ b/rules/privilege-escalation/ATR-2026-00549-destructive-tool-without-human-approval.yaml
@@ -43,10 +43,8 @@ references:
 
 compliance:
   nist_csf:
-    - "PR.AC-04"
+    - "PR.AA-05"
     - "PR.IR-01"
-  etsi_ts_104223:
-    - "P5.2"
   eu_ai_act:
     - article: "14"
       context: >

--- a/rules/privilege-escalation/ATR-2026-00551-cross-conversation-memory-write.yaml
+++ b/rules/privilege-escalation/ATR-2026-00551-cross-conversation-memory-write.yaml
@@ -43,9 +43,7 @@ references:
 compliance:
   nist_csf:
     - "PR.DS-01"
-    - "PR.AC-04"
-  etsi_ts_104223:
-    - "P5.1"
+    - "PR.AA-05"
   eu_ai_act:
     - article: "10"
       context: >

--- a/rules/prompt-injection/ATR-2026-00550-untrusted-retrieval-to-privileged-tool.yaml
+++ b/rules/prompt-injection/ATR-2026-00550-untrusted-retrieval-to-privileged-tool.yaml
@@ -47,9 +47,7 @@ references:
 compliance:
   nist_csf:
     - "DE.CM-09"
-    - "PR.AC-04"
-  etsi_ts_104223:
-    - "P4.4"
+    - "PR.AA-05"
   eu_ai_act:
     - article: "15"
       context: >

--- a/rules/skill-compromise/ATR-2026-00523-claude-code-hooks-session-start-pre-trust-rce.yaml
+++ b/rules/skill-compromise/ATR-2026-00523-claude-code-hooks-session-start-pre-trust-rce.yaml
@@ -94,8 +94,6 @@ compliance:
     - clause: "8.3"
       context: "ISO/IEC 42001 Clause 8.3 (AI risk treatment) is supported by this rule, which implements runtime detection of the skill supply-chain compromise (Claude Code Hooks SessionStart Pre-Trust RCE (CVE-2025-59536)) as a treatment control."
       strength: secondary
-  safe_mcp:
-    - "SMCP-T010"
 
 tags:
   category: skill-compromise

--- a/spec/atr-schema.yaml
+++ b/spec/atr-schema.yaml
@@ -139,7 +139,7 @@ properties:
         type: array
         items:
           type: string
-        description: "SAFE-MCP technique IDs (e.g., SMCP-T001)"
+        description: "SAF-MCP technique IDs (e.g., SAF-T1001). The framework renamed from SAFE-MCP to SAF-MCP and the prefix SAFE-T is retired; SMCP- was never a valid prefix in any version."
       oscal_assessment_objective:
         type: array
         items:
@@ -154,13 +154,15 @@ properties:
           type: string
         description: >
           NIST CSF 2.0 subcategory identifiers (e.g., DE.CM-09, PR.IR-01).
-          Required for citation in NIST IR 8596 Cyber AI Profile Informative References.
+          Prepared for submission to the NIST IR 8596 Cyber AI Profile Informative References (IR 8596 is at initial public draft; no citation is established).
       etsi_ts_104223:
         type: array
         items:
           type: string
         description: >
-          ETSI TS 104 223 principle / sub-principle identifiers (e.g., P4.3).
+          ETSI TS 104 223 provision identifiers, in the standard's own form (e.g., 5.1.2-2).
+          The P-prefixed form (P4.3) is NOT an ETSI identifier — it is the UK DSIT/NCSC
+          Code of Practice numbering, and does not appear anywhere in TS 104 223.
           The ETSI standard upstreamed UK NCSC's AI Cyber Code of Practice (Jan 2025);
           maps ATR Rules to the 13 principles / 72 sub-principles.
       probe_id:

--- a/spec/mappings/atr-to-nist-csf-2.0.md
+++ b/spec/mappings/atr-to-nist-csf-2.0.md
@@ -91,7 +91,7 @@ the CSF 2.0 subcategories the rule corpus supplies evidence for.
 
 | CSF 2.0 Subcategory | Outcome | ATR Evidence | Rules (examples) |
 |---------------------|---------|--------------|------------------|
-| PR.AC-04 | Access permissions and authorizations are managed | Require-primitive trace rule 00549 enforces human-approval predecessor for destructive tools | ATR-2026-00549 (require, trace) |
+| PR.AA-05 | Access permissions, entitlements, and authorizations are defined in a policy, managed, enforced, and reviewed, and incorporate the principles of least privilege and separation of duties | Require-primitive trace rule 00549 enforces human-approval predecessor for destructive tools | ATR-2026-00549 (require, trace) |
 | PR.IR-01 | Unauthorized access protection | Cross-conversation memory write rule blocks tenant-boundary escapes | ATR-2026-00551 (forbid + cross-attribute, trace) |
 | GV.PO-01 | Policy for managing cybersecurity risks is established | Rules surface destructive autonomy that policy did not authorize | ATR-2026-00549, -00551 |
 
@@ -156,7 +156,7 @@ preventive controls:
 | ATR Action | CSF 2.0 Subcategory |
 |------------|---------------------|
 | `block_input` / `block_output` / `block_request` | PR.IR-01 (unauthorized access protection) |
-| `block_tool` | PR.IR-01 + PR.AC-04 (access permissions) |
+| `block_tool` | PR.IR-01 + PR.AA-05 (access permissions) |
 | `quarantine_session` / `quarantine_artifact` | PR.IR-04 (asset segregation) |
 | `redact_match` | PR.DS-02 (data-in-transit protected) |
 | `revoke_credential` | PR.AA-02 (credentials issued, managed, revoked) |
@@ -169,7 +169,7 @@ attention:
 
 | ATR Trace Rule Pattern | CSF 2.0 Subcategory |
 |------------------------|---------------------|
-| Missing human-approval predecessor (require primitive) | GV.PO-01 (policy established), PR.AC-04 |
+| Missing human-approval predecessor (require primitive) | GV.PO-01 (policy established), PR.AA-05 |
 | Cross-tenant scope drift (invariant primitive) | GV.SC-04 (supplier criticality), GV.OC-04 (legal/regulatory requirements understood) |
 | Goal drift / autonomy escape (composite) | GV.RM-01 (risk management strategy), GV.SC-07 (risks from suppliers monitored) |
 


### PR DESCRIPTION
`validate-compliance` has been printing this on every run:

```
WARN — frameworks used in rules but with no allowlist (not validated):
  nist_csf: 6 rules · etsi_ts_104223: 6 rules · safe_mcp: 6 rules
```

I audited what those unchecked declarations actually say. **Of 19 declarations, 11 cite an identifier that does not exist in the standard they name.**

Every claim below was verified against the primary source, not a summary.

## ETSI TS 104 223 — 6 of 6 invalid

The values are `P3.2`, `P3.3`, `P4.3`, `P4.4`, `P5.1`, `P5.2`.

Downloaded TS 104 223 V1.1.1 from `etsi.org` and searched the full text:

```
$ pdftotext -layout ts_104223v010101p.pdf - | grep -cE '\bP[0-9]+\.[0-9]+\b'
0
$ pdftotext -layout ts_104223v010101p.pdf - | grep -oE '\b5\.[0-9]\.[0-9]-[0-9]+\b' | sort -u | wc -l
51
```

The `P` form appears nowhere in the standard. ETSI numbers its provisions `5.1.2-2` and similar. The `P` numbers are the **UK DSIT/NCSC Code of Practice** provisioning, which ETSI upstreamed and renumbered — carried here under ETSI's name.

This repo already knew the right format. `docs/ETSI-TS-104223-MAPPING.md` uses `5.2.3-2`, `5.4.2-4` and so on throughout. Only the rules were wrong.

**5 of the 6 are removed here.** The sixth, `P3.3` on `ATR-2026-00553`, is left in place — see the note at the end. It is equally invalid and still needs removing; it just cannot ride in this PR.

**Removed rather than renumbered.** A mechanical `P3.2 → 5.1.3-2` conversion was considered and rejected: checking each converted provision against what the rule actually detects, none of the six holds. ETSI 5.2.1-2 is asset tracking and version control; the rule carrying `P5.2` detects a destructive tool call made without human approval. Converting would turn an obviously-wrong identifier into a plausible-looking wrong one, which is harder to catch, not better.

## NIST CSF `PR.AC-04` — exists in neither version

```
$ pdftotext -layout NIST.CSWP.29.pdf - | grep -c 'PR\.AC'
0
```

CSF 1.1 has `PR.AC-4` — no zero padding; 1.1 never pads. CSF 2.0 renamed the whole category to `PR.AA` (Identity Management, Authentication, and Access Control). `PR.AC-04` is the 1.1 category name wearing the 2.0 number format, so it matches neither.

Corrected to **`PR.AA-05`**, whose title is quoted verbatim from CSWP 29:

> Access permissions, entitlements, and authorizations are defined in a policy, managed, enforced, and reviewed, and incorporate the principles of least privilege and separation of duties

This is the one with real external exposure. `spec/mappings/atr-to-nist-csf-2.0.md` is headed `Status: Draft for NIST IR 8596 Informative Reference submission`, and line 94 paired the nonexistent identifier with the **CSF 1.1 title text** under a document that declares CSF 2.0 as its reference framework. All three occurrences in that file are fixed, titles included — moving the error from the identifier into the title would not have been a fix.

## SAF-MCP `SMCP-T010` / `T011` / `T012` — never existed

The framework renamed from SAFE-MCP to SAF-MCP and moved to `secure-agentic-framework/saf-mcp`. Its identifiers are `SAF-T` followed by four digits (`SAF-T1001` Tool Poisoning Attack, `SAF-T1102` Prompt Injection). `SMCP-` was never a prefix in any version, and the digit count is wrong as well.

Removed. Correct `SAF-T` mappings are worth adding, but each needs its technique page read against the rule it would attach to, and that is separate work — inventing a replacement to keep the field populated is how the original values got here.

**Not in this PR:** three rules carry `SAFE-T1001` / `SAFE-T1102`. Those are a *retired prefix*, not fabrications — the IDs are real and the migration is documented, `SAFE-T<id>` → `SAF-T<id>`. Different class of problem, so it belongs in a different change. They also embed titles into the identifier string (`"SAFE-T1102 - Prompt Manipulation"`, where the suffix is not the official title), which needs deciding rather than sed-ing.

## Root cause

`spec/atr-schema.yaml` carried both fabricated forms as its own worked examples:

```yaml
safe_mcp:
  description: "SAFE-MCP technique IDs (e.g., SMCP-T001)"
etsi_ts_104223:
  description: >
    ETSI TS 104 223 principle / sub-principle identifiers (e.g., P4.3).
```

The bad identifiers were copied from the schema that was supposed to define them. Fixing the rules without fixing this would just regrow them. Both descriptions now carry the real format and name the wrong one explicitly so the next author does not repeat it.

The same schema has said `Allowlist TBD` in three places since these fields were added — this was known debt, not a surprise.

## Also

`Required for citation in NIST IR 8596 Cyber AI Profile Informative References` → `Prepared for submission to…`. IR 8596 is at initial public draft; nothing is required and no citation is established.

## Effect

```
before:  WARN — nist_csf: 6 rules · etsi_ts_104223: 6 rules · safe_mcp: 6 rules
after:   WARN — nist_csf: 6 rules · etsi_ts_104223: 1 rule
```

```
tests/validate-rules.ts        783 passed, 0 failed
scripts/validate-compliance.ts 0 violations across 783 mapped rules
YAML                           783 parse, 0 failures
```

**No detection behaviour changes.** No engine path reads `compliance` — `src/converters/sage.ts:533` discards these fields outright. No rule's match behaviour, precision, or lane assignment is affected.

**Field definitions are left in place.** `spec/atr-schema.yaml` still declares `etsi_ts_104223` and `safe_mcp`, and `spec/stix-extension/x-atr-rule-schema.json` is untouched, so a consumer doing strict schema validation still passes. No rule fills them with something false any more.

10 files, 11 insertions, 26 deletions. Every deleted line is a nonexistent identifier or a schema example containing one.

## What this does not fix

The remaining `nist_csf` warning is real: those 6 rules are still unchecked, and the fix is an allowlist. That is a larger change than it looks, because `validateItem()` requires an object with `context` — so adding `nist_csf.json` immediately fails every bare-string declaration in the repo. Building the allowlist and converting bare strings to structured entries with context is one coherent follow-up, not something to bolt onto a removal PR.

Worth noting for whoever picks it up: `regex alone will not do it`. CSWP 29 states the subcategory numbering is intentionally non-sequential, with gaps marking relocated 1.1 entries. `DE.CM-04`, `PR.DS-07` and similar match any sensible pattern and are not valid CSF 2.0 entries — as `PR.AC-04` itself demonstrates. The allowlist has to be the 106 literal values.

One semantic issue also survives this PR: `ATR-2026-00552` maps to `PR.AT-01`, which is a valid identifier for *personnel awareness and training*, attached to a runtime goal-drift detection rule. An allowlist can never catch that, because the identifier is real. It needs a human decision, and writing the required `context` prose is what would force it.

## A pre-existing failure this surfaced: ATR-2026-00553

The first push of this PR turned `ATR Rule Quality` red. The cause is not in this diff.

`rule-quality.yml` runs `agent-threat-rules test` on **changed** rule files only. Removing `P3.3` from `ATR-2026-00553` made it a changed file, so its test cases ran — and 5 of them fail. They also fail on the unmodified `origin/main` copy:

```
$ git show origin/main:rules/excessive-autonomy/ATR-2026-00553-...yaml > /tmp/x.yaml
$ agent-threat-rules test /tmp/x.yaml
FAIL ATR-2026-00553 [true_positive]   Expected: triggered, Got: not_triggered     (x5)
```

The rule is `detection.method: behavioral` — the corpus's only one, and the reference example shipped with v1.1 of the method-extensions spec. The engine routes behavioral rules to a behavioral evaluator, and the pattern engine running the test suite never reaches its `conditions` block. Its five `true_positives` assert `triggered` for something the test harness structurally cannot produce.

Confirmed it is the method and not the identifiers: flipping `status: draft` to `experimental` does not help, and a probe rule with identical conditions but `method: pattern` passes every equivalent case.

So the rule is not broken in production — it is inert (`status: draft`) and does no harm. What is broken is that a behavioral rule ships test cases the pattern-only test runner is asked to satisfy, and the changed-files-only gate kept that dormant until someone touched the file.

Fixing it means choosing one of: evaluate behavioral rules in the test runner, exclude them from it, or change what the example asserts. That is a decision about the behavioral method, not about compliance identifiers, so `ATR-2026-00553` is reverted out of this PR and its `P3.3` stays for now. Removing it needs to ride with whichever of those three is chosen.
