### PR TITLE
fix(cli): report method=behavioral cases as unevaluable, not failed

### DIFF
--- a/data/skill-benchmark/benchmark-report.json
+++ b/data/skill-benchmark/benchmark-report.json
@@ -1,7 +1,7 @@
 {
-  "timestamp": "2026-08-05T12:12:46.518Z",
+  "timestamp": "2026-08-05T14:52:43.447Z",
   "corpus_size": 498,
-  "rule_count": 780,
+  "rule_count": 783,
   "malicious_count": 32,
   "benign_count": 466,
   "overall_recall": 1,
@@ -29,8 +29,8 @@
   "false_negatives": 0,
   "expected_rules_accuracy": 1,
   "category_accuracy": 1,
-  "avg_latency_ms": 136.13,
-  "max_latency_ms": 2282.01,
+  "avg_latency_ms": 111.06,
+  "max_latency_ms": 1547.43,
   "results": [
     {
       "file": "malicious/adv-001-context-poisoning-claude-md.md",
@@ -43,7 +43,7 @@
         "ATR-2026-00125"
       ],
       "correct": true,
-      "latency_ms": 363.53,
+      "latency_ms": 411.05,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -57,7 +57,7 @@
         "ATR-2026-00157"
       ],
       "correct": true,
-      "latency_ms": 251.1,
+      "latency_ms": 275.4,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -71,7 +71,7 @@
         "ATR-2026-00121"
       ],
       "correct": true,
-      "latency_ms": 45.5,
+      "latency_ms": 43.12,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -85,7 +85,7 @@
         "ATR-2026-00149"
       ],
       "correct": true,
-      "latency_ms": 32.57,
+      "latency_ms": 32.81,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -99,7 +99,7 @@
         "ATR-2026-00149"
       ],
       "correct": true,
-      "latency_ms": 38.19,
+      "latency_ms": 37.9,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -113,7 +113,7 @@
         "ATR-2026-00149"
       ],
       "correct": true,
-      "latency_ms": 32.41,
+      "latency_ms": 33.66,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -127,7 +127,7 @@
         "ATR-2026-00162"
       ],
       "correct": true,
-      "latency_ms": 64.77,
+      "latency_ms": 64.04,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -141,7 +141,7 @@
         "ATR-2026-00121"
       ],
       "correct": true,
-      "latency_ms": 29.57,
+      "latency_ms": 29.03,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -156,7 +156,7 @@
         "ATR-2026-00149"
       ],
       "correct": true,
-      "latency_ms": 27.3,
+      "latency_ms": 27.19,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -171,7 +171,7 @@
         "ATR-2026-00149"
       ],
       "correct": true,
-      "latency_ms": 27.56,
+      "latency_ms": 27.65,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -185,7 +185,7 @@
         "ATR-2026-00149"
       ],
       "correct": true,
-      "latency_ms": 28.36,
+      "latency_ms": 28.76,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -199,7 +199,7 @@
         "ATR-2026-00149"
       ],
       "correct": true,
-      "latency_ms": 31.15,
+      "latency_ms": 30.28,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -213,7 +213,7 @@
         "ATR-2026-00149"
       ],
       "correct": true,
-      "latency_ms": 27.39,
+      "latency_ms": 26.87,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -227,7 +227,7 @@
         "ATR-2026-00149"
       ],
       "correct": true,
-      "latency_ms": 30.42,
+      "latency_ms": 29.96,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -244,7 +244,7 @@
         "ATR-2026-00225"
       ],
       "correct": true,
-      "latency_ms": 149.09,
+      "latency_ms": 129.79,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -258,7 +258,7 @@
         "ATR-2026-00121"
       ],
       "correct": true,
-      "latency_ms": 75.33,
+      "latency_ms": 61.6,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -275,7 +275,7 @@
         "ATR-2026-00225"
       ],
       "correct": true,
-      "latency_ms": 75.71,
+      "latency_ms": 70.68,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -289,7 +289,7 @@
         "ATR-2026-00121"
       ],
       "correct": true,
-      "latency_ms": 55.12,
+      "latency_ms": 49.12,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -306,7 +306,7 @@
         "ATR-2026-00225"
       ],
       "correct": true,
-      "latency_ms": 69.35,
+      "latency_ms": 66.29,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -320,7 +320,7 @@
         "ATR-2026-00128"
       ],
       "correct": true,
-      "latency_ms": 46.92,
+      "latency_ms": 52.02,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -336,7 +336,7 @@
         "ATR-2026-00276"
       ],
       "correct": true,
-      "latency_ms": 31.33,
+      "latency_ms": 42.07,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -350,7 +350,7 @@
         "ATR-2026-00135"
       ],
       "correct": true,
-      "latency_ms": 30.33,
+      "latency_ms": 35.19,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -365,7 +365,7 @@
         "ATR-2026-00206"
       ],
       "correct": true,
-      "latency_ms": 20.79,
+      "latency_ms": 26.33,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -382,7 +382,7 @@
         "ATR-2026-00225"
       ],
       "correct": true,
-      "latency_ms": 61.93,
+      "latency_ms": 68.75,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -399,7 +399,7 @@
         "ATR-2026-00225"
       ],
       "correct": true,
-      "latency_ms": 54.46,
+      "latency_ms": 57.6,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -416,7 +416,7 @@
         "ATR-2026-00225"
       ],
       "correct": true,
-      "latency_ms": 115.91,
+      "latency_ms": 106.94,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -430,7 +430,7 @@
         "ATR-2026-00121"
       ],
       "correct": true,
-      "latency_ms": 33.32,
+      "latency_ms": 31.61,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -444,7 +444,7 @@
         "ATR-2026-00121"
       ],
       "correct": true,
-      "latency_ms": 133.55,
+      "latency_ms": 114.14,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -458,7 +458,7 @@
         "ATR-2026-00129"
       ],
       "correct": true,
-      "latency_ms": 27.43,
+      "latency_ms": 28.29,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -472,7 +472,7 @@
         "ATR-2026-00121"
       ],
       "correct": true,
-      "latency_ms": 33.64,
+      "latency_ms": 33.36,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -486,7 +486,7 @@
         "ATR-2026-00121"
       ],
       "correct": true,
-      "latency_ms": 75.08,
+      "latency_ms": 63.68,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -503,7 +503,7 @@
         "ATR-2026-00225"
       ],
       "correct": true,
