### PR TITLE
fix(gate): report the benign gate's security-content half instead of removing it

### DIFF
--- a/docs/research/benign-gate-security-education-2026-08-07.md
+++ b/docs/research/benign-gate-security-education-2026-08-07.md
@@ -1,0 +1,202 @@
+# benign gate 裡的資安教材:算 benign 還是該分流?
+
+**裁定日期** 2026-08-07 · **量測基準** origin/main `e2e930c1d` · **語料** 5,352 筆
+(`data/skill-benchmark/benign` + `data/benign-corpus-extended` + `data/benign-code`)
+
+## 問題
+
+`scripts/gate-promotion-fp.ts` 對 776 條會 fire 的規則跑 5,352 筆 benign 樣本:
+clean 598 · dirty 178 · **FP 總數 14,561**。收緊規則的人一致回報,殘留 FP 幾乎
+全是滲透測試 / 資安教材文件逐字寫著 `' OR '1'='1`、`/etc/passwd`、`; DROP TABLE`、
+`find / -name "id_rsa"`。
+
+一份逐字引用攻擊 payload 當教學範例的資安教材,對偵測規則來說算 benign 還是
+該分流出去?
+
+## 裁定
+
+**語料一條不動、一條不移(採 A);gate 多報一行分段(採 B 的報告面,不採它的
+實質面)。對外數字永遠是總數 14,561,不准引用「一般 benign FP」那一半。**
+
+依據是下面的規模量測:嚴格判準下資安教材只解釋 **3.6%** 的 FP,寬到不可辯護的
+判準下也只有 **22%**。分流買不到修正,只買到數字變好看 —— 而這個 repo 今晚整晚
+都在修「閘報出它從未取得的 clean」,再造一個同類缺陷是不可接受的。
+
+## 1. 前人做過什麼(不重造,不推翻)
+
+`47d75f33a` (2026-06-21) 的稽核 `docs/research/precision-repair-broad-rules-2026-06-21.md`
+已經把同一個問題分成兩群並分開處置,而且**只有一群被隔離**:
+
+| 母體 | 規模 | 處置 | 理由 |
+|---|---:|---|---|
+| 真越獄樣本被標成 benign(DAN persona / ethics bypass) | 86(0.13%) | **隔離** `_contamination-jailbreak.txt` | 標籤錯誤 —— 同一批樣本在 `dan-corpus.json` 裡是 true positive,一份母體兩個相反標籤 |
+| dual-use SEO 模板(`ignore all previous instructions … [TARGETLANGUAGE]`) | 675(1.04%) | **留在 benign gate** | 不是攻擊。規則對它們開火就是真 FP |
+
+該文的政策原句:
+
+> A dual-use security skill that legitimately contains attack techniques is not a
+> false positive to suppress by blunting the rule; it is an advisory-tier signal
+> the consumer decides on. Blunting the deterministic rule to hide it would lose
+> real detections.
+
+以及它對「語料該往哪走」的指示是**擴大**而非縮小:
+
+> Expand the benign gate with representative wild-scan dual-use / doc / legit-MCP-
+> config samples, so the gate measures the real distribution the rules face.
+
+而且該次稽核已經量過同一個問題的答案:清掉 86 條污染只把 65K FP 率從 8.0% 挪到
+7.9% ——「殘留 FP 是 dual-use intent,只有語意/情境層能分開,不是清語料或鈍化
+regex 能解的」。
+
+**資安教材是第 2 群的近親,不是第 1 群。**本次裁定延伸該政策,沒有推翻它。
+(相關但不同的機制:PR #373 的 benign 語料採集器帶 jailbreak-exclusion filter,
+擋的是「採集時就別把攻擊收進來」,與「已在語料裡的教材怎麼處置」是兩件事。)
+
+## 2. 規模(腳本量的,不是 LLM 數的)
+
+判準 = `src/corpus/security-content.ts`:**逐字攻擊 payload ≥1** ﹠
+**相異資安主題標記 ≥2**。只提 OWASP 不算,只出現 `../../` 也不算。
+
+| | 樣本數 | 佔語料 | 貢獻 FP | 佔 14,561 |
+|---|---:|---:|---:|---:|
+| **嚴格判準**(payload AND ≥2 主題) | 37 | 0.69% | **526** | **3.61%** |
+| 寬鬆上界(payload OR ≥1 主題) | 642 | 12.0% | 3,212 | 22.1% |
+
+來源分佈(嚴格判準的 37 條):
+
+| 來源檔 | 樣本 | FP |
+|---|---:|---:|
+| `data/benign-corpus-extended/skills-sh.jsonl` | 31 | 439 |
+| `data/benign-corpus-extended/wild-fp-confirmed.jsonl` | 6 | 87 |
+| 其餘 6 個來源(arxiv / npm / pypi / official-skills / agent-ops / benign-code / skill-benchmark md) | 0 | 0 |
+
+FP 前 20 大規則(佔全部 FP 的 89.2%)的分段:
+
+| 規則 | FP 總 | 一般 | 資安內容 | 自宣告 TP |
+|---|---:|---:|---:|---:|
+| ATR-2026-00061 | 2814 | 2777 | 37 | 0/2 |
+| ATR-2026-00012 | 1672 | 1637 | 35 | 7/10 |
+| ATR-2026-00454 | 1337 | 1315 | 22 | 8/8 |
+| ATR-2026-01610 | 1180 | 1165 | 15 | 3/4 |
+| ATR-2026-00066 | 1035 | 1011 | 24 | 0/3 |
+| ATR-2026-00020 | 739 | 732 | 7 | 5/5 |
+| ATR-2026-00063 | 637 | 614 | 23 | 0/2 |
+| ATR-2026-00217 | 588 | 576 | 12 | 5/5 |
+| ATR-2026-00142 | 426 | 409 | 17 | 5/5 |
+| ATR-2026-00064 | 403 | 383 | 20 | 0/2 |
+
+(其餘 10 條的分段比例一致,均在 1–10% 區間。重現指令:
+`npx tsx scripts/measure-security-content-fp.ts` —— 它把全部規則跑在被標記的 37 條上,
+輸出即 526/14,561 這個頭條數字。)
+
+**這張表就是裁定的依據。**前 20 大規則的資安內容佔比是 1.3%。最大的單一 FP 源
+ATR-2026-00061 有 2,814 個 FP,其中 37 個落在資安內容上 —— 它的 FP 根本不是教材
+問題,是規則自己在註解裡承認的結構問題(`condition: any` 疊五個能力原語,
+`exec` 無字界匹配到 "execution",`\$\{?[A-Z_]+\}?` 匹配到每個 README 印過的
+shell 變數)。
+
+**順帶抓到的**:00061 / 00066 / 00063 / 00064 / 00062 在 gate 的事件形狀下,
+對自己宣告的 true positives 是 **0 命中**。幾千個 FP 配上零自證 —— 這是獨立於
+本線的問題,已記在此。
+
+## 3. 兩個實驗(可驗證,不是論證)
+
+### 實驗 A —「規則可以變聰明」:部分證偽
+
+改法:把 `condition: any` 疊加的獨立指標,改成 `condition: all` 要求
+**credential artifact** 與 **執行原語 / 外傳目的地**共現。
+recall 用 6,709 筆攻擊樣本量(全 repo 規則的 `test_cases.true_positives`
++ garak in-the-wild + llm-guard + promptfoo + nemo-guardrails + promptinject),
+不是只用規則自己的 5 條 test case。
+
+重現:
+```
+npx tsx scripts/measure-rule-fp-segmented.ts <rulesDir> <ATR-id...>   # FP + 分段 + 自宣告 TP
+npx tsx scripts/measure-rule-recall-ab.ts <baseRulesDir> <variantRulesDir> <ATR-id...>  # A/B attack recall
+```
+
+| 規則 | FP | 攻擊 recall | 判讀 |
+|---|---|---|---|
+| ATR-2026-00113 | 332 → **118**(−64.5%) | 94 → **31**(−67.0%) | 自宣告 TP 5/5 → 1/5 |
+| ATR-2026-00217 | 588 → **31**(−94.7%) | 14 → **5**(−64.3%) | 自宣告 TP 5/5 → 5/5 |
+
+兩點必須講清楚:
+
+1. **共現要求確實砍得動 FP,但不是免費的。**兩條都付出約 2/3 的攻擊 recall。
+2. **只看規則自己的 test case 會得到相反結論。**00217 的自宣告 TP 是 5/5 不變 ——
+   因為它那 5 條剛好都含外傳動作。放到 6,709 筆攻擊語料才看得到 −64%。
+   **「規則變聰明」的 recall 不可以用規則自己的 test case 量。**
+
+3. **它砍掉的不是資安教材的 FP。**00113 的資安內容 FP 只從 28 掉到 14,一般 FP
+   從 304 掉到 104。也就是說共現要求修的是「一般 benign 上的過度開火」,
+   跟教材無關 —— 又一個「教材不是問題根因」的獨立佐證。
+
+結論:regex 層可以用共現換 precision,交換率大約是「砍 64–95% FP 換掉 64–67%
+recall」。**要不付 recall 就得到 precision,需要 regex 以外的層** —— 這與
+2026-06-21 的結論(「只有語意/情境層能分開 dual-use intent」)一致。
+
+### 實驗 B —「標記分流」:規模不足以成為解法
+
+見上表。嚴格判準 3.61%,寬鬆上界 22.1%。而寬鬆判準會把 12% 的 benign 語料標成
+「資安內容」,那個口徑站不住(它會撞爆 `SECURITY_CONTENT_BUDGET` ratchet,而且
+在真攻擊語料上的標記率會跳到 2.9%,撞爆 `LAUNDERING_CEILING`)。
+
+**所以 (B) 的實質面不採用。**
+
+## 4. 判準與防濫用
+
+判準寫在 `src/corpus/security-content.ts`,可腳本化、可重跑、可被人審(regex
+清單全部攤開)。四道防線,每一道都是 `tests/benign-gate-security-content.test.ts`
+的斷言,不是註解:
+
+| # | 濫用方式 | 防線 | 現值 |
+|---|---|---|---|
+| 1 | 判準放寬成掃地機 | `SECURITY_CONTENT_BUDGET` = 2% | 實測 37/5352 = 0.69% |
+| 2 | 把真攻擊標成「教材」洗白 | `LAUNDERING_CEILING` = 1%,對規則自宣告 TP 與 garak in-the-wild 各測一次 | 實測 1/3805 = 0.03% · 0/650 = 0.00% |
+| 3 | 結果導向(看哪些樣本害我 FP 再反推判準) | 判準模組零 import,拿不到引擎/規則 id/FP 計數;測試斷言之 | — |
+| 4 | 分段被拿去縮小語料或改變判定 | 測試斷言 `partitionByFp()` 與 `resolveExitCode()` 的引數不得出現 `security`;並斷言 `general + security == total` | — |
+
+**`LAUNDERING_CEILING` 是實測校準出來的,不是憑感覺挑的。** 原本訂 5%,然後刻意
+把攻擊語言(`ignore all previous instructions`、`do anything now`、
+jailbreak / DAN / prompt injection)偷渡進 payload 與主題清單 —— 這是最典型的
+洗白手法。結果 garak 標記率跳到 3.85%,**5% 沒有咬住**。上限因此收到 1%,
+再破壞一次確認會紅(2.92% > 1%),還原後綠。
+
+ratchet 已親自破壞兩次確認會紅:
+- 判準由 AND 放寬成 OR → 預算斷言紅(6.65% > 2%)+ 窄口徑斷言紅。
+- 攻擊語言偷渡進清單 → 洗白斷言紅(2.92% > 1%)。
+兩次都還原,還原後 8/8 綠。
+
+## 5. gate 的輸出怎麼變
+
+`scripts/gate-promotion-fp.ts` 多印兩行,**headline / clean·dirty / exit code
+完全不變**:
+
+```
+[fp-gate] corpus split — security-content 37/5352 (0.7%) · general 5315
+[fp-gate] FP split — general N · security-content M (x% of total).
+          Both are false positives; the outward number is the total.
+```
+
+dirty 清單每條後面附註 `(M on security content)`。**一條 400 FP 全部落在資安
+內容上的規則,照樣 FAIL 這道閘。**
+
+## 6. 對外數字口徑
+
+`state/benchmark-claims.json` 的 `benign-gate-fp` 條目維持 `status: MISLABELED`、
+`outward_safe: false` —— 本線沒有解決它的效度缺口(「65K」標籤掛錯語料、
+兩個 lane 數字都還沒在新語料上重測)。本線新增的是:
+
+- 這次量到的硬數字(5,352 / 776 effective / 14,561 FP / 178 dirty)連同條件。
+- **新增禁令:分段出來的「一般 benign FP」永遠不可單獨對外引用。**
+  對外的 FP 數字是總數。分段是內部診斷用的,不是折扣。
+
+## 7. 沒做到的 / 留給下一手
+
+- **14,561 是真債,本線沒有還。**它主要由少數結構性過寬的規則造成
+  (00061 一條 2,814),不是語料問題。
+- 5 條規則(00061/00062/00063/00064/00066)在 gate 的事件形狀下對自己宣告的
+  true positives 零命中,值得獨立一線。
+- 判準是 regex,對「引用 payload」與「執行 payload」的區分能力有上限;
+  真正的分辨要語意/情境層 —— 與 2026-06-21 的結論相同,七週內兩次從不同方向
+  撞到同一堵牆。

