### PR TITLE
perf(ci): run the rule quality gate once instead of once per file

### DIFF
--- a/.github/workflows/rule-quality.yml
+++ b/.github/workflows/rule-quality.yml
@@ -43,25 +43,41 @@ jobs:
             echo "$CHANGED" > changed_rules.txt
           fi
 
+      # The validate and test steps below each used to spawn one `npx` process
+      # per changed file. That is fine for a three-rule PR and quadratic pain
+      # for a sweep: PR #436 touched 787 files and this job took 1h24m, almost
+      # all of it Node start-up. Both commands accept a directory and recurse,
+      # so the changed files are staged once and each command runs once.
+      # Paths are preserved under the stage so reported files still read as
+      # rules/<category>/<id>.yaml.
+      - name: Stage changed rules
+        if: steps.changed-rules.outputs.has_changes == 'true'
+        run: |
+          rm -rf .rulestage
+          while IFS= read -r file; do
+            if [ -f "$file" ]; then
+              mkdir -p ".rulestage/$(dirname "$file")"
+              cp "$file" ".rulestage/$file"
+            fi
+          done < changed_rules.txt
+          echo "Staged $(find .rulestage -name '*.yaml' -o -name '*.yml' | wc -l) rule file(s)."
+
       - name: Validate changed rules
         if: steps.changed-rules.outputs.has_changes == 'true'
         id: validate
         run: |
-          PASS=0
-          FAIL=0
-          ERRORS=""
+          npx agent-threat-rules validate .rulestage --json > validate.json || true
 