-      "latency_ms": 145.27,
+      "latency_ms": 130.92,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -514,7 +514,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 19.57,
+      "latency_ms": 23.21,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -525,7 +525,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 19.3,
+      "latency_ms": 21.14,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -536,7 +536,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 19.36,
+      "latency_ms": 21.23,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -547,7 +547,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 19.28,
+      "latency_ms": 22.52,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -558,7 +558,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 18.83,
+      "latency_ms": 20.83,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -569,7 +569,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 18.61,
+      "latency_ms": 22.12,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -580,7 +580,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 18.9,
+      "latency_ms": 21.55,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -591,7 +591,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 19.25,
+      "latency_ms": 20.79,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -602,7 +602,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 18.31,
+      "latency_ms": 22.38,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -613,7 +613,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 125.95,
+      "latency_ms": 91.15,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -624,7 +624,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 157.66,
+      "latency_ms": 174.12,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -635,7 +635,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 202.21,
+      "latency_ms": 140.28,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -646,7 +646,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 169.19,
+      "latency_ms": 119.83,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -657,7 +657,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 88.43,
+      "latency_ms": 69.41,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -668,7 +668,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 122.72,
+      "latency_ms": 89.64,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -679,7 +679,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 72.6,
+      "latency_ms": 59.48,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -690,7 +690,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 272.63,
+      "latency_ms": 186.08,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -701,7 +701,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 70.61,
+      "latency_ms": 58.91,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -712,7 +712,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 81.92,
+      "latency_ms": 66.2,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -723,7 +723,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 93.56,
+      "latency_ms": 72.56,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -734,7 +734,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 60.27,
+      "latency_ms": 50.82,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -745,7 +745,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 48.14,
+      "latency_ms": 46.17,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -756,7 +756,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 235.45,
+      "latency_ms": 201.95,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -767,7 +767,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 80.52,
+      "latency_ms": 67.68,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -778,7 +778,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 78.48,
+      "latency_ms": 68.15,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -789,7 +789,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 136.73,
+      "latency_ms": 106.13,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -800,7 +800,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 143.44,
+      "latency_ms": 118.91,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -811,7 +811,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 155.73,
+      "latency_ms": 167.53,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -822,7 +822,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 122.98,
+      "latency_ms": 133.71,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -833,7 +833,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 133.94,
+      "latency_ms": 95.27,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -844,7 +844,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 129.13,
+      "latency_ms": 92.75,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -855,7 +855,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 160.56,
+      "latency_ms": 110.5,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -866,7 +866,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 128.15,
+      "latency_ms": 94.12,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -877,7 +877,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 91.47,
+      "latency_ms": 70.76,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -888,7 +888,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 60.5,
+      "latency_ms": 52.88,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -899,7 +899,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 40.53,
+      "latency_ms": 36.27,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -910,7 +910,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 127.47,
+      "latency_ms": 93.46,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -921,7 +921,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 152.38,
+      "latency_ms": 108.7,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -932,7 +932,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 1907.44,
+      "latency_ms": 1108.99,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -943,7 +943,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 255.43,
+      "latency_ms": 180.97,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -954,7 +954,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 69.06,
+      "latency_ms": 59.04,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -965,7 +965,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 232.96,
+      "latency_ms": 176,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -976,7 +976,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 102.49,
+      "latency_ms": 83.03,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -987,7 +987,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 140.48,
+      "latency_ms": 107.78,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -998,7 +998,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 160.84,
+      "latency_ms": 114.06,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1009,7 +1009,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 64.43,
+      "latency_ms": 58.8,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1020,7 +1020,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 68.13,
+      "latency_ms": 61.82,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1031,7 +1031,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 86.86,
+      "latency_ms": 76.02,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1042,7 +1042,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 45.4,
+      "latency_ms": 41.98,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1053,7 +1053,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 67.32,
+      "latency_ms": 57.67,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1064,7 +1064,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 120.81,
+      "latency_ms": 94.07,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1075,7 +1075,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 72.33,
+      "latency_ms": 60.62,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1086,7 +1086,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 87.52,
+      "latency_ms": 73.11,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1097,7 +1097,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 106.15,
+      "latency_ms": 82.95,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1108,7 +1108,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 205.61,
+      "latency_ms": 151.1,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1119,7 +1119,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 82.35,
+      "latency_ms": 67.35,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1130,7 +1130,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 104.81,
+      "latency_ms": 82.06,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1141,7 +1141,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 299.71,
+      "latency_ms": 247.36,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1152,7 +1152,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 643.88,
+      "latency_ms": 421.03,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1163,7 +1163,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 123.16,
+      "latency_ms": 95.1,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1174,7 +1174,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 122.64,
+      "latency_ms": 94.8,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1185,7 +1185,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 111.45,
+      "latency_ms": 87.76,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1196,7 +1196,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 117.17,
+      "latency_ms": 89.76,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1207,7 +1207,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 69.7,
+      "latency_ms": 58.44,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1218,7 +1218,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 39.75,
+      "latency_ms": 35.77,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1229,7 +1229,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 2282.01,
+      "latency_ms": 1547.43,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1240,7 +1240,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 54.97,
+      "latency_ms": 54.87,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1251,7 +1251,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 86.07,
+      "latency_ms": 88.75,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1262,7 +1262,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 135.94,
+      "latency_ms": 140.42,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1273,7 +1273,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 85.53,
+      "latency_ms": 87.57,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1284,7 +1284,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 86.76,
+      "latency_ms": 91.02,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1295,7 +1295,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 87.23,
+      "latency_ms": 93.99,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1306,7 +1306,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 72.48,
+      "latency_ms": 75.67,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1317,7 +1317,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 115.03,
+      "latency_ms": 99.75,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1328,7 +1328,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 208.7,
+      "latency_ms": 197.24,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1339,7 +1339,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 59.47,
+      "latency_ms": 59.17,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1350,7 +1350,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 104.02,
+      "latency_ms": 99.01,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1361,7 +1361,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 122.88,
+      "latency_ms": 121.44,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1372,7 +1372,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 207.81,
+      "latency_ms": 180.88,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1383,7 +1383,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 73.9,
+      "latency_ms": 76.02,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1394,7 +1394,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 137.6,
+      "latency_ms": 132.34,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1405,7 +1405,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 59.14,
+      "latency_ms": 63.94,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1416,7 +1416,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 91.6,
+      "latency_ms": 97.56,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1427,7 +1427,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 106.74,
+      "latency_ms": 103.36,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1438,7 +1438,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 45.16,
+      "latency_ms": 44.74,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1449,7 +1449,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 44.22,
+      "latency_ms": 43.67,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1460,7 +1460,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 93.55,
+      "latency_ms": 85.38,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1471,7 +1471,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 174.07,
+      "latency_ms": 130.01,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1482,7 +1482,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 58.97,
+      "latency_ms": 52.92,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1493,7 +1493,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 73.57,
+      "latency_ms": 62.97,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1504,7 +1504,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 84.36,
+      "latency_ms": 69.69,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1515,7 +1515,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 45.67,
+      "latency_ms": 43.18,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1526,7 +1526,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 74.73,
+      "latency_ms": 85.63,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1537,7 +1537,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 88.4,
+      "latency_ms": 95.27,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1548,7 +1548,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 117.89,
+      "latency_ms": 87.26,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1559,7 +1559,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 44.58,
+      "latency_ms": 38.98,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1570,7 +1570,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 36.81,
+      "latency_ms": 33.7,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1581,7 +1581,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 67.84,
+      "latency_ms": 58.56,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1592,7 +1592,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 84.38,
+      "latency_ms": 64.06,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1603,7 +1603,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 414.73,
+      "latency_ms": 272.64,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1614,7 +1614,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 83.25,
+      "latency_ms": 63.84,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1625,7 +1625,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 112.4,
+      "latency_ms": 119.26,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1636,7 +1636,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 51.52,
+      "latency_ms": 45.83,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1647,7 +1647,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 148.65,
+      "latency_ms": 104.42,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1658,7 +1658,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 92.16,
+      "latency_ms": 70.75,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1669,7 +1669,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 112.13,
+      "latency_ms": 92.19,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1680,7 +1680,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 117.19,
+      "latency_ms": 88.06,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1691,7 +1691,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 43.12,
+      "latency_ms": 39.76,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1702,7 +1702,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 146.32,
+      "latency_ms": 106.93,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1713,7 +1713,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 125.63,
+      "latency_ms": 92.6,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1724,7 +1724,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 55.82,
+      "latency_ms": 48.98,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1735,7 +1735,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 54.66,
+      "latency_ms": 46.99,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1746,7 +1746,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 45.79,
+      "latency_ms": 40.37,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1757,7 +1757,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 247.75,
+      "latency_ms": 166.22,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1768,7 +1768,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 56.36,
+      "latency_ms": 47.03,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1779,7 +1779,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 155.86,
+      "latency_ms": 109.67,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1790,7 +1790,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 137.9,
+      "latency_ms": 101.27,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1801,7 +1801,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 152.04,
+      "latency_ms": 126.15,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1812,7 +1812,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 425.78,
+      "latency_ms": 281.89,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1823,7 +1823,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 153.65,
+      "latency_ms": 115.41,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1834,7 +1834,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 441.81,
+      "latency_ms": 287.56,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1845,7 +1845,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 327.47,
+      "latency_ms": 224.65,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1856,7 +1856,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 299.53,
+      "latency_ms": 201.8,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1867,7 +1867,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 539.19,
+      "latency_ms": 345.51,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1878,7 +1878,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 53.82,
+      "latency_ms": 46.42,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1889,7 +1889,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 40.92,
+      "latency_ms": 37.32,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1900,7 +1900,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 206.66,
+      "latency_ms": 144.13,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1911,7 +1911,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 81.83,
+      "latency_ms": 65.24,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1922,7 +1922,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 84.37,
+      "latency_ms": 67.43,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1933,7 +1933,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 214.12,
+      "latency_ms": 170.93,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1944,7 +1944,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 163.22,
+      "latency_ms": 117.91,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1955,7 +1955,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 758.05,
+      "latency_ms": 474.03,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1966,7 +1966,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 144.16,
+      "latency_ms": 105.19,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1977,7 +1977,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 109.12,
+      "latency_ms": 84.19,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1988,7 +1988,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 119.47,
+      "latency_ms": 99.08,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1999,7 +1999,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 377.2,
+      "latency_ms": 252.29,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2010,7 +2010,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 47.23,
+      "latency_ms": 42.07,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2021,7 +2021,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 64.36,
+      "latency_ms": 50.09,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2032,7 +2032,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 56.37,
+      "latency_ms": 52.07,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2043,7 +2043,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 80.32,
+      "latency_ms": 87.77,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2054,7 +2054,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 157.38,
+      "latency_ms": 114.14,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2065,7 +2065,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 602.81,
+      "latency_ms": 385.75,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2076,7 +2076,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 75.94,
+      "latency_ms": 62.89,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2087,7 +2087,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 372.13,
+      "latency_ms": 252.8,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2098,7 +2098,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 208.64,
+      "latency_ms": 149.39,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2109,7 +2109,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 97.63,
+      "latency_ms": 84.3,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2120,7 +2120,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 63.51,
+      "latency_ms": 54.41,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2131,7 +2131,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 65.57,
+      "latency_ms": 54.8,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2142,7 +2142,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 58.57,
+      "latency_ms": 49.72,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2153,7 +2153,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 445.97,
+      "latency_ms": 297.51,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2164,7 +2164,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 442,
+      "latency_ms": 289.15,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2175,7 +2175,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 52.61,
+      "latency_ms": 46.72,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2186,7 +2186,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 545.08,
+      "latency_ms": 356.1,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2197,7 +2197,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 459.46,
+      "latency_ms": 304.1,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2208,7 +2208,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 64.3,
+      "latency_ms": 53.24,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2219,7 +2219,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 77.19,
+      "latency_ms": 63.4,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2230,7 +2230,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 59.05,
+      "latency_ms": 50.49,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2241,7 +2241,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 43.01,
+      "latency_ms": 39.75,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2252,7 +2252,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 53.25,
+      "latency_ms": 46.71,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2263,7 +2263,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 51.85,
+      "latency_ms": 46.92,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2274,7 +2274,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 50.77,
+      "latency_ms": 44.66,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2285,7 +2285,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 56.26,
+      "latency_ms": 49.01,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2296,7 +2296,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 71.57,
+      "latency_ms": 59.84,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2307,7 +2307,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 43.17,
+      "latency_ms": 39.32,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2318,7 +2318,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 155.1,
+      "latency_ms": 111.45,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2329,7 +2329,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 135.26,
+      "latency_ms": 99.53,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2340,7 +2340,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 114.56,
+      "latency_ms": 86,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2351,7 +2351,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 87.22,
+      "latency_ms": 69.53,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2362,7 +2362,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 96.09,
+      "latency_ms": 75.13,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2373,7 +2373,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 66.09,
+      "latency_ms": 56.12,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2384,7 +2384,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 65.09,
+      "latency_ms": 54.92,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2395,7 +2395,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 52.15,
+      "latency_ms": 47.51,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2406,7 +2406,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 83.2,
+      "latency_ms": 68.88,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2417,7 +2417,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 109.02,
+      "latency_ms": 85.36,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2428,7 +2428,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 408.96,
+      "latency_ms": 262.61,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2439,7 +2439,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 140.76,
+      "latency_ms": 126.31,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2450,7 +2450,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 194.17,
+      "latency_ms": 154.65,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2461,7 +2461,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 349.07,
+      "latency_ms": 252.21,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2472,7 +2472,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 102.02,
+      "latency_ms": 80.15,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2483,7 +2483,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 65.28,
+      "latency_ms": 55.4,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2494,7 +2494,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 313.17,
+      "latency_ms": 260.32,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2505,7 +2505,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 250.63,
+      "latency_ms": 211.83,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2516,7 +2516,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 210,
+      "latency_ms": 175.68,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2527,7 +2527,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 184.9,
+      "latency_ms": 154.63,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2538,7 +2538,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 112.01,
+      "latency_ms": 88.72,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2549,7 +2549,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 218,
+      "latency_ms": 173.77,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2560,7 +2560,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 109.04,
+      "latency_ms": 84.11,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2571,7 +2571,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 203.47,
+      "latency_ms": 145.52,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2582,7 +2582,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 45.42,
+      "latency_ms": 39.98,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2593,7 +2593,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 124.66,
+      "latency_ms": 164.63,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2604,7 +2604,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 95.52,
+      "latency_ms": 75.63,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2615,7 +2615,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 111.68,
+      "latency_ms": 94.41,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2626,7 +2626,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 159.89,
+      "latency_ms": 129.67,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2637,7 +2637,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 174.76,
+      "latency_ms": 124.17,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2648,7 +2648,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 56.84,
+      "latency_ms": 50.63,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2659,7 +2659,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 143.18,
+      "latency_ms": 106.44,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2670,7 +2670,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 121.3,
+      "latency_ms": 91.7,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2681,7 +2681,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 63.03,
+      "latency_ms": 54.13,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2692,7 +2692,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 153.57,
+      "latency_ms": 124.3,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2703,7 +2703,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 47.5,
+      "latency_ms": 42.02,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2714,7 +2714,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 36.31,
+      "latency_ms": 33.89,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2725,7 +2725,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 38.91,
+      "latency_ms": 35.42,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2736,7 +2736,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 80.27,
+      "latency_ms": 65.02,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2747,7 +2747,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 31.62,
+      "latency_ms": 30.64,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2758,7 +2758,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 156.97,
+      "latency_ms": 115.2,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2769,7 +2769,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 190.42,
+      "latency_ms": 137.03,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2780,7 +2780,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 205.6,
+      "latency_ms": 170.17,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2791,7 +2791,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 189.44,
+      "latency_ms": 158.75,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2802,7 +2802,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 109.69,
+      "latency_ms": 83.12,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2813,7 +2813,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 57.86,
+      "latency_ms": 51.49,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2824,7 +2824,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 1080.09,
+      "latency_ms": 696.58,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2835,7 +2835,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 21.76,
+      "latency_ms": 23.27,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2846,7 +2846,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 47.75,
+      "latency_ms": 43.25,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2857,7 +2857,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 102.23,
+      "latency_ms": 80.91,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2868,7 +2868,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 92.59,
+      "latency_ms": 82.67,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2879,7 +2879,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 54,
+      "latency_ms": 49.38,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2890,7 +2890,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 97.71,
+      "latency_ms": 84.18,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2901,7 +2901,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 79.07,
+      "latency_ms": 69.74,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2912,7 +2912,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 49.88,
+      "latency_ms": 44.58,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2923,7 +2923,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 102.22,
+      "latency_ms": 87.85,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2934,7 +2934,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 78.57,
+      "latency_ms": 63.89,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2945,7 +2945,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 136.74,
+      "latency_ms": 106.49,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2956,7 +2956,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 149.64,
+      "latency_ms": 129.15,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2967,7 +2967,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 53.12,
+      "latency_ms": 49.41,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2978,7 +2978,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 220.16,
+      "latency_ms": 165.69,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2989,7 +2989,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 133.49,
+      "latency_ms": 104.65,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3000,7 +3000,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 291.6,
+      "latency_ms": 204.26,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3011,7 +3011,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 176.06,
+      "latency_ms": 133.08,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3022,7 +3022,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 110.83,
+      "latency_ms": 88.58,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3033,7 +3033,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 138.45,
+      "latency_ms": 107.73,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3044,7 +3044,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 90.24,
+      "latency_ms": 82.66,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3055,7 +3055,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 31.21,
+      "latency_ms": 32.23,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3066,7 +3066,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 127.39,
+      "latency_ms": 110.44,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3077,7 +3077,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 281.17,
+      "latency_ms": 223.49,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3088,7 +3088,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 59.24,
+      "latency_ms": 56.63,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3099,7 +3099,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 87.69,
+      "latency_ms": 76.51,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3110,7 +3110,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 131.47,
+      "latency_ms": 107.13,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3121,7 +3121,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 609.32,
+      "latency_ms": 417.8,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3132,7 +3132,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 337.7,
+      "latency_ms": 291.46,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3143,7 +3143,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 98.2,
+      "latency_ms": 82.91,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3154,7 +3154,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 71.01,
+      "latency_ms": 60.11,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3165,7 +3165,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 35.94,
+      "latency_ms": 33.75,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3176,7 +3176,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 108.97,
+      "latency_ms": 87.05,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3187,7 +3187,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 121.88,
+      "latency_ms": 135.32,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3198,7 +3198,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 101.05,
+      "latency_ms": 111.7,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3209,7 +3209,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 24.38,
+      "latency_ms": 24.93,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3220,7 +3220,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 294.58,
+      "latency_ms": 331.16,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3231,7 +3231,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 45.52,
+      "latency_ms": 53.66,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3242,7 +3242,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 448.45,
+      "latency_ms": 339.49,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3253,7 +3253,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 68.73,
+      "latency_ms": 69.88,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3264,7 +3264,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 130.42,
+      "latency_ms": 117.22,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3275,7 +3275,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 177.56,
+      "latency_ms": 154.08,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3286,7 +3286,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 323.87,
+      "latency_ms": 271.35,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3297,7 +3297,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 89.96,
+      "latency_ms": 92.66,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3308,7 +3308,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 28.69,
+      "latency_ms": 40.04,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3319,7 +3319,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 28.91,
+      "latency_ms": 34.61,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3330,7 +3330,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 27.9,
+      "latency_ms": 35.64,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3341,7 +3341,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 27.88,
+      "latency_ms": 58.71,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3352,7 +3352,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 24.44,
+      "latency_ms": 41.46,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3363,7 +3363,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 174.81,
+      "latency_ms": 179.43,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3374,7 +3374,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 134.21,
+      "latency_ms": 147.39,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3385,7 +3385,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 93.4,
+      "latency_ms": 115.69,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3396,7 +3396,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 482.71,
+      "latency_ms": 408.1,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3407,7 +3407,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 241.41,
+      "latency_ms": 203.98,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3418,7 +3418,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 139.69,
+      "latency_ms": 133.21,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3429,7 +3429,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 57.44,
+      "latency_ms": 63.69,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3440,7 +3440,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 24.92,
+      "latency_ms": 38.28,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3451,7 +3451,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 45.7,
+      "latency_ms": 54.11,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3462,7 +3462,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 219.12,
+      "latency_ms": 195.35,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3473,7 +3473,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 24.53,
+      "latency_ms": 32.38,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3484,7 +3484,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 249.35,
+      "latency_ms": 262.66,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3495,7 +3495,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 161.73,
+      "latency_ms": 186.06,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3506,7 +3506,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 55.14,
+      "latency_ms": 59.94,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3517,7 +3517,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 123.51,
+      "latency_ms": 174.73,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3528,7 +3528,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 67.46,
+      "latency_ms": 68.68,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3539,7 +3539,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 55.66,
+      "latency_ms": 58.25,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3550,7 +3550,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 86.45,
+      "latency_ms": 81.6,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3561,7 +3561,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 42.36,
+      "latency_ms": 49.6,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3572,7 +3572,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 75.09,
+      "latency_ms": 70.49,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3583,7 +3583,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 101.57,
+      "latency_ms": 103.88,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3594,7 +3594,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 160.38,
+      "latency_ms": 158.32,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3605,7 +3605,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 169.2,
+      "latency_ms": 303.71,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3616,7 +3616,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 148,
+      "latency_ms": 504.36,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3627,7 +3627,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 485.68,
+      "latency_ms": 1187.57,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3638,7 +3638,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 112.98,
+      "latency_ms": 139.53,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3649,7 +3649,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 216.99,
+      "latency_ms": 152.79,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3660,7 +3660,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 296.7,
+      "latency_ms": 199.8,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3671,7 +3671,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 174.39,
+      "latency_ms": 126.03,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3682,7 +3682,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 116.96,
+      "latency_ms": 91.31,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3693,7 +3693,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 45.26,
+      "latency_ms": 41.91,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3704,7 +3704,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 77.96,
+      "latency_ms": 63.9,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3715,7 +3715,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 176.49,
+      "latency_ms": 145.03,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3726,7 +3726,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 301.99,
+      "latency_ms": 212.75,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3737,7 +3737,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 88.11,
+      "latency_ms": 100.88,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3748,7 +3748,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 89.76,
+      "latency_ms": 100.97,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3759,7 +3759,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 139.69,
+      "latency_ms": 105.89,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3770,7 +3770,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 143.87,
+      "latency_ms": 109.12,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3781,7 +3781,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 93.16,
+      "latency_ms": 107.93,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3792,7 +3792,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 136.65,
+      "latency_ms": 103.75,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3803,7 +3803,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 124.32,
+      "latency_ms": 96.41,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3814,7 +3814,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 135.86,
+      "latency_ms": 116.21,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3825,7 +3825,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 39.63,
+      "latency_ms": 36.19,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3836,7 +3836,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 57.3,
+      "latency_ms": 52.68,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3847,7 +3847,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 124.78,
+      "latency_ms": 96.19,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3858,7 +3858,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 94.47,
+      "latency_ms": 76.67,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3869,7 +3869,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 99.91,
+      "latency_ms": 81.77,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3880,7 +3880,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 42.66,
+      "latency_ms": 38.52,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3891,7 +3891,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 80.15,
+      "latency_ms": 91.25,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3902,7 +3902,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 89,
+      "latency_ms": 72.66,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3913,7 +3913,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 135.62,
+      "latency_ms": 103.99,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3924,7 +3924,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 66.9,
+      "latency_ms": 58.12,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3935,7 +3935,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 188.52,
+      "latency_ms": 138.6,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3946,7 +3946,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 179.47,
+      "latency_ms": 129.78,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3957,7 +3957,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 260.45,
+      "latency_ms": 182.41,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3968,7 +3968,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 38.07,
+      "latency_ms": 35.54,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3979,7 +3979,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 61.98,
+      "latency_ms": 53.99,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3990,7 +3990,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 50.65,
+      "latency_ms": 46.61,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4001,7 +4001,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 57.87,
+      "latency_ms": 51.13,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4012,7 +4012,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 29.34,
+      "latency_ms": 30.18,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4023,7 +4023,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 69.89,
+      "latency_ms": 59.81,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4034,7 +4034,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 70.18,
+      "latency_ms": 58.9,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4047,7 +4047,7 @@
         "ATR-2026-00123"
       ],
       "correct": false,