--- a/scripts/gate-promotion-fp.ts
+++ b/scripts/gate-promotion-fp.ts
@@ -90,6 +90,7 @@ import { tmpdir } from "node:os";
 import { execFileSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { ATREngine } from "../src/engine.js";
+import { classifySecurityContent } from "../src/corpus/security-content.js";
 import {
   corpusShapes,
   shapeNames,
@@ -171,7 +172,9 @@ export function parseCliOptions(argv: readonly string[]): GateOptions {
   const emitDirty = pathValue(argv, "--emit-dirty");
   const filterMode = argv.includes("--filter-mode");
   if (emitClean !== null && emitClean === emitDirty) {
-    throw new GateUsageError("--emit-clean and --emit-dirty must be different paths");
+    throw new GateUsageError(
+      "--emit-clean and --emit-dirty must be different paths",
+    );
   }
   if (filterMode && emitClean === null && emitDirty === null) {
     throw new GateUsageError(
@@ -204,7 +207,8 @@ export function parsePromotedFiles(diff: string): readonly string[] {
       continue;
     }
     const maturity = /^\+\s*maturity:\s*["']?(\w+)["']?\s*$/.exec(line);
-    if (maturity && current && ENFORCE_MATURITIES.has(maturity[1] ?? "")) files.add(current);
+    if (maturity && current && ENFORCE_MATURITIES.has(maturity[1] ?? ""))
+      files.add(current);
   }
   return [...files];
 }
@@ -215,7 +219,9 @@ export interface FpPartition {
 }
 
 /** Split scanned ids into FP-clean and FP-producing, deterministically ordered. */
-export function partitionByFp(counts: ReadonlyMap<string, number>): FpPartition {
+export function partitionByFp(
+  counts: ReadonlyMap<string, number>,
+): FpPartition {
   const entries = [...counts.entries()];
   const clean = entries
     .filter(([, n]) => n === 0)
@@ -233,7 +239,10 @@ export function partitionByFp(counts: ReadonlyMap<string, number>): FpPartition 
  * Filter semantics (--filter-mode): the caller wants the lists, not a verdict,
  * so a dirty finding is data — exiting non-zero would abort a `set -e` promoter.
  */
-export function resolveExitCode(dirtyCount: number, filterMode: boolean): number {
+export function resolveExitCode(
+  dirtyCount: number,
+  filterMode: boolean,
+): number {
   if (dirtyCount === 0) return EXIT_OK;
   return filterMode ? EXIT_OK : EXIT_FAIL;
 }
@@ -274,10 +283,20 @@ function execGit(repoRoot: string): GitRunner {
  * scanned. If such an id was explicitly requested it surfaces as a missing id
  * (exit 3) rather than as a crash or a silent skip.
  */
-export function gitRuleFiles(repoRoot: string, run: GitRunner = execGit(repoRoot)): readonly string[] {
-  const isRule = (f: string): boolean => f.endsWith(".yaml") || f.endsWith(".yml");
+export function gitRuleFiles(
+  repoRoot: string,
+  run: GitRunner = execGit(repoRoot),
+): readonly string[] {
+  const isRule = (f: string): boolean =>
+    f.endsWith(".yaml") || f.endsWith(".yml");
   const tracked = run(["ls-files", "--", "rules/"]).split("\n").filter(isRule);
-  const untracked = run(["ls-files", "--others", "--exclude-standard", "--", "rules/"])
+  const untracked = run([
+    "ls-files",
+    "--others",
+    "--exclude-standard",
+    "--",
+    "rules/",
+  ])
     .split("\n")
     .filter(isRule);
   return [...new Set([...tracked, ...untracked])]
@@ -285,12 +304,19 @@ export function gitRuleFiles(repoRoot: string, run: GitRunner = execGit(repoRoot
     .sort();
 }
 
-function promotedFilesFromDiff(base: string, repoRoot: string): readonly string[] {
-  const diff = execFileSync("git", ["diff", `${base}...HEAD`, "--unified=0", "--", "rules/"], {
-    cwd: repoRoot,
-    encoding: "utf-8",
-    maxBuffer: 64 * 1024 * 1024,
-  });
+function promotedFilesFromDiff(
+  base: string,
+  repoRoot: string,
+): readonly string[] {
+  const diff = execFileSync(
+    "git",
+    ["diff", `${base}...HEAD`, "--unified=0", "--", "rules/"],
+    {
+      cwd: repoRoot,
+      encoding: "utf-8",
+      maxBuffer: 64 * 1024 * 1024,
+    },
+  );
   return parsePromotedFiles(diff);
 }
 
@@ -312,12 +338,16 @@ function writeIdList(path: string, ids: readonly string[]): void {
 function emitLists(options: GateOptions, partition: FpPartition): void {
   if (options.emitClean !== null) {
     writeIdList(options.emitClean, partition.clean);
-    console.log(`[fp-gate] wrote ${partition.clean.length} clean id(s) -> ${options.emitClean}`);
+    console.log(
+      `[fp-gate] wrote ${partition.clean.length} clean id(s) -> ${options.emitClean}`,
+    );
   }
   if (options.emitDirty !== null) {
     const ids = partition.dirty.map(([id]) => id);
     writeIdList(options.emitDirty, ids);
-    console.log(`[fp-gate] wrote ${ids.length} dirty id(s) -> ${options.emitDirty}`);
+    console.log(
+      `[fp-gate] wrote ${ids.length} dirty id(s) -> ${options.emitDirty}`,
+    );
   }
 }
 
@@ -361,7 +391,8 @@ function loadCorpusTexts(pathStr: string): readonly string[] {
   const texts: string[] = [];
   if (!existsSync(pathStr)) return texts;
   const files: string[] = [];
-  if (statSync(pathStr).isDirectory()) files.push(...collectCorpusFiles(pathStr));
+  if (statSync(pathStr).isDirectory())
+    files.push(...collectCorpusFiles(pathStr));
   else files.push(pathStr);
   for (const f of files) {
     let raw: string;
@@ -379,7 +410,8 @@ function loadCorpusTexts(pathStr: string): readonly string[] {
       if (!t) continue;
       try {
         const obj = JSON.parse(t) as { text?: string };
-        if (typeof obj.text === "string" && obj.text.length > 0) texts.push(obj.text);
+        if (typeof obj.text === "string" && obj.text.length > 0)
+          texts.push(obj.text);
       } catch {
         continue;
       }
@@ -391,7 +423,8 @@ function loadCorpusTexts(pathStr: string): readonly string[] {
 /** Copy just the target rule files into a temp dir so the engine loads only them. */
 function scopedRulesDir(repoRoot: string, files: readonly string[]): string {
   const dir = mkdtempSync(join(tmpdir(), "atr-gate-"));
-  for (const f of files) copyFileSync(join(repoRoot, f), join(dir, basename(f)));
+  for (const f of files)
+    copyFileSync(join(repoRoot, f), join(dir, basename(f)));
   return dir;
 }
 
@@ -427,7 +460,8 @@ function targetsFromIdsFile(idsFile: string, deps: GateDeps): Targets {
 }
 
 function resolveTargets(options: GateOptions, deps: GateDeps): Targets {
-  if (options.idsFile !== null) return targetsFromIdsFile(options.idsFile, deps);
+  if (options.idsFile !== null)
+    return targetsFromIdsFile(options.idsFile, deps);
   const files = promotedFilesFromDiff(options.base, deps.repoRoot);
   const ids = files
     .map((f) => ruleIdOf(deps.repoRoot, f))
@@ -438,29 +472,67 @@ function resolveTargets(options: GateOptions, deps: GateDeps): Targets {
 interface ScanResult {
   readonly counts: ReadonlyMap<string, number>;
   readonly sampleCount: number;
+  /**
+   * The half of `counts` that landed on samples labelled `security-content`
+   * (see src/corpus/security-content.ts). Reported alongside the headline,
+   * NEVER subtracted from it.
+   */
+  readonly securityCounts: ReadonlyMap<string, number>;
+  /** How many of `sampleCount` carry the security-content label. */
+  readonly securitySampleCount: number;
   /** Target rules with conditions this corpus cannot measure. */
   readonly coverage: readonly FieldCoverage[];
   /** Target rules the `skill` half of matchedRuleIds cannot ever match. */
   readonly skillCoverage: readonly SkillPathGap[];
 }
 
-async function scanFpCounts(targets: Targets, deps: GateDeps): Promise<ScanResult> {
-  const engine = new ATREngine({ rulesDir: scopedRulesDir(deps.repoRoot, targets.files) });
+async function scanFpCounts(
+  targets: Targets,
+  deps: GateDeps,
+): Promise<ScanResult> {
+  const engine = new ATREngine({
+    rulesDir: scopedRulesDir(deps.repoRoot, targets.files),
+  });
   await engine.loadRules();
 
   const samples: string[] = [];
   for (const c of deps.corpora) samples.push(...loadCorpusTexts(c));
 
   const counts = new Map<string, number>();
-  for (const id of targets.ids) counts.set(id, 0);
+  const securityCounts = new Map<string, number>();
+  for (const id of targets.ids) {
+    counts.set(id, 0);
+    securityCounts.set(id, 0);
+  }
+  let securitySampleCount = 0;
   for (const text of samples) {
+    // Labelled BEFORE the rules run and from the sample text alone. The label
+    // cannot be a function of which rules fired, or it degenerates into
+    // "whatever is inconvenient is not benign".
+    const isSecurityContent =
+      classifySecurityContent(text).label === "security-content";
+    if (isSecurityContent) securitySampleCount += 1;
     for (const id of matchedRuleIds(engine, text)) {
-      if (targets.ids.has(id)) counts.set(id, (counts.get(id) ?? 0) + 1);
+      if (!targets.ids.has(id)) continue;
+      counts.set(id, (counts.get(id) ?? 0) + 1);
+      if (isSecurityContent)
+        securityCounts.set(id, (securityCounts.get(id) ?? 0) + 1);
     }
   }
-  const coverage = fieldCoverage(engine.getRules()).filter((c) => targets.ids.has(c.ruleId));
-  const skillCoverage = skillPathCoverage(engine.getRules()).filter((c) => targets.ids.has(c.ruleId));
-  return { counts, sampleCount: samples.length, coverage, skillCoverage };
+  const coverage = fieldCoverage(engine.getRules()).filter((c) =>
+    targets.ids.has(c.ruleId),
+  );
+  const skillCoverage = skillPathCoverage(engine.getRules()).filter((c) =>
+    targets.ids.has(c.ruleId),
+  );
+  return {
+    counts,
+    sampleCount: samples.length,
+    securityCounts,
+    securitySampleCount,
+    coverage,
+    skillCoverage,
+  };
 }
 
 /**
@@ -483,7 +555,8 @@ function reportCoverage(coverage: readonly FieldCoverage[]): void {
   for (const c of coverage) {
     const tag = c.zeroMeasurement ? "ZERO-MEASUREMENT" : "partially measured";
     console.log(`  ${c.ruleId} — ${tag}`);
-    for (const f of c.unmeasured) console.log(`      ${f}: ${unmeasurableReason(f)}`);
+    for (const f of c.unmeasured)
+      console.log(`      ${f}: ${unmeasurableReason(f)}`);
   }
 }
 
@@ -509,7 +582,9 @@ function reportSkillPathCoverage(gaps: readonly SkillPathGap[]): void {
   console.log(
     `\n[fp-gate] NOT MEASURED ON THE SKILL PATH — ${gaps.length} rule(s) cannot produce a ` +
       `match through engine.scanSkill() for any input` +
-      (enforce.length > 0 ? `, ${enforce.length} of them in the enforce lane` : "") +
+      (enforce.length > 0
+        ? `, ${enforce.length} of them in the enforce lane`
+        : "") +
       `. They were measured on the evaluate() shapes only:`,
   );
   for (const g of gaps) {
@@ -521,34 +596,100 @@ function reportSkillPathCoverage(gaps: readonly SkillPathGap[]): void {
   }
 }
 
+/**
+ * Split the FP count into "general benign" and "security content".
+ *
+ * READ THIS BEFORE USING THE SECOND NUMBER FOR ANYTHING.
+ *
+ * The corpus genuinely contains pentest guides, compliance write-ups and
+ * security-audit skills that quote `' OR '1'='1` or `/etc/passwd` verbatim. A
+ * rule firing on those is a different kind of miss from a rule firing on an
+ * ordinary README, and reporting one number hides that.
+ *
+ * What this split is NOT allowed to become:
+ *   - It never removes a sample. `general + security == total`, asserted in
+ *     tests/benign-gate-security-content.test.ts.
+ *   - It never changes clean/dirty or the exit code. A rule with 400 FP all of
+ *     them on security content still fails this gate.
+ *   - The outward FP number stays the TOTAL. The split is context, not a
+ *     discount. Measured 2026-08-07: the security-content half is single-digit
+ *     percent of the FP mass, so a caller quoting only "general" would be
+ *     shaving noise while claiming a fix.
+ */
+function reportSecuritySplit(
+  partition: FpPartition,
+  securityCounts: ReadonlyMap<string, number>,
+  securitySampleCount: number,
+  sampleCount: number,
+): void {
+  const total = partition.dirty.reduce((a, [, n]) => a + n, 0);
+  if (total === 0) return;
+  let sec = 0;
+  for (const [id] of partition.dirty) sec += securityCounts.get(id) ?? 0;
+  const pct = (n: number, d: number): string =>
+    d === 0 ? "n/a" : `${((100 * n) / d).toFixed(1)}%`;
+  console.log(
+    `[fp-gate] corpus split — security-content ${securitySampleCount}/${sampleCount} ` +
+      `(${pct(securitySampleCount, sampleCount)}) · general ${sampleCount - securitySampleCount}`,
+  );
+  console.log(
+    `[fp-gate] FP split — general ${total - sec} · security-content ${sec} ` +
+      `(${pct(sec, total)} of ${total}). Both are false positives; the outward number is the total.`,
+  );
+}
+
 function report(
   partition: FpPartition,
   sampleCount: number,
   filterMode: boolean,
   coverage: readonly FieldCoverage[] = [],
   skillCoverage: readonly SkillPathGap[] = [],
+  securityCounts: ReadonlyMap<string, number> = new Map(),
+  securitySampleCount = 0,
 ): void {
   console.log(`[fp-gate] corpus = ${sampleCount} benign samples`);
   console.log(
     `[fp-gate] shapes = ${shapeNames().join(", ")}, skill ` +
       `(a rule's true positives MUST be measured on this same set)`,
   );
-  console.log(`[fp-gate] clean = ${partition.clean.length} · dirty = ${partition.dirty.length}`);
+  console.log(
+    `[fp-gate] clean = ${partition.clean.length} · dirty = ${partition.dirty.length}`,
+  );
+  reportSecuritySplit(
+    partition,
+    securityCounts,
+    securitySampleCount,
+    sampleCount,
+  );
   reportCoverage(coverage);
   reportSkillPathCoverage(skillCoverage);
   if (partition.dirty.length === 0) {
-    console.log(`[fp-gate] PASS — all promoted rules are FP-clean on the benign corpus.`);
+    console.log(
+      `[fp-gate] PASS — all promoted rules are FP-clean on the benign corpus.`,
+    );
     return;
   }
+  const secOf = (id: string): string => {
+    const n = securityCounts.get(id) ?? 0;
+    return n > 0 ? ` (${n} on security content)` : "";
+  };
   if (filterMode) {
-    console.log(`\n[fp-gate] FILTERED — these rules false-positive on benign content and were`);
-    console.log(`excluded from the clean list (they must not enter the enforce lane):`);
-    for (const [id, n] of partition.dirty) console.log(`  ${id} — ${n} FP`);
+    console.log(
+      `\n[fp-gate] FILTERED — these rules false-positive on benign content and were`,
+    );
+    console.log(
+      `excluded from the clean list (they must not enter the enforce lane):`,
+    );
+    for (const [id, n] of partition.dirty)
+      console.log(`  ${id} — ${n} FP${secOf(id)}`);
     return;
   }
-  console.error(`\n[fp-gate] FAIL — these promoted rules false-positive on benign content and`);
+  console.error(
+    `\n[fp-gate] FAIL — these promoted rules false-positive on benign content and`,
+  );
   console.error(`must not enter the enforce (auto-block) lane:`);
-  for (const [id, n] of partition.dirty) console.error(`  ${id} — ${n} FP`);
+  for (const [id, n] of partition.dirty)
+    console.error(`  ${id} — ${n} FP${secOf(id)}`);
 }
 
 /**
@@ -572,15 +713,21 @@ function reportMissingIds(missing: readonly string[], idsFile: string): number {
   return EXIT_MISSING_IDS;
 }
 
-export async function runGate(options: GateOptions, deps: GateDeps = defaultDeps()): Promise<number> {
+export async function runGate(
+  options: GateOptions,
+  deps: GateDeps = defaultDeps(),
+): Promise<number> {
   const targets = resolveTargets(options, deps);
   if (targets.missing.length > 0 && options.idsFile !== null) {
     return reportMissingIds(targets.missing, options.idsFile);
   }
 
   if (targets.files.length === 0) {
-    const scope = options.idsFile !== null ? `in ${options.idsFile}` : `vs ${options.base}`;
-    console.log(`[fp-gate] no rules promoted to enforce lane ${scope} — nothing to gate.`);
+    const scope =
+      options.idsFile !== null ? `in ${options.idsFile}` : `vs ${options.base}`;
+    console.log(
+      `[fp-gate] no rules promoted to enforce lane ${scope} — nothing to gate.`,
+    );
     emitLists(options, { clean: [], dirty: [] });
     return EXIT_OK;
   }
@@ -588,9 +735,24 @@ export async function runGate(options: GateOptions, deps: GateDeps = defaultDeps
   console.log(
     `[fp-gate] gating ${targets.files.length} promoted rule(s) against the benign corpus`,
   );
-  const { counts, sampleCount, coverage, skillCoverage } = await scanFpCounts(targets, deps);
+  const {
+    counts,
+    sampleCount,
+    securityCounts,
+    securitySampleCount,
+    coverage,
+    skillCoverage,
+  } = await scanFpCounts(targets, deps);
   const partition = partitionByFp(counts);
-  report(partition, sampleCount, options.filterMode, coverage, skillCoverage);
+  report(
+    partition,
+    sampleCount,
+    options.filterMode,
+    coverage,
+    skillCoverage,
+    securityCounts,
+    securitySampleCount,
+  );
   emitLists(options, partition);
   return resolveExitCode(partition.dirty.length, options.filterMode);
 }

--- a/scripts/measure-rule-fp-segmented.ts
+++ b/scripts/measure-rule-fp-segmented.ts
@@ -1,0 +1,186 @@
+#!/usr/bin/env npx tsx
+/**
+ * measure-rule-fp-segmented.ts — 對一小組規則同時量:
+ *   FP  = data/skill-benchmark/benign + benign-corpus-extended + benign-code(與 gate 同一組語料 / 同一組事件形狀)
+ *   TP  = 規則自己的 test_cases.true_positives(每條各自算)
+ *   + 依 src/corpus/security-content.ts 把 FP 拆成「一般 benign」與「資安內容」
+ *
+ * 用法:npx tsx scripts/measure-rule-fp-segmented.ts <rulesDir> <ATR-id> [<ATR-id>...]
+ */
+import {
+  readFileSync,
+  readdirSync,
+  existsSync,
+  statSync,
+  mkdtempSync,
+  copyFileSync,
+} from "node:fs";
+import { join, resolve, dirname, basename, relative } from "node:path";
+import { tmpdir } from "node:os";
+import { execFileSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { load } from "js-yaml";
+import { ATREngine } from "../src/engine.js";
+import { corpusShapes } from "../src/corpus-event.js";
+import { classifySecurityContent } from "../src/corpus/security-content.js";
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const CORPORA = [
+  join(REPO_ROOT, "data/skill-benchmark/benign"),
+  join(REPO_ROOT, "data/benign-corpus-extended"),
+  join(REPO_ROOT, "data/benign-code"),
+];
+
+interface Sample {
+  readonly source: string;
+  readonly text: string;
+}
+
+function walk(dir: string): string[] {
+  const out: string[] = [];
+  for (const e of readdirSync(dir)) {
+    const full = join(dir, e);
+    if (statSync(full).isDirectory()) out.push(...walk(full));
+    else if (e.endsWith(".jsonl") || e.endsWith(".md")) out.push(full);
+  }
+  return out;
+}
+
+function loadCorpus(p: string): Sample[] {
+  const out: Sample[] = [];
+  if (!existsSync(p)) return out;
+  for (const f of statSync(p).isDirectory() ? walk(p) : [p]) {
+    let raw: string;
+    try {
+      raw = readFileSync(f, "utf-8");
+    } catch {
+      continue;
+    }
+    const rel = relative(REPO_ROOT, f);
+    if (f.endsWith(".md")) {
+      out.push({ source: rel, text: raw });
+      continue;
+    }
+    for (const line of raw.split("\n")) {
+      const t = line.trim();
+      if (!t) continue;
+      try {
+        const o = JSON.parse(t) as { text?: string };
+        if (o.text) out.push({ source: rel, text: o.text });
+      } catch {
+        /* ignore */
+      }
+    }
+  }
+  return out;
+}
+
+function ruleFileFor(rulesDir: string, id: string): string | null {
+  const search = (d: string): string | null => {
+    for (const e of readdirSync(d)) {
+      const full = join(d, e);
+      if (statSync(full).isDirectory()) {
+        const r = search(full);
+        if (r) return r;
+      } else if (e.endsWith(".yaml") || e.endsWith(".yml")) {
+        if (
+          readFileSync(full, "utf-8").includes(`\nid: ${id}\n`) ||
+          readFileSync(full, "utf-8").startsWith(`id: ${id}\n`)
+        )
+          return full;
+      }
+    }
+    return null;
+  };
+  return search(rulesDir);
+}
+
+async function main(): Promise<void> {
+  const [rulesDirArg, ...ids] = process.argv.slice(2);
+  if (!rulesDirArg || ids.length === 0)
+    throw new Error("usage: measure-rule-fp-segmented.ts <rulesDir> <id...>");
+  const rulesDir = resolve(rulesDirArg);
+
+  const files = ids.map((id) => {
+    const f = ruleFileFor(rulesDir, id);
+    if (!f) throw new Error(`rule not found: ${id} under ${rulesDir}`);
+    return f;
+  });
+
+  const scoped = mkdtempSync(join(tmpdir(), "atr-exp-"));
+  files.forEach((f) => copyFileSync(f, join(scoped, basename(f))));
+  const engine = new ATREngine({ rulesDir: scoped });
+  await engine.loadRules();
+
+  const samples: Sample[] = [];
+  for (const c of CORPORA) samples.push(...loadCorpus(c));
+
+  const fpGeneral = new Map<string, number>();
+  const fpSecurity = new Map<string, number>();
+  const bySource = new Map<string, Map<string, number>>();
+  for (const id of ids) {
+    fpGeneral.set(id, 0);
+    fpSecurity.set(id, 0);
+    bySource.set(id, new Map());
+  }
+
+  let nSecurity = 0;
+  for (const s of samples) {
+    const isSec = classifySecurityContent(s.text).label === "security-content";
+    if (isSec) nSecurity += 1;
+    const matched = new Set<string>();
+    for (const shape of corpusShapes(s.text))
+      for (const m of engine.evaluate(shape.event)) matched.add(m.rule.id);
+    for (const m of engine.scanSkill(s.text)) matched.add(m.rule.id);
+    for (const id of matched) {
+      if (!fpGeneral.has(id)) continue;
+      if (isSec) fpSecurity.set(id, (fpSecurity.get(id) ?? 0) + 1);
+      else fpGeneral.set(id, (fpGeneral.get(id) ?? 0) + 1);
+      const bs = bySource.get(id)!;
+      bs.set(s.source, (bs.get(s.source) ?? 0) + 1);
+    }
+  }
+
+  // recall on each rule's own declared true positives
+  const tpHit = new Map<string, [number, number]>();
+  for (let i = 0; i < ids.length; i++) {
+    const id = ids[i]!;
+    const d = load(readFileSync(files[i]!, "utf-8")) as any;
+    const tps =
+      d?.test_cases?.true_positives ??
+      d?.detection?.test_cases?.true_positives ??
+      [];
+    let hit = 0;
+    for (const t of tps) {
+      const text = typeof t === "string" ? t : (t?.input ?? JSON.stringify(t));
+      const matched = new Set<string>();
+      for (const shape of corpusShapes(String(text)))
+        for (const m of engine.evaluate(shape.event)) matched.add(m.rule.id);
+      for (const m of engine.scanSkill(String(text))) matched.add(m.rule.id);
+      if (matched.has(id)) hit += 1;
+    }
+    tpHit.set(id, [hit, tps.length]);
+  }
+
+  console.log(
+    `corpus = ${samples.length} samples (security-content labeled = ${nSecurity})`,
+  );
+  console.log(`rulesDir = ${rulesDir}`);
+  for (const id of ids) {
+    const g = fpGeneral.get(id) ?? 0;
+    const s = fpSecurity.get(id) ?? 0;
+    const [h, n] = tpHit.get(id) ?? [0, 0];
+    console.log(
+      `${id}  FP_total=${g + s}  FP_general=${g}  FP_security=${s}  own_TP=${h}/${n}`,
+    );
+    const top = [...(bySource.get(id) ?? new Map())]
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, 4);
+    for (const [src, n2] of top) console.log(`      ${src}: ${n2}`);
+  }
+}
+
+main().catch((e: unknown) => {
+  console.error(e instanceof Error ? e.stack : String(e));
+  process.exit(1);
+});

--- a/scripts/measure-rule-recall-ab.ts
+++ b/scripts/measure-rule-recall-ab.ts
@@ -1,0 +1,150 @@
+#!/usr/bin/env npx tsx
+/**
+ * measure-rule-recall-ab.ts — 規則收緊前後的 A/B attack recall。
+ *
+ * 「規則變聰明」的 recall 不能只用它自己的 5 條 test_cases 量。這裡用一個
+ * 寬得多的攻擊集:
+ *   1. 全 repo 所有規則的 test_cases.true_positives(4,038 條真攻擊樣本)
+ *   2. data/test-corpora/ 底下的標準攻擊語料(garak inthewild / llm-guard /
+ *      promptinject / promptfoo / nemo-guardrails / mitre-atlas)
+ *
+ * 判準:BASE 規則會 fire 的攻擊樣本裡,VARIANT 還 fire 幾條。
+ */
+import {
+  readFileSync,
+  readdirSync,
+  statSync,
+  existsSync,
+  mkdtempSync,
+  copyFileSync,
+} from "node:fs";
+import { join, resolve, dirname, basename } from "node:path";
+import { tmpdir } from "node:os";
+import { execFileSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { load } from "js-yaml";
+import { ATREngine } from "../src/engine.js";
+import { corpusShapes } from "../src/corpus-event.js";
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+function attackSamples(): string[] {
+  const out: string[] = [];
+  for (const f of execFileSync("git", ["ls-files", "rules/"], {
+    encoding: "utf-8",
+    maxBuffer: 64 * 1024 * 1024,
+  })
+    .split("\n")
+    .filter((f) => f.endsWith(".yaml") || f.endsWith(".yml"))) {
+    let d: any;
+    try {
+      d = load(readFileSync(join(REPO_ROOT, f), "utf-8"));
+    } catch {
+      continue;
+    }
+    const tps =
+      d?.test_cases?.true_positives ??
+      d?.detection?.test_cases?.true_positives ??
+      [];
+    for (const t of tps) {
+      const txt = typeof t === "string" ? t : (t?.input ?? "");
+      if (typeof txt === "string" && txt.length > 0) out.push(txt);
+    }
+  }
+  const push = (v: unknown): void => {
+    if (typeof v === "string" && v.length > 0) out.push(v);
+  };
+  const gk = join(REPO_ROOT, "data/test-corpora/garak-full/inthewild.json");
+  if (existsSync(gk))
+    (JSON.parse(readFileSync(gk, "utf-8")).prompts as string[]).forEach(push);
+  for (const rel of [
+    "data/test-corpora/llm-guard/corpus.json",
+    "data/test-corpora/promptfoo/corpus.json",
+    "data/test-corpora/nemo-guardrails/corpus.json",
+  ]) {
+    const p = join(REPO_ROOT, rel);
+    if (!existsSync(p)) continue;
+    const j = JSON.parse(readFileSync(p, "utf-8")) as any;
+    for (const a of j.attacks ?? j.samples ?? [])
+      push(a?.text ?? a?.prompt ?? a);
+  }
+  const pi = join(REPO_ROOT, "data/test-corpora/promptinject");
+  if (existsSync(pi))
+    for (const f of readdirSync(pi).filter((x) => x.endsWith(".json"))) {
+      try {
+        const j = JSON.parse(readFileSync(join(pi, f), "utf-8")) as any[];
+        if (Array.isArray(j))
+          for (const r of j) push(r?.full_prompt ?? r?.attack_instruction);
+      } catch {
+        /* ignore */
+      }
+    }
+  return out;
+}
+
+function ruleFileFor(dir: string, id: string): string | null {
+  for (const e of readdirSync(dir)) {
+    const full = join(dir, e);
+    if (statSync(full).isDirectory()) {
+      const r = ruleFileFor(full, id);
+      if (r) return r;
+    } else if (e.endsWith(".yaml") || e.endsWith(".yml")) {
+      const s = readFileSync(full, "utf-8");
+      if (s.includes(`\nid: ${id}\n`) || s.startsWith(`id: ${id}\n`))
+        return full;
+    }
+  }
+  return null;
+}
+
+async function engineFor(dir: string, ids: string[]): Promise<ATREngine> {
+  const scoped = mkdtempSync(join(tmpdir(), "atr-ab-"));
+  for (const id of ids) {
+    const f = ruleFileFor(resolve(dir), id);
+    if (!f) throw new Error(`not found ${id} in ${dir}`);
+    copyFileSync(f, join(scoped, basename(f)));
+  }
+  const e = new ATREngine({ rulesDir: scoped });
+  await e.loadRules();
+  return e;
+}
+
+function fires(e: ATREngine, text: string, id: string): boolean {
+  for (const shape of corpusShapes(text))
+    for (const m of e.evaluate(shape.event)) if (m.rule.id === id) return true;
+  for (const m of e.scanSkill(text)) if (m.rule.id === id) return true;
+  return false;
+}
+
+async function main(): Promise<void> {
+  const [baseDir, varDir, ...ids] = process.argv.slice(2);
+  if (!baseDir || !varDir || ids.length === 0)
+    throw new Error(
+      "usage: measure-rule-recall-ab.ts <baseRulesDir> <variantRulesDir> <id...>",
+    );
+  const attacks = attackSamples();
+  console.log(`attack corpus = ${attacks.length} samples`);
+  const base = await engineFor(baseDir, ids);
+  const vari = await engineFor(varDir, ids);
+  for (const id of ids) {
+    let b = 0;
+    let kept = 0;
+    let newHits = 0;
+    for (const a of attacks) {
+      const fb = fires(base, a, id);
+      const fv = fires(vari, a, id);
+      if (fb) {
+        b += 1;
+        if (fv) kept += 1;
+      } else if (fv) newHits += 1;
+    }
+    console.log(
+      `${id}  base_attack_hits=${b}  variant_kept=${kept} (${b ? ((100 * kept) / b).toFixed(1) : "n/a"}%)  variant_new=${newHits}`,
+    );
+  }
+}
+
+main().catch((e: unknown) => {
+  console.error(e instanceof Error ? e.stack : String(e));
+  process.exit(1);
+});

--- a/scripts/measure-security-content-fp.ts
+++ b/scripts/measure-security-content-fp.ts
@@ -1,0 +1,97 @@
+#!/usr/bin/env npx tsx
+/**
+ * measure-security-content-fp.ts — 重現 docs/research/benign-gate-security-education-2026-08-07.md 的頭條數字。
+ *
+ * 問題:14,561 個 FP 裡,有多少落在被標為「資安內容」的樣本上?
+ *
+ * 不需要重跑全語料。被標記的樣本只有 37 條,所以把**全部規則**跑在**那 37 條**上,
+ * 得到的 match 總數就是資安內容貢獻的 FP 精確值(gate 的計數方式是 per-sample
+ * per-rule,與這裡一致)。
+ */
+import { readFileSync, readdirSync, existsSync, statSync } from "node:fs";
+import { join, resolve, dirname, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+import { ATREngine } from "../src/engine.js";
+import { corpusShapes } from "../src/corpus-event.js";
+import { classifySecurityContent } from "../src/corpus/security-content.js";
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const CORPORA = [
+  join(REPO_ROOT, "data/skill-benchmark/benign"),
+  join(REPO_ROOT, "data/benign-corpus-extended"),
+  join(REPO_ROOT, "data/benign-code"),
+];
+
+function walk(dir: string): string[] {
+  const out: string[] = [];
+  for (const e of readdirSync(dir)) {
+    const full = join(dir, e);
+    if (statSync(full).isDirectory()) out.push(...walk(full));
+    else if (e.endsWith(".jsonl") || e.endsWith(".md")) out.push(full);
+  }
+  return out;
+}
+
+async function main(): Promise<void> {
+  const secSamples: { source: string; text: string }[] = [];
+  let total = 0;
+  for (const c of CORPORA) {
+    if (!existsSync(c)) continue;
+    for (const f of statSync(c).isDirectory() ? walk(c) : [c]) {
+      const raw = readFileSync(f, "utf-8");
+      const rel = relative(REPO_ROOT, f);
+      const consider = (t: string): void => {
+        total += 1;
+        if (classifySecurityContent(t).label === "security-content")
+          secSamples.push({ source: rel, text: t });
+      };
+      if (f.endsWith(".md")) {
+        consider(raw);
+        continue;
+      }
+      for (const line of raw.split("\n")) {
+        const t = line.trim();
+        if (!t) continue;
+        try {
+          const o = JSON.parse(t) as { text?: string };
+          if (typeof o.text === "string" && o.text.length > 0) consider(o.text);
+        } catch {
+          /* ignore */
+        }
+      }
+    }
+  }
+  console.log(`corpus = ${total} · security-content = ${secSamples.length}`);
+
+  const engine = new ATREngine({ rulesDir: join(REPO_ROOT, "rules") });
+  await engine.loadRules();
+  console.log(`rules loaded = ${engine.getRules().length}`);
+
+  let fp = 0;
+  const perRule = new Map<string, number>();
+  const perSource = new Map<string, number>();
+  for (const s of secSamples) {
+    const matched = new Set<string>();
+    for (const shape of corpusShapes(s.text))
+      for (const m of engine.evaluate(shape.event)) matched.add(m.rule.id);
+    for (const m of engine.scanSkill(s.text)) matched.add(m.rule.id);
+    fp += matched.size;
+    perSource.set(s.source, (perSource.get(s.source) ?? 0) + matched.size);
+    for (const id of matched) perRule.set(id, (perRule.get(id) ?? 0) + 1);
+  }
+  console.log(`FP landing on security-content samples = ${fp}`);
+  console.log(`distinct rules firing on them = ${perRule.size}`);
+  console.log("\ntop rules on security content:");
+  for (const [id, n] of [...perRule].sort((a, b) => b[1] - a[1]).slice(0, 15))
+    console.log(`  ${id} — ${n}`);
+  console.log("\nsource distribution of the labelled samples:");
+  const cnt = new Map<string, number>();
+  for (const s of secSamples) cnt.set(s.source, (cnt.get(s.source) ?? 0) + 1);
+  for (const [src, n] of [...cnt].sort((a, b) => b[1] - a[1]))
+    console.log(`  ${src}: ${n} sample(s), ${perSource.get(src) ?? 0} FP`);
+}
+
+main().catch((e: unknown) => {
+  console.error(e instanceof Error ? e.stack : String(e));
+  process.exit(1);
+});

--- a/src/corpus/security-content.ts
+++ b/src/corpus/security-content.ts
@@ -1,0 +1,160 @@
+/**
+ * security-content.ts — 把 benign gate 的樣本標成「一般 benign」與「資安內容」兩段。
+ *
+ * WHY THIS EXISTS
+ *
+ * benign gate 的用途是量「規則在 agent 會讀到的一般內容上誤報多少」。語料裡確實
+ * 混著滲透測試教材、合規報告、安全稽核 skill —— 這類文件逐字寫著 `' OR '1'='1`、
+ * `/etc/passwd`、`; DROP TABLE`。一條 regex 規則看到那些字串就開火,而那份文件
+ * 本身沒有攻擊任何人。
+ *
+ * WHAT THIS IS NOT
+ *
+ * **這個模組不會、也不能從語料裡拿掉任何樣本。**它只回傳標籤。gate 的頭條數字
+ * 仍然是全語料的 FP 總數,分段數字是額外資訊,不是替代品。
+ *
+ * 理由寫在 docs/research/precision-repair-broad-rules-2026-06-21.md 定下的政策裡:
+ *
+ *   > A dual-use security skill that legitimately contains attack techniques is
+ *   > not a false positive to suppress by blunting the rule; it is an advisory-
+ *   > tier signal the consumer decides on.
+ *
+ * 那次稽核把 benign 語料分成兩群並分開處置,而且只有其中一群被隔離:
+ *   - 86 條「真越獄樣本被標成 benign」→ 標籤錯誤 → 隔離(它們同時是 dan-corpus
+ *     的 true positive,一份母體兩個相反標籤)。
+ *   - 675 條 dual-use SEO 模板 → **不是**攻擊 → 留在 benign gate,規則對它們開火
+ *     就是真 FP。
+ *
+ * 本模組處理的是第二群的近親:資安教材。政策一致 —— 留著,但分開報。
+ *
+ * ANTI-ABUSE(這是本檔最重要的部分)
+ *
+ * 「把難的樣本標成另一類讓頭條數字變好看」是洗白。四道防線:
+ *
+ *   1. **只標記,不移除。** 本模組沒有 delete/filter/exclude 的出口。
+ *   2. **判準與規則結果無關。** classify() 只吃樣本文字,拿不到引擎、規則 id、
+ *      FP 計數。判準不能被「哪些樣本害我 FP」反推調整。
+ *      tests 會斷言本檔不 import 引擎。
+ *   3. **窄口徑。** 要同時滿足「逐字攻擊 payload」與「≥2 個相異資安主題標記」
+ *      才算資安內容。只提 OWASP 不算,只出現 `../../` 也不算。
+ *   4. **預算上限 + 洗白偵測。** ratchet 測試斷言(a)被標記的比例不得超過語料的
+ *      SECURITY_CONTENT_BUDGET,(b)同一支判準跑在真攻擊語料上,標記率必須低於
+ *      LAUNDERING_CEILING —— 一支會把真攻擊也標成「教材」的判準就是洗白機器。
+ */
+
+/** 逐字攻擊 payload:文件把可執行的攻擊字串原樣抄進去。 */
+const PAYLOAD_PATTERNS: readonly RegExp[] = [
+  // SQL injection
+  /'\s*or\s*'?1'?\s*=\s*'?1/i,
+  /\bor\s+1\s*=\s*1\s*(--|#|;)/i,
+  /\bunion\s+(all\s+)?select\b/i,
+  /\bdrop\s+table\b/i,
+  /\bxp_cmdshell\b/i,
+  // path traversal / sensitive files
+  /\/etc\/(passwd|shadow)\b/i,
+  /(\.\.[/\\]){2,}/,
+  /%2e%2e(%2f|%5c)/i,
+  /\bid_rsa\b/i,
+  // XSS
+  /<script>\s*alert\s*\(/i,
+  /\bjavascript:\s*alert\s*\(/i,
+  /\bonerror\s*=\s*["']?alert\s*\(/i,
+  // shell / reverse shell
+  /\brm\s+-rf\s+\/(?!\w)/,
+  /\bnc\s+-[a-z]*e[a-z]*\s+\/bin\/(ba)?sh/i,
+  /\/bin\/(ba)?sh\s+-i\s+>&/i,
+  /\bbase64\s+-d\s*\|\s*(ba)?sh\b/i,
+  // offensive tooling invoked with flags (not the bare product name)
+  /\bsqlmap\s+-/i,
+  /\bmsfvenom\s+-/i,
+  /\bnmap\s+-s[A-Za-z]/,
+  /\bhydra\s+-[lL]\b/,
+  /\bjohn\s+--wordlist/i,
+  /\bhashcat\s+-m\s+\d/i,
+  /\bmimikatz\b/i,
+];
+
+/**
+ * 資安主題標記。需要 ≥2 個**相異**標記才算「這份文件在談資安」——
+ * 一次提及可能只是順帶,兩個以上相異標記才是主題。
+ */
+const TOPIC_PATTERNS: readonly RegExp[] = [
+  /\bpenetration\s+test(ing|er)?\b/i,
+  /\bpentest(ing)?\b/i,
+  /\bred[\s-]?team(ing)?\b/i,
+  /\bbug\s+bounty\b/i,
+  /\bvulnerability\s+(scan|assessment|research|disclosure)/i,
+  /\bowasp\b/i,
+  /\bcve-\d{4}-\d+/i,
+  /\bcwe-\d+/i,
+  /\bmitre\s+att&?ck\b/i,
+  /\bsecurity\s+(audit|review|assessment|hardening)\b/i,
+  /\bthreat\s+model(ing|s)?\b/i,
+  /\battack\s+(surface|vector|chain|tree)\b/i,
+  /\bsql\s+injection\b/i,
+  /\bcross[\s-]site\s+scripting\b|\bxss\b/i,
+  /\bcsrf\b|\bssrf\b/i,
+  /\bprivilege\s+escalation\b/i,
+  /\breverse\s+shell\b/i,
+  /\bmalware\s+analysis\b/i,
+  /\bincident\s+response\b/i,
+  /\bremediation\b/i,
+  /\bmitigation[s]?\b/i,
+  /\bsecure\s+coding\b/i,
+  /\bcis\s+benchmark\b/i,
+  /\bnist\s+(sp\s?)?800/i,
+  /\bpci[\s-]?dss\b/i,
+  /\bsoc\s?2\b/i,
+  /\bsast\b|\bdast\b/i,
+  /\bexploit(ation)?\b/i,
+];
+
+export type SecurityContentLabel = "general" | "security-content";
+
+export interface SecurityContentVerdict {
+  readonly label: SecurityContentLabel;
+  /** 命中的逐字 payload pattern(以 regex source 表示,方便人審)。 */
+  readonly payloads: readonly string[];
+  /** 命中的相異資安主題標記數。 */
+  readonly topicMarkers: number;
+}
+
+/**
+ * 唯一的判準。輸入只有樣本文字 —— 沒有規則、沒有引擎、沒有 FP 計數。
+ *
+ * label = "security-content" ⟺ 逐字 payload ≥1 **且** 相異主題標記 ≥ MIN_TOPIC_MARKERS。
+ */
+export const MIN_TOPIC_MARKERS = 2;
+
+export function classifySecurityContent(text: string): SecurityContentVerdict {
+  const payloads: string[] = [];
+  for (const p of PAYLOAD_PATTERNS) if (p.test(text)) payloads.push(p.source);
+
+  let topicMarkers = 0;
+  for (const t of TOPIC_PATTERNS) if (t.test(text)) topicMarkers += 1;
+
+  const label: SecurityContentLabel =
+    payloads.length > 0 && topicMarkers >= MIN_TOPIC_MARKERS
+      ? "security-content"
+      : "general";
+  return { label, payloads, topicMarkers };
+}
+
+/**
+ * 被標為資安內容的樣本佔語料的比例上限。超過就是判準被放寬成掃地機。
+ * 2026-08-07 實測 = 0.69%(37/5352)。上限 2% 給語料成長留餘裕。
+ */
+export const SECURITY_CONTENT_BUDGET = 0.02;
+
+/**
+ * 同一支判準跑在**真攻擊**語料上的標記率上限。真攻擊被標成「教材」= 洗白。
+ *
+ * 這個數字是實測校準出來的,不是憑感覺挑的。2026-08-07 乾淨判準實測:
+ * 規則自宣告 true_positives 1/3805 = 0.03%、garak in-the-wild 0/650 = 0.00%。
+ *
+ * 校準過程:先訂 5%,然後刻意把攻擊語言(「ignore all previous instructions」、
+ * 「do anything now」、jailbreak/DAN/prompt injection)偷渡進 payload 與主題清單 ——
+ * 這是最典型的洗白手法。結果 garak 標記率跳到 3.85%,**5% 沒有咬住**。
+ * 上限因此收到 1%:窄判準在真攻擊上本來就該是零,任何有意義的攻擊掃入都會撞線。
+ */
+export const LAUNDERING_CEILING = 0.01;

--- a/tests/benign-gate-security-content.test.ts
+++ b/tests/benign-gate-security-content.test.ts
@@ -1,0 +1,236 @@
+/**
+ * Tests for src/corpus/security-content.ts — 資安教材分段標籤的防濫用閘。
+ *
+ * THE FAILURE MODE THESE TESTS EXIST TO PREVENT
+ *
+ * benign gate 對 776 條會 fire 的規則量出 14,561 個 FP。收緊規則的人一致回報
+ * 殘留 FP 是滲透測試教材逐字寫的 `' OR '1'='1` / `/etc/passwd`。於是很自然會想:
+ * 「那些不是一般 benign,分流出去就好」。
+ *
+ * 那個念頭就是這個檔案要擋的東西。**把難的樣本重新歸類讓頭條數字變好看,是洗白,
+ * 不是修正。**而且它比一般缺陷更難抓,因為它偽裝成「語料治理」。
+ *
+ * 這個 repo 已經處理過同一種誘惑並定下政策
+ * (docs/research/precision-repair-broad-rules-2026-06-21.md):
+ *   - 86 條真越獄樣本被標成 benign → 標籤錯誤 → 隔離。
+ *   - 675 條 dual-use 模板 → 不是攻擊 → **留在 benign gate**,規則對它們開火就是真 FP。
+ * 資安教材屬於後者。所以判準只准「標記」,不准「移除」。
+ *
+ * 四道斷言,對應四種濫用方式:
+ *   1. 預算 — 判準被放寬成掃地機(標記率暴增)。
+ *   2. 洗白 — 判準把真攻擊也標成「教材」。
+ *   3. 結果導向 — 判準看規則的 FP 結果反推,把礙事的樣本歸到另一類。
+ *   4. 移除 — 分段被拿去縮小語料 / 改變 gate 的 clean·dirty 判定。
+ */
+
+import { describe, it, expect } from "vitest";
+import { readFileSync, readdirSync, statSync, existsSync } from "node:fs";
+import { join, resolve, dirname } from "node:path";
+import { execFileSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { load } from "js-yaml";
+import {
+  classifySecurityContent,
+  MIN_TOPIC_MARKERS,
+  SECURITY_CONTENT_BUDGET,
+  LAUNDERING_CEILING,
+} from "../src/corpus/security-content.js";
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const CLASSIFIER_SRC = join(REPO_ROOT, "src/corpus/security-content.ts");
+const GATE_SRC = join(REPO_ROOT, "scripts/gate-promotion-fp.ts");
+
+/** 與 scripts/gate-promotion-fp.ts 完全相同的語料集合。 */
+const CORPORA = [
+  join(REPO_ROOT, "data/skill-benchmark/benign"),
+  join(REPO_ROOT, "data/benign-corpus-extended"),
+  join(REPO_ROOT, "data/benign-code"),
+];
+
+function walk(dir: string): string[] {
+  const out: string[] = [];
+  for (const e of readdirSync(dir)) {
+    const full = join(dir, e);
+    if (statSync(full).isDirectory()) out.push(...walk(full));
+    else if (e.endsWith(".jsonl") || e.endsWith(".md")) out.push(full);
+  }
+  return out;
+}
+
+function benignSamples(): string[] {
+  const out: string[] = [];
+  for (const c of CORPORA) {
+    if (!existsSync(c)) continue;
+    for (const f of statSync(c).isDirectory() ? walk(c) : [c]) {
+      const raw = readFileSync(f, "utf-8");
+      if (f.endsWith(".md")) {
+        out.push(raw);
+        continue;
+      }
+      for (const line of raw.split("\n")) {
+        const t = line.trim();
+        if (!t) continue;
+        try {
+          const o = JSON.parse(t) as { text?: string };
+          if (typeof o.text === "string" && o.text.length > 0) out.push(o.text);
+        } catch {
+          /* not a sample line */
+        }
+      }
+    }
+  }
+  return out;
+}
+
+/** 全 repo 規則自己宣告的 true positives — 真攻擊樣本。 */
+function ruleTruePositives(): string[] {
+  const out: string[] = [];
+  const files = execFileSync("git", ["ls-files", "rules/"], {
+    cwd: REPO_ROOT,
+    encoding: "utf-8",
+    maxBuffer: 64 * 1024 * 1024,
+  })
+    .split("\n")
+    .filter((f) => f.endsWith(".yaml") || f.endsWith(".yml"));
+  for (const f of files) {
+    let d: unknown;
+    try {
+      d = load(readFileSync(join(REPO_ROOT, f), "utf-8"));
+    } catch {
+      continue;
+    }
+    const doc = d as { test_cases?: { true_positives?: unknown[] } };
+    for (const t of doc?.test_cases?.true_positives ?? []) {
+      const txt =
+        typeof t === "string" ? t : ((t as { input?: unknown })?.input ?? "");
+      if (typeof txt === "string" && txt.length > 0) out.push(txt);
+    }
+  }
+  return out;
+}
+
+describe("security-content 判準:預算", () => {
+  it("被標為資安內容的樣本不得超過 benign gate 語料的 SECURITY_CONTENT_BUDGET", () => {
+    const samples = benignSamples();
+    expect(samples.length).toBeGreaterThan(5000); // 語料本身沒被縮小
+
+    const labeled = samples.filter(
+      (t) => classifySecurityContent(t).label === "security-content",
+    ).length;
+    const fraction = labeled / samples.length;
+
+    // 2026-08-07 實測 37/5352 = 0.69%。上限 2% 給語料成長留餘裕,
+    // 但任何把判準放寬成「凡是提到資安就分流」的改動都會撞到這條線。
+    expect(fraction).toBeLessThanOrEqual(SECURITY_CONTENT_BUDGET);
+  });
+
+  it("判準要窄到有意義:單一訊號不足以被標記", () => {
+    // 只有主題,沒有逐字 payload
+    expect(
+      classifySecurityContent(
+        "Our OWASP threat model review found no SQL injection.",
+      ).label,
+    ).toBe("general");
+    // 只有 payload,沒有資安主題
+    expect(classifySecurityContent("open('../../config/app.json')").label).toBe(
+      "general",
+    );
+    // 兩者兼具才算
+    const both = classifySecurityContent(
+      "OWASP penetration testing lab: the classic tautology payload ' OR '1'='1 bypasses the login form; remediation is parameterised queries.",
+    );
+    expect(both.label).toBe("security-content");
+    expect(both.topicMarkers).toBeGreaterThanOrEqual(MIN_TOPIC_MARKERS);
+    expect(both.payloads.length).toBeGreaterThan(0);
+  });
+});
+
+describe("security-content 判準:洗白偵測", () => {
+  it("真攻擊樣本(全 repo 規則的 true_positives)不得被大量標成資安內容", () => {
+    const tps = ruleTruePositives();
+    expect(tps.length).toBeGreaterThan(3000);
+    const labeled = tps.filter(
+      (t) => classifySecurityContent(t).label === "security-content",
+    ).length;
+    // 2026-08-07 實測 1/3805 = 0.03%。一支會把真攻擊標成「教材」的判準就是洗白機器。
+    expect(labeled / tps.length).toBeLessThanOrEqual(LAUNDERING_CEILING);
+  });
+
+  it("garak in-the-wild 越獄語料不得被標成資安內容", () => {
+    const p = join(REPO_ROOT, "data/test-corpora/garak-full/inthewild.json");
+    if (!existsSync(p)) return; // 語料不在這個 checkout 裡就跳過
+    const prompts = (
+      JSON.parse(readFileSync(p, "utf-8")) as { prompts: string[] }
+    ).prompts;
+    expect(prompts.length).toBeGreaterThan(100);
+    const labeled = prompts.filter(
+      (t) => classifySecurityContent(t).label === "security-content",
+    ).length;
+    // 2026-08-07 實測 0/650。
+    expect(labeled / prompts.length).toBeLessThanOrEqual(LAUNDERING_CEILING);
+  });
+});
+
+describe("security-content 判準:結構性防濫用", () => {
+  it("判準不得看見規則、引擎或 FP 結果", () => {
+    const src = readFileSync(CLASSIFIER_SRC, "utf-8");
+    // 註解裡會提到 ATR-2026-xxxxx,所以只看 import 行與可執行識別字。
+    const imports = src.split("\n").filter((l) => /^\s*import\b/.test(l));
+    expect(imports).toEqual([]); // 零依賴 = 拿不到引擎,也拿不到 FP 計數
+    const code = src
+      .split("\n")
+      .filter((l) => !/^\s*(\*|\/\/|\/\*)/.test(l))
+      .join("\n");
+    for (const forbidden of [
+      "ATREngine",
+      "engine.",
+      "fpCount",
+      "matchedRuleIds",
+      "rule.id",
+    ]) {
+      expect(code).not.toContain(forbidden);
+    }
+  });
+
+  it("判準沒有移除樣本的出口", () => {
+    const src = readFileSync(CLASSIFIER_SRC, "utf-8");
+    const code = src
+      .split("\n")
+      .filter((l) => !/^\s*(\*|\/\/|\/\*)/.test(l))
+      .join("\n");
+    for (const forbidden of [
+      ".filter(",
+      ".splice(",
+      "unlinkSync",
+      "writeFileSync",
+      "quarantine",
+    ]) {
+      expect(code).not.toContain(forbidden);
+    }
+  });
+
+  it("gate 的 clean·dirty 判定與離開碼不得讀取分段標籤", () => {
+    const gate = readFileSync(GATE_SRC, "utf-8");
+    // partitionByFp 決定 clean/dirty;resolveExitCode 決定 PR 紅綠。
+    // 兩者的引數都不得出現 securityCounts —— 分段只能進 report 與 emit 的字串。
+    const partitionCall = /partitionByFp\(([^)]*)\)/g;
+    for (const m of gate.matchAll(partitionCall)) {
+      expect(m[1] ?? "").not.toContain("security");
+    }
+    const exitCall = /resolveExitCode\(([^)]*)\)/g;
+    for (const m of gate.matchAll(exitCall)) {
+      expect(m[1] ?? "").not.toContain("security");
+    }
+  });
+
+  it("分段是加法而非減法:general + security 必須等於總數", () => {
+    const samples = benignSamples();
+    const sec = samples.filter(
+      (t) => classifySecurityContent(t).label === "security-content",
+    ).length;
+    const gen = samples.filter(
+      (t) => classifySecurityContent(t).label === "general",
+    ).length;
+    expect(sec + gen).toBe(samples.length);
+  });
+});


### PR DESCRIPTION
Four rules were tightened against the benign gate this week. **Three were rejected in review for trading recall for false positives**, and every author reported the same thing: the residue is security-education documents quoting `' OR '1'='1`, `/etc/passwd`, `; DROP TABLE` verbatim.

The obvious move is to pull those samples out of the gate. **This PR measures that idea and rejects it.**

## The number that settles it

| | samples | FP explained |
|---|---:|---:|
| strict criterion | 37 / 5,352 (**0.69%**) | 526 / 14,561 (**3.61%**) |
| loosest defensible-ish bound | 642 (12%) | 3,212 (**22.1%**) |

Even the loose bound — which sweeps in 12% of the benign corpus and could not be defended in review — leaves **11,349 false positives**. Partitioning buys no correction. It buys a nicer number.

Concentration says the same thing: of the top-20 rules by FP (89.2% of all FP), security content is **1.3%**. The single worst rule, `ATR-2026-00061` at 2,814 FP, has **37** on security content. Its own comment already names the real cause — `condition: any` stacking five capability primitives, `exec` without a word boundary matching "execution", `\$\{?[A-Z_]+\}?` matching every shell variable any README ever printed.

## This repo already decided this, and this PR extends rather than overturns

`47d75f33a` (2026-06-21) and `docs/research/precision-repair-broad-rules-2026-06-21.md` split the corpus into two groups and quarantined only one:

- **86 real jailbreaks mislabelled benign** (0.13%) → quarantined, because the same samples are true positives in `dan-corpus.json`. One population, two contradictory labels.
- **675 dual-use SEO templates** (1.04%) → **kept**. Not attacks. A rule firing on them is a real false positive.

Its words: *"A dual-use security skill that legitimately contains attack techniques is not a false positive to suppress by blunting the rule."* And it instructed the corpus be **expanded** so the gate measures the real distribution — not shrunk.

It also already ran this experiment: removing the 86 contaminated samples moved the 65K FP rate 8.0% → 7.9%. The residue was dual-use intent then too.

**Security education is group 2, not group 1.** Keeping it is the consistent decision.

## Can the rules just get smarter? Partly — and it is not free

Tested on `ATR-2026-00113` and `ATR-2026-00217`: replace `condition: any` over independent indicators with a co-occurrence requirement (credential artifact **and** an execution primitive or egress destination).

Recall measured on **6,709 attack samples** — every rule's declared true positives plus garak in-the-wild, llm-guard, promptfoo, nemo-guardrails, promptinject — not on the rule's own five test cases.

```
ATR-2026-00113   FP 332 -> 118  (-64.5%)   attack recall 94 -> 31  (-67.0%)
ATR-2026-00217   FP 588 ->  31  (-94.7%)   attack recall 14 ->  5  (-64.3%)
```

**Roughly 64–95% of the FP costs 64–67% of the recall.** No rule change is shipped in this PR — the tightening was measured and then declined.

### The methodological finding is the more valuable half

**Judging by a rule's own test cases gives the opposite answer.** `ATR-2026-00217` stays 5/5 on its declared true positives across that change, because all five happen to include an egress action. Only at 6,709 samples does the −64% appear.

Any future tightening on this repo has to be measured on a broad attack corpus. A rule's own test cases are the sample most likely to survive its author's edit.

And the tightening does not even remove security-education FPs: `00113`'s security-content FP went 28 → 14 while its general FP went 304 → 104. Getting precision without paying recall needs a layer above regex — the same wall the 2026-06-21 audit hit from the other direction.

## What ships

The gate now **reports** the split instead of removing it. `clean`/`dirty`, the headline counts and the exit code are all unchanged; two extra lines and a `(N on security content)` annotation per dirty rule. **Diagnostic, not a discount.**

`src/corpus/security-content.ts` holds the criterion: a verbatim attack payload (23 patterns) **and** at least two distinct security-topic markers (28 patterns). Mentioning OWASP alone does not qualify; a bare `../../` does not qualify.

## Four anti-laundering guards, as assertions rather than comments

1. **Budget** — `SECURITY_CONTENT_BUDGET ≤ 2%`, measured 0.69%. Widen the criterion into a dragnet and the test goes red.
2. **Laundering detector** — `LAUNDERING_CEILING ≤ 1%`, run against rules' declared true positives (1/3,805 = 0.03%) and garak in-the-wild (0/650 = 0.00%). A criterion that labels real attacks as "education" is a laundering machine.
   **This ceiling was calibrated by attack, not chosen by feel.** It was set at 5%, then attack language (`ignore all previous instructions`, `do anything now`, `DAN`, `jailbreak`) was deliberately smuggled into the payload and topic lists — the textbook laundering move. The garak labelling rate jumped to 3.85% and **5% did not catch it.** Hence 1%.
3. **Result-blindness** — the criterion module imports nothing. It cannot see the engine, a rule id, or an FP count, so it cannot be tuned toward an outcome. Asserted by checking the import list is empty and the source contains no `ATREngine` / `matchedRuleIds` / `rule.id`.
4. **Removal-blocked** — asserted that `partitionByFp()` and `resolveExitCode()` take no `security` argument, and that `general + security == total`.

Each ratchet was broken on purpose and confirmed red, then restored: `AND` → `OR` trips the budget assertion (0.0665 > 0.02); smuggled attack language trips the laundering assertion (0.0292 > 0.01).

## Known imprecision, disclosed

Reviewing the 37 labelled samples individually found **4 mislabels** — the `(\.\.[/\\]){2,}` payload pattern matches markdown relative links like `[CONNECTORS.md](../../CONNECTORS.md)`, catching a compliance checklist, an SRE runbook and a TypeScript style guide. The error inflates the security bucket, which makes the 3.61% figure *more* conservative, not less.

Reverse sampling found the opposite gap: 60 unlabelled samples carry four or more distinct security topics and are genuinely security education, missed only because they do not quote a payload verbatim. That is what the 22.1% loose bound covers — and 22.1% still does not change the conclusion.

## Outward numbers

`benign-gate-fp` stays **MISLABELED / outward-unsafe**. This PR does not close its validity gap — the "65K" label is still attached to the wrong corpus and neither lane figure has been re-measured on the 5,352-sample set.

One ban added: **the "general benign" half of the split may never be quoted on its own.** The outward FP number is the total. The split is internal diagnostics, not a discount — a false positive on security content is still a false positive.

## Not in scope

`ATR-2026-00061/62/63/64/66` register **zero hits against their own declared true positives** under the gate's event shapes. Thousands of false positives with no self-evidence. Could be broken rules, could be a shape-routing problem. Recorded, unverified, worth its own line.

## Verification

```
tsc --noEmit            exit 0
prettier --check        exit 0  (main's CI gate)
validate-rules          exit 0
vitest                  917 passed · 3 skipped · 58 files · exit 0
gate-promotion-fp       still exits 1 on dirty rules; only the report is richer
data/ and rules/        0 lines changed
```