-          while IFS= read -r file; do
-            if [ -f "$file" ]; then
-              echo "Validating: $file"
-              if npx agent-threat-rules validate "$file" 2>&1; then
-                PASS=$((PASS + 1))
-              else
-                FAIL=$((FAIL + 1))
-                ERRORS="${ERRORS}\n- ${file}"
-              fi
-            fi
-          done < changed_rules.txt
+          PASS=$(jq -r '.passed // 0' validate.json)
+          FAIL=$(jq -r '.failed // 0' validate.json)
+          ERRORS=$(jq -r '
+            [.results[]? | select(.valid | not)
+             | "- " + (.file | sub("^.*/\\.rulestage/"; "")) + ": " + ((.errors // []) | join("; "))]
+            | join("\n")' validate.json)
+
+          jq -r '.results[]? | select(.valid | not)
+                 | "INVALID " + (.file | sub("^.*/\\.rulestage/"; ""))' validate.json
+          echo "Validated $(jq -r '.total // 0' validate.json) rule file(s): $PASS ok, $FAIL invalid."
 
           echo "validate_pass=$PASS" >> "$GITHUB_OUTPUT"
           echo "validate_fail=$FAIL" >> "$GITHUB_OUTPUT"
@@ -79,23 +95,23 @@ jobs:
         if: steps.changed-rules.outputs.has_changes == 'true'
         id: test
         run: |
-          PASS=0
-          FAIL=0
-          ERRORS=""
+          npx agent-threat-rules test .rulestage --json > test.json || true
 
-          while IFS= read -r file; do
-            if [ -f "$file" ]; then
-              echo "Testing: $file"
-              OUTPUT=$(npx agent-threat-rules test "$file" 2>&1) || true
-              if echo "$OUTPUT" | grep -q "All tests passed"; then
-                PASS=$((PASS + 1))
-              else
-                FAIL=$((FAIL + 1))
-                ERRORS="${ERRORS}\n- ${file}"
-              fi
-              echo "$OUTPUT"
-            fi
-          done < changed_rules.txt
+          # Counts are per test case now, not per file. The old loop grepped for
+          # "All tests passed", which a rule reports even when every one of its
+          # cases was unevaluable — so a rule nothing could evaluate counted as a
+          # pass. failed == 0 is the gate; unevaluable is surfaced separately.
+          PASS=$(jq -r '.passed // 0' test.json)
+          FAIL=$(jq -r '.failed // 0' test.json)
+          SKIPPED=$(jq -r '.skipped // 0' test.json)
+          ERRORS=$(jq -r '
+            [.failures[]? | "- " + .ruleId + " [" + .testType + "]: expected "
+             + .expected + ", got " + .got]
+            | unique | join("\n")' test.json)
+
+          jq -r '.failures[]? | "FAIL " + .ruleId + " [" + .testType + "] " + (.input // "")' test.json
+          jq -r '.skippedRules[]? | "UNEVALUABLE " + .ruleId + " (" + (.cases|tostring) + " case(s)): " + .reason' test.json
+          echo "Ran $(jq -r '.totalTests // 0' test.json) case(s) across $(jq -r '.totalRules // 0' test.json) rule(s): $PASS pass, $FAIL fail, $SKIPPED unevaluable."
 
           echo "test_pass=$PASS" >> "$GITHUB_OUTPUT"
           echo "test_fail=$FAIL" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
`ATR Rule Quality` took **1h24m10s** on #436. The work is minutes; the rest was Node start-up.

## Cause

The validate and test steps each spawned one `npx` process per changed rule file:

```bash
while IFS= read -r file; do
  npx agent-threat-rules validate "$file"
done < changed_rules.txt
```

Fine for a three-rule PR. #436 touched 783 files, so that is 1,566 process starts across the two steps, each paying npm resolution and engine load to check one file.

## Fix

Both commands already accept a directory and recurse. The changed files are staged once into `.rulestage`, and each command runs once with `--json`. Paths are preserved under the stage, so reported files still read as `rules/<category>/<id>.yaml` rather than as bare basenames.

Measured end-to-end on the same 783-file workload:

| | before | after |
|---|---|---|
| validate + test | **1h 24m 10s** | **3m 49s** |

Same result either way — 783 validated, 7,917 cases, 7,907 pass, 0 fail, 10 unevaluable.

## A hole the rewrite exposed

The old test step decided pass/fail like this:

```bash
if echo "$OUTPUT" | grep -q "All tests passed"; then PASS=...
```

Since #432 a `method: behavioral` rule prints:

```
Unevaluable:     10
    ATR-2026-00553: 10 case(s) — method=behavioral requires a streaming evaluator
All tests passed. (10 case(s) unevaluable — see above)
```

The grep matches. **A rule where nothing could be evaluated counted as a clean pass**, which is the same shape as the defect #440 fixed inside `ATR-2026-01774` — eight green true_negatives that were never evaluated.

The gate is now `failed == 0` read from the JSON, with `skipped` counted and printed on its own line. Unevaluable stays visible instead of hiding inside a success string.

## Verified by injection, not assumption

A faster gate that cannot fail is worse than a slow one.

| injected | result |
|---|---|
| rule whose `true_positive` cannot match | `FAIL ATR-2026-09998 [true_positive]: expected triggered, got not_triggered` — gate fails |
| rule missing required fields | `INVALID rules/.../ATR-2026-09997-invalid.yaml: missing required fields (id, title, detection)` — gate fails |

Also checked the path rewrite against a real staged tree: `.rulestage/rules/agent-manipulation/ATR-2026-00030-cross-agent-attack.yaml` reports as `rules/agent-manipulation/ATR-2026-00030-cross-agent-attack.yaml`.

One file, workflow only. No rule, engine or script change.

## This PR cannot test itself

`rule-quality.yml` triggers on `paths: rules/**`. This PR changes only the workflow, so the job does not run and GitHub reports no checks at all. A green tick here would mean nothing was executed, not that the change works.

The verification above is therefore local: the rewritten shell was run verbatim — same staging loop, same `jq` expressions — against 783 real changed files out of this repo, and against the two injected failure cases. The numbers in the table come from that run, not from an estimate.

First live exercise will be the next PR that touches `rules/**`. Worth watching that job's duration and its `unevaluable` line to confirm both behaviours in CI.