-      "latency_ms": 44.56,
+      "latency_ms": 41.51,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4058,7 +4058,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 95.78,
+      "latency_ms": 76.7,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4069,7 +4069,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 62.74,
+      "latency_ms": 54.37,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4080,7 +4080,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 95.32,
+      "latency_ms": 75.55,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4091,7 +4091,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 93.73,
+      "latency_ms": 76.34,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4102,7 +4102,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 164.89,
+      "latency_ms": 140.17,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4113,7 +4113,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 48.49,
+      "latency_ms": 45.42,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4124,7 +4124,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 355.84,
+      "latency_ms": 243.59,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4135,7 +4135,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 90.51,
+      "latency_ms": 80.43,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4146,7 +4146,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 151.42,
+      "latency_ms": 129.16,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4157,7 +4157,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 285.65,
+      "latency_ms": 230.92,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4168,7 +4168,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 122.27,
+      "latency_ms": 92.44,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4179,7 +4179,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 119.64,
+      "latency_ms": 92.19,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4190,7 +4190,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 250.29,
+      "latency_ms": 178.81,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4201,7 +4201,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 185.91,
+      "latency_ms": 136.87,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4212,7 +4212,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 89.2,
+      "latency_ms": 74.26,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4223,7 +4223,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 87.74,
+      "latency_ms": 71.77,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4234,7 +4234,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 75.66,
+      "latency_ms": 63.05,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4245,7 +4245,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 86.37,
+      "latency_ms": 75.19,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4256,7 +4256,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 85.67,
+      "latency_ms": 70.25,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4267,7 +4267,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 101.84,
+      "latency_ms": 89.02,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4278,7 +4278,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 125.09,
+      "latency_ms": 93.42,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4289,7 +4289,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 64.38,
+      "latency_ms": 58.67,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4300,7 +4300,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 39.96,
+      "latency_ms": 37.29,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4311,7 +4311,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 64,
+      "latency_ms": 56.01,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4322,7 +4322,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 41.29,
+      "latency_ms": 37.76,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4333,7 +4333,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 41.24,
+      "latency_ms": 38.39,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4344,7 +4344,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 184.11,
+      "latency_ms": 150.15,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4355,7 +4355,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 192.1,
+      "latency_ms": 156.88,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4366,7 +4366,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 58.94,
+      "latency_ms": 49.47,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4377,7 +4377,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 68.18,
+      "latency_ms": 60.14,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4388,7 +4388,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 69.49,
+      "latency_ms": 61.17,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4399,7 +4399,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 183.26,
+      "latency_ms": 134.98,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4410,7 +4410,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 26.59,
+      "latency_ms": 28.17,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4421,7 +4421,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 183.89,
+      "latency_ms": 262.56,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4432,7 +4432,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 202.91,
+      "latency_ms": 163.85,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4443,7 +4443,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 419.05,
+      "latency_ms": 273.35,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4454,7 +4454,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 49.74,
+      "latency_ms": 43.48,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4465,7 +4465,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 41.96,
+      "latency_ms": 39.44,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4476,7 +4476,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 55.86,
+      "latency_ms": 47.27,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4487,7 +4487,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 50.27,
+      "latency_ms": 44.76,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4498,7 +4498,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 33.5,
+      "latency_ms": 32.94,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4509,7 +4509,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 259.44,
+      "latency_ms": 188.52,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4520,7 +4520,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 71.44,
+      "latency_ms": 67.94,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4531,7 +4531,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 46.14,
+      "latency_ms": 52.26,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4542,7 +4542,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 25.53,
+      "latency_ms": 26.51,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4553,7 +4553,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 73.03,
+      "latency_ms": 70.9,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4564,7 +4564,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 75.53,
+      "latency_ms": 67.8,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4575,7 +4575,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 113.71,
+      "latency_ms": 126.27,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4586,7 +4586,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 139.5,
+      "latency_ms": 107.73,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4597,7 +4597,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 59.98,
+      "latency_ms": 50.69,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4608,7 +4608,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 36.11,
+      "latency_ms": 40.32,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4619,7 +4619,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 47.32,
+      "latency_ms": 41.72,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4630,7 +4630,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 64.23,
+      "latency_ms": 55.57,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4641,7 +4641,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 73.16,
+      "latency_ms": 59.29,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4652,7 +4652,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 60.26,
+      "latency_ms": 52.5,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4663,7 +4663,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 71.75,
+      "latency_ms": 58.92,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4674,7 +4674,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 53.92,
+      "latency_ms": 47.53,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4685,7 +4685,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 30.87,
+      "latency_ms": 29.58,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4696,7 +4696,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 33.48,
+      "latency_ms": 32.14,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4707,7 +4707,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 34.12,
+      "latency_ms": 31.52,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4718,7 +4718,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 143.58,
+      "latency_ms": 107.94,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4729,7 +4729,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 55.72,
+      "latency_ms": 50.27,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4740,7 +4740,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 96.02,
+      "latency_ms": 77.3,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4751,7 +4751,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 118.02,
+      "latency_ms": 91.17,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4762,7 +4762,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 63.71,
+      "latency_ms": 52.19,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4773,7 +4773,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 98.04,
+      "latency_ms": 78.14,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4784,7 +4784,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 78.23,
+      "latency_ms": 68.92,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4795,7 +4795,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 68.22,
+      "latency_ms": 62.62,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4806,7 +4806,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 74.4,
+      "latency_ms": 71.94,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4817,7 +4817,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 54.47,
+      "latency_ms": 130.35,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4828,7 +4828,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 41.81,
+      "latency_ms": 40.71,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4839,7 +4839,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 112.93,
+      "latency_ms": 95.65,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4850,7 +4850,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 92.68,
+      "latency_ms": 85.34,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4861,7 +4861,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 44.63,
+      "latency_ms": 43.1,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4872,7 +4872,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 145.16,
+      "latency_ms": 105.75,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4883,7 +4883,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 58.82,
+      "latency_ms": 53.28,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4894,7 +4894,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 108.97,
+      "latency_ms": 87.36,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4905,7 +4905,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 87.75,
+      "latency_ms": 76.78,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4916,7 +4916,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 85.02,
+      "latency_ms": 67.23,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4927,7 +4927,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 29.51,
+      "latency_ms": 27.46,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4938,7 +4938,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 214.3,
+      "latency_ms": 152.38,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4949,7 +4949,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 415.26,
+      "latency_ms": 273.98,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4960,7 +4960,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 133.83,
+      "latency_ms": 102.76,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4971,7 +4971,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 251.08,
+      "latency_ms": 209.23,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4982,7 +4982,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 27.91,
+      "latency_ms": 27.92,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4993,7 +4993,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 204.73,
+      "latency_ms": 152.15,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -5004,7 +5004,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 402.33,
+      "latency_ms": 273.87,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -5015,7 +5015,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 317.47,
+      "latency_ms": 257.1,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -5026,7 +5026,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 543.98,
+      "latency_ms": 350.66,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -5037,7 +5037,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 63.69,
+      "latency_ms": 54.46,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -5048,7 +5048,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 115.42,
+      "latency_ms": 88.37,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -5059,7 +5059,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 84.98,
+      "latency_ms": 73.15,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -5070,7 +5070,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 74.79,
+      "latency_ms": 65.15,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -5081,7 +5081,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 473.98,
+      "latency_ms": 311.86,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -5092,7 +5092,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 360.1,
+      "latency_ms": 244.46,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -5103,7 +5103,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 45.58,
+      "latency_ms": 40.9,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -5114,7 +5114,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 66.87,
+      "latency_ms": 56.39,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -5125,7 +5125,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 117.83,
+      "latency_ms": 91.62,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -5136,7 +5136,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 72.71,
+      "latency_ms": 59.7,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -5147,7 +5147,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 267.82,
+      "latency_ms": 179.45,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -5158,7 +5158,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 480.73,
+      "latency_ms": 313.26,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -5169,7 +5169,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 151.15,
+      "latency_ms": 126.1,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -5180,7 +5180,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 147.06,
+      "latency_ms": 123.92,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -5191,7 +5191,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 525.87,
+      "latency_ms": 332.19,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -5202,7 +5202,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 84.29,
+      "latency_ms": 66.69,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -5213,7 +5213,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 96.57,
+      "latency_ms": 75.76,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -5224,7 +5224,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 149.1,
+      "latency_ms": 109.51,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -5235,7 +5235,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 136.29,
+      "latency_ms": 102.9,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -5246,7 +5246,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 182.01,
+      "latency_ms": 128.58,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -5257,7 +5257,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 51.06,
+      "latency_ms": 43.67,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -5268,7 +5268,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 83.42,
+      "latency_ms": 67.47,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -5279,7 +5279,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 176.58,
+      "latency_ms": 127.98,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -5290,7 +5290,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 141.01,
+      "latency_ms": 104.1,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -5301,7 +5301,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 170.05,
+      "latency_ms": 142.37,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -5312,7 +5312,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 94.84,
+      "latency_ms": 74.31,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -5323,7 +5323,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 87.7,
+      "latency_ms": 74.56,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -5334,7 +5334,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 60.73,
+      "latency_ms": 52.98,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -5345,7 +5345,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 317.94,
+      "latency_ms": 219.56,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -5356,7 +5356,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 39.06,
+      "latency_ms": 36.59,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -5367,7 +5367,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 108.86,
+      "latency_ms": 92.41,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -5378,7 +5378,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 56.68,
+      "latency_ms": 50.89,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -5389,7 +5389,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 43.27,
+      "latency_ms": 39.27,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -5400,7 +5400,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 56.54,
+      "latency_ms": 47.63,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -5411,7 +5411,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 147.05,
+      "latency_ms": 108.97,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -5422,7 +5422,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 183.21,
+      "latency_ms": 131.25,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -5433,7 +5433,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 77.57,
+      "latency_ms": 66.52,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -5444,7 +5444,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 61.77,
+      "latency_ms": 67.25,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -5455,7 +5455,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 236.47,
+      "latency_ms": 165.14,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -5466,7 +5466,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 228.17,
+      "latency_ms": 156.24,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -5477,7 +5477,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 47.81,
+      "latency_ms": 41.85,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -5488,7 +5488,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 25.11,
+      "latency_ms": 25.69,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -5499,7 +5499,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 106.8,
+      "latency_ms": 84.32,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -5510,7 +5510,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 69.84,
+      "latency_ms": 59.78,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -5521,7 +5521,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 85.22,
+      "latency_ms": 70.62,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -5532,7 +5532,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 261.78,
+      "latency_ms": 181.6,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -5543,7 +5543,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 104.43,
+      "latency_ms": 81.65,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -5554,7 +5554,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 89.58,
+      "latency_ms": 72.92,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -5565,7 +5565,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 113.75,
+      "latency_ms": 87.31,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -5576,7 +5576,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 243.42,
+      "latency_ms": 172,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -5587,7 +5587,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 56.06,
+      "latency_ms": 49.59,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -5598,7 +5598,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 55.65,
+      "latency_ms": 48.25,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -5609,7 +5609,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 46.6,
+      "latency_ms": 42.42,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -5620,7 +5620,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 332.21,
+      "latency_ms": 228.78,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -5631,7 +5631,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 50.56,
+      "latency_ms": 46.6,
       "expected_rules_matched": true,
       "category_correct": true
     }
