### PR TITLE
fix(rules): ATR-2026-00107 test cases put the payload in a field the rule cannot read

### DIFF
--- a/rules/privilege-escalation/ATR-2026-00107-delayed-execution-bypass.yaml
+++ b/rules/privilege-escalation/ATR-2026-00107-delayed-execution-bypass.yaml
@@ -94,17 +94,17 @@ test_cases:
     - tool_description: Creates delayed operations that bypass standard security checks when executed in the background system context.
       expected: triggered
       description: Delayed operations bypassing security checks
-    - input: >-
+    - tool_description: >-
         This tool manages scheduled tasks that bypass normal permission checks to ensure background operations complete
         without interruption.
       expected: triggered
       description: Scheduled tasks bypassing normal permission checks
-    - input: >-
+    - tool_description: >-
         Registers background processes that bypass standard access checks, allowing elevated execution after a time
         delay.
       expected: triggered
       description: Background processes bypassing standard access checks
-    - input: >-
+    - tool_description: >-
         Enqueues delayed tasks that bypass regular security checks by deferring execution to a privileged system timer
         context.
       expected: triggered
@@ -120,17 +120,17 @@ test_cases:
         access controls.
       expected: not_triggered
       description: Jobs that inherit user permissions correctly
-    - input: >-
+    - tool_description: >-
         This tool creates cron jobs that execute under the invoking user's credentials. All access control policies are
         enforced at runtime.
       expected: not_triggered
       description: Cron job scheduler with proper access control enforcement
-    - input: >-
+    - tool_description: >-
         Queues asynchronous work items for later processing. Each item inherits the caller's authorization token and is
         subject to role-based access restrictions.
       expected: not_triggered
       description: Async work queue that preserves caller authorization
-    - input: >-
+    - tool_description: >-
         Documentation note: attackers sometimes abuse deferred execution to circumvent authorization gates. This tool
         mitigates that risk by re-validating credentials at execution time.
       expected: not_triggered


### PR DESCRIPTION
`ATR-2026-00107` fails 3 of its own 5 declared true positives on `main`. It is not a detection failure — the engine never read the field the payloads were placed in.

## The mechanism

The rule has one condition, on `field: tool_description`. Six of its test cases put the tool-description text under the `input:` key instead.

`src/cli.ts`'s `buildEventFromTestCase` routes `input:` into `fields.user_input`, `fields.tool_args`, `fields.content` and `fields.agent_message`. **`fields.tool_description` is populated only when a test case names it explicitly.** And `src/engine.ts`'s `resolveField` has no alias fallback for `tool_description` — it reads `event.fields.tool_description` or `event.metadata`, nothing else (the sole exception being skill context, where every field falls back to content).

So the payload went into a field the rule can never read. The three "passing" true negatives were the same artifact in reverse: they passed by not being measured. Renamed too — they still correctly do not trigger.

## Why the field was NOT widened

The obvious alternative was to let the rule also read `content`. That was **tried, measured, and rejected**, not dismissed by argument.

Where does a poisoned tool description actually arrive in production?

- **Claude Code hook** (`src/hook-handler.ts`) builds `{tool_name, tool_args, content}` plus `tool_response` on PostToolUse. It never populates `tool_description` — and `HookInput` (`src/types.ts:468`) carries only `hook`/`tool_name`/`tool_input`/`session_id`/`timestamp`. **The tool description does not enter that process at all.** Reading `content` would not rescue this channel; the text simply is not there.
- **`pga scan events.json`** deserializes `AgentEvent` as given, so an integrator can populate `fields.tool_description` — and the SPEC lists it as a first-class detection field. **This is the rule's one live channel, and it is exactly the field the rule already reads.**
- **skill context** falls back to content, but the compound gate closes it: `scan_target: mcp` is not skill/both, and `condition: any` short-circuits so `matchedConditions` can never exceed 1 against a threshold of 2. Verified against a two-condition variant — the gate still reports `max 1 of 2`.

So widening to `content` buys no additional poisoned tool description. What it does buy is matching this text when it appears in a written file, an LLM message or a request body — which is precisely what the rule's own `false_positives` list warns about (security training material quoting the phrasing, compliance reports pasting flagged descriptions) and what its own TN#5 is.

## The 0-FP certificate for that variant would have been empty

`gate-promotion-fp` runs the `wide-raw` shape, which pours every benign sample into `tool_description` **and** `content` simultaneously (`src/corpus-event.ts:158-175`). It cannot distinguish the two variants — measured, and the outputs are identical.

Citing "0 FP on 5,352 samples" as clearance for the wider variant would have been a certificate that measured nothing: the rule charged on a presentation wider than production, passing, while never answering whether production's `content` channel misfires. That is tonight's recurring defect wearing the other face, so the variant was reverted and is not in this commit.

## Recall impact: zero

The rule body — pattern, condition, field, severity, maturity, status — is unchanged. `git diff` is 6 key renames. This fixes a rule whose *self-description* was lying, not a rule that could not detect.

```
main branch     10 cases · 7 passed · 3 failed
this branch     10 cases · 10 passed · exit 0
FP gate         5,352 benign · 0 FP
```

## Two things found and deliberately left

**The rule is effectively dead outside `pga scan events.json`.** The hook channel never carries the text; the skill channel is gated shut. Reviving it means changing `scan_target` or adding a condition — redesigning the rule, not fixing its tests. Worth recording that its `wild_validated: 2026/04/08 · wild_samples: 53577 · wild_fp_rate: 0` was therefore obtained in a configuration where it can barely fire. (See #433 — that field is unmeasured across 230 rules.)

**`evasion_tests[3]` makes a false claim.** It asserts that inserting U+200B zero-width spaces into "bypass" defeats the match. Probed directly: placed in `tool_description` it **triggers** — `src/engine.ts:1856`'s `normalizeUnicode` strips zero-width characters, and the pattern uses `\s+`. It "passes" today for the same reason as everything above: its payload is under `input:`. Fixing it requires flipping `expected: not_triggered` to `triggered`, and no harness evaluates `evasion_tests` at all — the CLI runner and `validate-rule-testcases.ts` both iterate only TPs and TNs. A one-line change, but it is a claim about the rule's capability, so it is flagged rather than made.

## Verification

```
src/cli.ts test          exit 0 · 10/10
validate-rule-testcases  10/10
gate-promotion-fp        0 FP / 5,352
validate-rules           783 passed
```

`CI=1 npx vitest run` did not converge locally within the session and is **not claimed green** — the change touches only YAML test-case keys, no `.ts`, but that is inference, not measurement. CI on this PR is the check that matters.