@@ -5647,7 +5647,7 @@
         "ATR-2026-00123"
       ],
       "correct": false,
-      "latency_ms": 44.56,
+      "latency_ms": 41.51,
       "expected_rules_matched": true,
       "category_correct": true
     }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -36,6 +36,7 @@ const GREEN = '\x1b[32m';
 const RED = '\x1b[31m';
 const DIM = '\x1b[2m';
 const BOLD = '\x1b[1m';
+const YELLOW = '\x1b[33m';
 
 function printUsage(): void {
   console.log(`
@@ -247,7 +248,9 @@ async function cmdTest(target: string, options: Record<string, string>): Promise
   let totalTests = 0;
   let passed = 0;
   let failed = 0;
+  let skipped = 0;
   const failures: Array<{ ruleId: string; testType: string; input: string; expected: string; got: string }> = [];
+  const skippedRules: Array<{ ruleId: string; cases: number; reason: string }> = [];
 
   // Map extended agent_source types to basic event-compatible source types
   // so the engine's source type filter doesn't skip rules during testing.
@@ -262,6 +265,24 @@ async function cmdTest(target: string, options: Record<string, string>): Promise
 
   for (const rule of rules) {
     if (!rule.test_cases) continue;
+
+    // method=behavioral rules cannot be evaluated here, and that is by design:
+    // engine.ts returns null for them because windowed metric evaluation needs
+    // state across many events, which the synchronous evaluate() API does not
+    // carry. Running their cases anyway reports "Expected: triggered, Got:
+    // not_triggered" for every true_positive, which reads as a detection
+    // failure when the truth is that this engine never looked. Count them as
+    // unevaluable and say so, rather than failing them or passing them
+    // silently. (method=trace is different: it has a real evaluation path
+    // below, so its cases still run.)
+    if (rule.detection?.method === 'behavioral') {
+      const cases =
+        (rule.test_cases.true_positives?.length ?? 0) + (rule.test_cases.true_negatives?.length ?? 0);
+      totalTests += cases;
+      skipped += cases;
+      skippedRules.push({ ruleId: rule.id, cases, reason: 'method=behavioral requires a streaming evaluator' });
+      continue;
+    }
 
     // For testing, normalize extended source types so the engine doesn't filter them out
     const originalSourceType = rule.agent_source?.type;
@@ -331,7 +352,13 @@ async function cmdTest(target: string, options: Record<string, string>): Promise
   }
 
   if (jsonOutput) {
-    console.log(JSON.stringify({ totalRules: rules.length, totalTests, passed, failed, failures }, null, 2));
+    console.log(
+      JSON.stringify(
+        { totalRules: rules.length, totalTests, passed, failed, skipped, failures, skippedRules },
+        null,
+        2,
+      ),
+    );
     return;
   }
 
@@ -342,6 +369,12 @@ async function cmdTest(target: string, options: Record<string, string>): Promise
   console.log(`  ${GREEN}Passed:${RESET}          ${passed}`);
   if (failed > 0) {
     console.log(`  ${RED}Failed:${RESET}          ${failed}`);
+  }
+  if (skipped > 0) {
+    console.log(`  ${YELLOW}Unevaluable:${RESET}     ${skipped}`);
+    for (const s of skippedRules) {
+      console.log(`    ${DIM}${s.ruleId}: ${s.cases} case(s) — ${s.reason}${RESET}`);
+    }
   }
   console.log(`${DIM}${'─'.repeat(60)}${RESET}`);
 
@@ -354,7 +387,13 @@ async function cmdTest(target: string, options: Record<string, string>): Promise
     }
     process.exit(1);
   } else {
-    console.log(`\n${GREEN}All tests passed.${RESET}\n`);
+    // The literal "All tests passed" is what rule-quality.yml greps for, so it
+    // has to survive; the suffix keeps it from overstating what actually ran.
+    console.log(
+      skipped > 0
+        ? `\n${GREEN}All tests passed.${RESET} ${DIM}(${skipped} case(s) unevaluable — see above)${RESET}\n`
+        : `\n${GREEN}All tests passed.${RESET}\n`,
+    );
   }
 }
 

--- a/tests/cli-test-behavioral-unevaluable.test.ts
+++ b/tests/cli-test-behavioral-unevaluable.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Tests for how `atr test` reports method=behavioral rules.
+ *
+ * THE BUG THIS PINS
+ *   engine.ts returns null for method=behavioral without evaluating anything —
+ *   deliberately, because windowed metric evaluation needs state across many
+ *   events and the synchronous evaluate() API carries none. The test runner
+ *   did not know that, so it ran every case anyway and reported each
+ *   true_positive as "Expected: triggered, Got: not_triggered".
+ *
+ *   That reads as a detection failure. The truth is that the engine never
+ *   looked. ATR-2026-00553 — the corpus's only behavioral rule, and the
+ *   reference example shipped with v1.1 of the method-extensions spec — had
+ *   five such "failures" sitting on main. Nobody saw them because
+ *   rule-quality.yml only tests files a PR changes, so the breakage stayed
+ *   dormant until someone edited that file for an unrelated reason.
+ *
+ *   Cases the engine cannot evaluate are now counted and named as
+ *   unevaluable. Not failed, which blames the rule for the harness's gap, and
+ *   not quietly passed, which would hide that nothing ran.
+ *
+ * The CLI is spawned rather than imported because cmdTest is not exported, and
+ * the contract worth pinning is what an operator and CI actually see on
+ * stdout — the counts and the exit code — not an internal function's return.
+ */
+
+import { describe, it, expect } from "vitest";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+const CLI = new URL("../src/cli.ts", import.meta.url).pathname;
+
+/** A rule that differs from the pattern case only in detection.method. */
+function ruleYaml(method: "behavioral" | "pattern"): string {
+  return `title: "Fixture"
+id: ATR-2026-09001
+rule_version: 1
+status: experimental
+description: "Fixture rule for harness reporting."
+author: "ATR Community"
+date: "2026/08/05"
+schema_version: "0.1"
+maturity: test
+severity: low
+tags:
+  category: excessive-autonomy
+  subcategory: fixture
+  scan_target: both
+  confidence: low
+agent_source:
+  type: agent_behavior
+  framework: [any]
+  provider: [any]
+detection:
+  method: ${method}
+  condition: any
+  conditions:
+    - field: content
+      operator: regex
+      value: "(?i)threshold_exceeded_marker"
+      description: "fixture"
+${method === "behavioral" ? `  behavioral:
+    metric: "tool_calls"
+    aggregation: count
+    window: "PT1M"
+    operator: gt
+    threshold: 100
+` : ""}response:
+  actions: [alert]
+  message_template: "fixture"
+test_cases:
+  true_positives:
+    - input: "threshold_exceeded_marker"
+      expected: triggered
+  true_negatives:
+    - input: "nothing to see"
+      expected: not_triggered
+`;
+}
+
+interface TestReport {
+  totalTests: number;
+  passed: number;
+  failed: number;
+  skipped: number;
+  skippedRules: Array<{ ruleId: string; cases: number; reason: string }>;
+}
+
+function runCli(method: "behavioral" | "pattern"): { report: TestReport; status: number } {
+  const dir = mkdtempSync(join(tmpdir(), "atr-harness-"));
+  try {
+    const rulesDir = join(dir, "rules", "excessive-autonomy");
+    mkdirSync(rulesDir, { recursive: true });
+    const file = join(rulesDir, "ATR-2026-09001-fixture.yaml");
+    writeFileSync(file, ruleYaml(method));
+
+    const r = spawnSync("npx", ["tsx", CLI, "test", file, "--json"], {
+      encoding: "utf8",
+      timeout: 120_000,
+    });
+    const stdout = r.stdout ?? "";
+    const start = stdout.indexOf("{");
+    expect(start, `no JSON in stdout: ${stdout}${r.stderr}`).toBeGreaterThanOrEqual(0);
+    return { report: JSON.parse(stdout.slice(start)) as TestReport, status: r.status ?? -1 };
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+describe("atr test — method=behavioral reporting", () => {
+  it("counts behavioral cases as unevaluable rather than failed", () => {
+    const { report, status } = runCli("behavioral");
+
+    // The engine never evaluated them, so calling them failures blames the rule.
+    expect(report.failed).toBe(0);
+    // And calling them passes would hide that nothing ran.
+    expect(report.passed).toBe(0);
+    expect(report.skipped).toBe(2);
+    expect(report.totalTests).toBe(2);
+    expect(status).toBe(0);
+  });
+
+  it("names the rule and the reason, so a skip is never silent", () => {
+    const { report } = runCli("behavioral");
+
+    expect(report.skippedRules).toHaveLength(1);
+    expect(report.skippedRules[0]?.ruleId).toBe("ATR-2026-09001");
+    expect(report.skippedRules[0]?.cases).toBe(2);
+    expect(report.skippedRules[0]?.reason).toMatch(/behavioral/i);
+  });
+
+  it("still evaluates an otherwise identical pattern rule", () => {
+    // Guards against the skip widening past method=behavioral: the same
+    // conditions, source type and cases must run normally under method=pattern.
+    const { report, status } = runCli("pattern");
+
+    expect(report.skipped).toBe(0);
+    expect(report.failed).toBe(0);
+    expect(report.passed).toBe(2);
+    expect(status).toBe(0);
+  });
+});


### PR DESCRIPTION
`ATR-2026-00553` has five failing test cases on main right now:

```
$ agent-threat-rules test rules/excessive-autonomy/ATR-2026-00553-runaway-tool-loop-behavioral.yaml
FAIL ATR-2026-00553 [true_positive]   Expected: triggered, Got: not_triggered    (×5)
```

They are not a detection failure. The engine never looked.

## What is actually happening

`src/engine.ts:667`:

```ts
// method=behavioral — windowed metric evaluation. Requires state across
// multiple events; the sync evaluate() API cannot maintain state.
// Skip silently; behavioral evaluation belongs in a separate streaming path.
if (method === 'behavioral') {
  return null;
}
```

That is a deliberate, documented decision. `evaluate()` returns `null` for behavioral rules without reading a single condition.

The test runner did not know about it. It called `evaluate()`, got no match, and recorded `Expected: triggered, Got: not_triggered` — which reads as "this rule does not detect what it claims". The rule is fine. The harness was reporting the absence of an evaluator as a property of the rule.

`ATR-2026-00553` is the corpus's only `method: behavioral` rule and the reference example shipped with v1.1 of the method-extensions spec, so it is the only one affected:

```
$ grep -rl "method: behavioral" rules/ | wc -l
1
```

## Why nobody noticed

`rule-quality.yml` runs `agent-threat-rules test` on **changed** rule files only. Nothing had edited that file in a while, so five permanent failures sat on main unseen. They surfaced in #430, which touched the file to remove an unrelated bad compliance identifier — and that PR had to drop the file from its scope to go green.

Any change to that rule, for any reason, hits this. It needs fixing before the file can be touched again.

## The fix

Cases the engine cannot evaluate are counted and named as **unevaluable**:

```
  Rules tested:    1
  Test cases:      10
  Passed:          0
  Unevaluable:     10
    ATR-2026-00553: 10 case(s) — method=behavioral requires a streaming evaluator
────────────────────────────────────────────────────────────
All tests passed. (10 case(s) unevaluable — see above)
```

Deliberately not failed — that blames the rule for a gap in the harness. Deliberately not passed — that would hide that nothing ran. `skipped` and `skippedRules` are in the `--json` output too, so a downstream consumer can tell the difference between "ten cases verified" and "ten cases nobody checked".

The literal string `All tests passed` is preserved because `rule-quality.yml` greps for it; the suffix keeps it from overstating what ran.

There is precedent immediately below the changed code. `method: trace` had the same problem and was given a real evaluation path, with a comment naming the failure mode exactly:

> Without this, trace rules can never satisfy their own declared true_positives: the harness would otherwise feed the raw JSON as text to the pattern fallback, whose regex expects a pre-computed synthetic verdict field that is absent from a raw trace.

Behavioral rules have no evaluator to route to, so reporting them honestly is the available move.

## Tests

`tests/cli-test-behavioral-unevaluable.test.ts`, three cases:

- behavioral cases counted unevaluable, `failed: 0` **and** `passed: 0`
- the rule id and reason are reported, so a skip is never silent
- an otherwise identical rule differing only in `method: pattern` still runs normally — this is the guard against the skip widening

Confirmed the tests fail without the fix: removing the skip block turns the first two red and leaves the third green, which is the correct signature since pattern behaviour is unchanged.

Full suite passes. `tsc --noEmit` clean.

## What this does not do

It does not make behavioral rules evaluable. `ATR-2026-00553` still cannot be verified by anything in this repo, and its five true_positives remain unproven. That needs the streaming evaluator `engine.ts` refers to, and it is a real gap — this change just stops mislabelling it.

If the intent is that behavioral rules should never be shipped without an evaluator, the follow-up is a gate that rejects them, not a change here. That is a decision about the method, and this PR does not take it.
