### PR TITLE
feat(gate): freeze the enforce lane's evidence debt instead of leaving it silent

### DIFF
--- a/.github/workflows/enforce-lane-evidence.yml
+++ b/.github/workflows/enforce-lane-evidence.yml
@@ -1,0 +1,83 @@
+name: Enforce-lane evidence gate
+
+# docs/QUALITY-STANDARD.md defines STABLE as "Wild-validated, enterprise-ready /
+# confidence >= 80, wild FP rate <= 0.5%", and STABLE is the enforce lane:
+# auto-block, no human in the loop. That is the bar the project published for
+# itself.
+#
+# Measured 2026-08-09: 106 of 106 live stable rules fail it. 87 carry no
+# `confidence` field at all, 4 are below 80, and 15 clear the confidence bar but
+# have no wild evidence — the last group only became visible when #433 stripped
+# 230 `wild_fp_rate: 0` values that no run ever produced.
+#
+# The rules are not bad. All 106 measure zero false positives on the 5,352-sample
+# public benign corpus. What they lack is the evidence the standard asks for, and
+# the wild corpus it comes from is private and unreachable from CI — so the
+# project structurally cannot produce it here.
+#
+# Hence a RATCHET, same shape as rule-status-gate.yml and re2-portability.yml.
+# Failing the build on 106 of 106 would either stop all work or, far more likely,
+# get the standard quietly edited until the numbers agree. The two honest fixes —
+# demote all 106 and empty the enforce lane, or change the standard to accept
+# public-corpus evidence — are product decisions, not gate behaviour.
+#
+# So this freezes the debt at its measured size, names every rule in it, and
+# fails the moment it grows. The gap stops being silent without anyone having to
+# pretend it is closed.
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "rules/**"
+      - "data/enforce-lane-evidence-baseline.json"
+      - "scripts/gate-enforce-lane-evidence.ts"
+      - "docs/QUALITY-STANDARD.md"
+      - ".github/workflows/enforce-lane-evidence.yml"
+  push:
+    branches: [main]
+    paths:
+      - "rules/**"
+      - "data/enforce-lane-evidence-baseline.json"
+      - "scripts/gate-enforce-lane-evidence.ts"
+      - "docs/QUALITY-STANDARD.md"
+
+permissions:
+  contents: read
+
+jobs:
+  enforce-lane-evidence:
+    name: Auto-block lane needs evidence
+    runs-on: ubuntu-latest
+    steps:
+      # No fetch-depth: 0 — the gate compares the working tree against a
+      # committed baseline, not against a base ref.
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version: "22"
+
+      - name: Install dependencies
+        run: npm ci
+
+      # Exit 1: a rule entered the enforce lane without the evidence the
+      # standard requires, or a rule file has no determinable maturity.
+      # "Cannot determine" is never reported as "does not apply" — that is the
+      # class of silent pass this repo spent a week removing.
+      - name: Enforce-lane evidence ratchet
+        run: npx tsx scripts/gate-enforce-lane-evidence.ts
+
+      # The baseline may only shrink. --write-baseline refuses to add entries,
+      # so a run that leaves the file dirty means rules earned their evidence
+      # without the record being tightened. Advisory: bookkeeping lag, not a
+      # safety failure — the ratchet above already blocks the direction that
+      # matters.
+      - name: Baseline is not stale
+        run: |
+          npx tsx scripts/gate-enforce-lane-evidence.ts --write-baseline
+          if ! git diff --quiet -- data/enforce-lane-evidence-baseline.json; then
+            echo "::warning::rules now meet the STABLE bar but the baseline still lists them."
+            echo "Run: npx tsx scripts/gate-enforce-lane-evidence.ts --write-baseline"
+            git diff --stat -- data/enforce-lane-evidence-baseline.json
+          fi

--- a/data/enforce-lane-evidence-baseline.json
+++ b/data/enforce-lane-evidence-baseline.json
@@ -1,0 +1,416 @@
+{
+  "_comment": "Rules in the enforce (auto-block) lane that do not meet the STABLE bar published in docs/QUALITY-STANDARD.md (confidence >= 80, wild FP rate <= 0.5%). This file records existing debt so it stops being silent. Do NOT add entries to silence the gate — a new entry means a rule reached the auto-block lane without the evidence the standard requires. Entries may only be removed, by producing the evidence or by demoting the rule.",
+  "measured_at": "2026-08-09",
+  "stable_rules_total": 106,
+  "rules": {
+    "ATR-2026-00030": [
+      "no wild_fp_rate (never measured)"
+    ],
+    "ATR-2026-00080": [
+      "confidence 61 < 80",
+      "no wild_fp_rate (never measured)"
+    ],
+    "ATR-2026-00203": [
+      "no confidence field",
+      "no wild_fp_rate (never measured)"
+    ],
+    "ATR-2026-00432": [
+      "no wild_fp_rate (never measured)"
+    ],
+    "ATR-2026-00433": [
+      "no wild_fp_rate (never measured)"
+    ],
+    "ATR-2026-00434": [
+      "no wild_fp_rate (never measured)"
+    ],
+    "ATR-2026-00435": [
+      "confidence 72 < 80",
+      "no wild_fp_rate (never measured)"
+    ],
+    "ATR-2026-00436": [
+      "no wild_fp_rate (never measured)"
+    ],
+    "ATR-2026-00440": [
+      "no confidence field",
+      "no wild_fp_rate (never measured)"
+    ],
+    "ATR-2026-00443": [
+      "confidence 72 < 80",
+      "no wild_fp_rate (never measured)"
+    ],
+    "ATR-2026-00446": [
+      "confidence 70 < 80",
+      "no wild_fp_rate (never measured)"
+    ],
+    "ATR-2026-00452": [
+      "no wild_fp_rate (never measured)"
+    ],
+    "ATR-2026-00453": [
+      "no wild_fp_rate (never measured)"
+    ],
+    "ATR-2026-00456": [
+      "no wild_fp_rate (never measured)"
+    ],
+    "ATR-2026-00511": [
+      "no wild_fp_rate (never measured)"
+    ],
+    "ATR-2026-00512": [
+      "no wild_fp_rate (never measured)"
+    ],
+    "ATR-2026-00513": [
+      "no wild_fp_rate (never measured)"
+    ],
+    "ATR-2026-00517": [
+      "no wild_fp_rate (never measured)"
+    ],
+    "ATR-2026-00700": [
+      "no confidence field",
+      "no wild_fp_rate (never measured)"
+    ],
+    "ATR-2026-00702": [
+      "no confidence field",
+      "no wild_fp_rate (never measured)"
+    ],
+    "ATR-2026-00703": [
+      "no confidence field",
+      "no wild_fp_rate (never measured)"
+    ],
+    "ATR-2026-00704": [
+      "no confidence field",
+      "no wild_fp_rate (never measured)"
+    ],
+    "ATR-2026-00705": [
+      "no confidence field",
+      "no wild_fp_rate (never measured)"
+    ],
+    "ATR-2026-00706": [
+      "no confidence field",
+      "no wild_fp_rate (never measured)"
+    ],
+    "ATR-2026-00707": [
+      "no confidence field",
+      "no wild_fp_rate (never measured)"
+    ],
+    "ATR-2026-00708": [
+      "no confidence field",
+      "no wild_fp_rate (never measured)"
+    ],
+    "ATR-2026-00709": [
+      "no confidence field",
+      "no wild_fp_rate (never measured)"
+    ],
+    "ATR-2026-00710": [
+      "no confidence field",
+      "no wild_fp_rate (never measured)"
+    ],
+    "ATR-2026-00711": [
+      "no confidence field",
+      "no wild_fp_rate (never measured)"
+    ],
+    "ATR-2026-00712": [
+      "no confidence field",
+      "no wild_fp_rate (never measured)"
+    ],
+    "ATR-2026-00714": [
+      "no confidence field",
+      "no wild_fp_rate (never measured)"
+    ],
+    "ATR-2026-00715": [
+      "no confidence field",
+      "no wild_fp_rate (never measured)"
+    ],
+    "ATR-2026-00716": [
+      "no confidence field",
+      "no wild_fp_rate (never measured)"
+    ],
+    "ATR-2026-00718": [
+      "no confidence field",
+      "no wild_fp_rate (never measured)"
+    ],
+    "ATR-2026-00719": [
+      "no confidence field",
+      "no wild_fp_rate (never measured)"
+    ],
+    "ATR-2026-00720": [
+      "no confidence field",
+      "no wild_fp_rate (never measured)"
+    ],
+    "ATR-2026-00722": [
+      "no confidence field",
+      "no wild_fp_rate (never measured)"
+    ],
+    "ATR-2026-00850": [
+      "no confidence field",
+      "no wild_fp_rate (never measured)"
+    ],
+    "ATR-2026-00851": [
+      "no confidence field",
+      "no wild_fp_rate (never measured)"
+    ],
+    "ATR-2026-00852": [
+      "no confidence field",
+      "no wild_fp_rate (never measured)"
+    ],
+    "ATR-2026-00853": [
+      "no confidence field",
+      "no wild_fp_rate (never measured)"
+    ],
+    "ATR-2026-00855": [
+      "no confidence field",
+      "no wild_fp_rate (never measured)"
+    ],
+    "ATR-2026-00856": [
+      "no confidence field",
+      "no wild_fp_rate (never measured)"
+    ],
+    "ATR-2026-01000": [
+      "no confidence field",
+      "no wild_fp_rate (never measured)"
+    ],
+    "ATR-2026-01001": [
+      "no confidence field",
+      "no wild_fp_rate (never measured)"
+    ],
+    "ATR-2026-01002": [
+      "no confidence field",
+      "no wild_fp_rate (never measured)"
+    ],
+    "ATR-2026-01005": [
+      "no confidence field",
+      "no wild_fp_rate (never measured)"
+    ],
+    "ATR-2026-01006": [
+      "no confidence field",
+      "no wild_fp_rate (never measured)"
+    ],
+    "ATR-2026-01007": [
+      "no confidence field",
+      "no wild_fp_rate (never measured)"
+    ],
+    "ATR-2026-01009": [
+      "no confidence field",
+      "no wild_fp_rate (never measured)"
+    ],
+    "ATR-2026-01012": [
+      "no confidence field",
+      "no wild_fp_rate (never measured)"
+    ],
+    "ATR-2026-01013": [
+      "no confidence field",
+      "no wild_fp_rate (never measured)"
+    ],
+    "ATR-2026-01015": [
+      "no confidence field",
+      "no wild_fp_rate (never measured)"
+    ],
+    "ATR-2026-01016": [
+      "no confidence field",
+      "no wild_fp_rate (never measured)"
+    ],
+    "ATR-2026-01017": [
+      "no confidence field",
+      "no wild_fp_rate (never measured)"
+    ],
+    "ATR-2026-01019": [
+      "no confidence field",
+      "no wild_fp_rate (never measured)"
+    ],
+    "ATR-2026-01020": [
+      "no confidence field",
+      "no wild_fp_rate (never measured)"
+    ],
+    "ATR-2026-01021": [
+      "no confidence field",
+      "no wild_fp_rate (never measured)"
+    ],
+    "ATR-2026-01023": [
+      "no confidence field",
+      "no wild_fp_rate (never measured)"
+    ],
+    "ATR-2026-01024": [
+      "no confidence field",
+      "no wild_fp_rate (never measured)"
+    ],
+    "ATR-2026-01026": [
+      "no confidence field",
+      "no wild_fp_rate (never measured)"
+    ],
+    "ATR-2026-01301": [
+      "no confidence field",
+      "no wild_fp_rate (never measured)"
+    ],
+    "ATR-2026-01302": [
+      "no confidence field",
+      "no wild_fp_rate (never measured)"
+    ],
+    "ATR-2026-01303": [
+      "no confidence field",
+      "no wild_fp_rate (never measured)"
+    ],
+    "ATR-2026-01304": [
+      "no confidence field",
+      "no wild_fp_rate (never measured)"
+    ],
+    "ATR-2026-01306": [
+      "no confidence field",
+      "no wild_fp_rate (never measured)"
+    ],
+    "ATR-2026-01307": [
+      "no confidence field",
+      "no wild_fp_rate (never measured)"
+    ],
+    "ATR-2026-01310": [
+      "no confidence field",
+      "no wild_fp_rate (never measured)"
+    ],
+    "ATR-2026-01450": [
+      "no confidence field",
+      "no wild_fp_rate (never measured)"
+    ],
+    "ATR-2026-01453": [
+      "no confidence field",
+      "no wild_fp_rate (never measured)"
+    ],
+    "ATR-2026-01454": [
+      "no confidence field",
+      "no wild_fp_rate (never measured)"
+    ],
+    "ATR-2026-01455": [
+      "no confidence field",
+      "no wild_fp_rate (never measured)"
+    ],
+    "ATR-2026-01457": [
+      "no confidence field",
+      "no wild_fp_rate (never measured)"
+    ],
+    "ATR-2026-01458": [
+      "no confidence field",
+      "no wild_fp_rate (never measured)"
+    ],
+    "ATR-2026-01459": [
+      "no confidence field",
+      "no wild_fp_rate (never measured)"
+    ],
+    "ATR-2026-01460": [
+      "no confidence field",
+      "no wild_fp_rate (never measured)"
+    ],
+    "ATR-2026-01462": [
+      "no confidence field",
+      "no wild_fp_rate (never measured)"
+    ],
+    "ATR-2026-01463": [
+      "no confidence field",
+      "no wild_fp_rate (never measured)"
+    ],
+    "ATR-2026-01601": [
+      "no wild_fp_rate (never measured)"
+    ],
+    "ATR-2026-01602": [
+      "no wild_fp_rate (never measured)"
+    ],
+    "ATR-2026-01606": [
+      "no wild_fp_rate (never measured)"
+    ],
+    "ATR-2026-01750": [
+      "no confidence field",
+      "no wild_fp_rate (never measured)"
+    ],
+    "ATR-2026-01751": [
+      "no confidence field",
+      "no wild_fp_rate (never measured)"
+    ],
+    "ATR-2026-01752": [
+      "no confidence field",
+      "no wild_fp_rate (never measured)"
+    ],
+    "ATR-2026-01753": [
+      "no confidence field",
+      "no wild_fp_rate (never measured)"
+    ],
+    "ATR-2026-01754": [
+      "no confidence field",
+      "no wild_fp_rate (never measured)"
+    ],
+    "ATR-2026-01755": [
+      "no confidence field",
+      "no wild_fp_rate (never measured)"
+    ],
+    "ATR-2026-01757": [
+      "no confidence field",
+      "no wild_fp_rate (never measured)"
+    ],
+    "ATR-2026-01758": [
+      "no confidence field",
+      "no wild_fp_rate (never measured)"
+    ],
+    "ATR-2026-01759": [
+      "no confidence field",
+      "no wild_fp_rate (never measured)"
+    ],
+    "ATR-2026-01760": [
+      "no confidence field",
+      "no wild_fp_rate (never measured)"
+    ],
+    "ATR-2026-01841": [
+      "no confidence field",
+      "no wild_fp_rate (never measured)"
+    ],
+    "ATR-2026-01890": [
+      "no confidence field",
+      "no wild_fp_rate (never measured)"
+    ],
+    "ATR-2026-01891": [
+      "no confidence field",
+      "no wild_fp_rate (never measured)"
+    ],
+    "ATR-2026-01892": [
+      "no confidence field",
+      "no wild_fp_rate (never measured)"
+    ],
+    "ATR-2026-01893": [
+      "no confidence field",
+      "no wild_fp_rate (never measured)"
+    ],
+    "ATR-2026-01894": [
+      "no confidence field",
+      "no wild_fp_rate (never measured)"
+    ],
+    "ATR-2026-01895": [
+      "no confidence field",
+      "no wild_fp_rate (never measured)"
+    ],
+    "ATR-2026-01896": [
+      "no confidence field",
+      "no wild_fp_rate (never measured)"
+    ],
+    "ATR-2026-01897": [
+      "no confidence field",
+      "no wild_fp_rate (never measured)"
+    ],
+    "ATR-2026-01898": [
+      "no confidence field",
+      "no wild_fp_rate (never measured)"
+    ],
+    "ATR-2026-01899": [
+      "no confidence field",
+      "no wild_fp_rate (never measured)"
+    ],
+    "ATR-2026-01900": [
+      "no confidence field",
+      "no wild_fp_rate (never measured)"
+    ],
+    "ATR-2026-01902": [
+      "no confidence field",
+      "no wild_fp_rate (never measured)"
+    ],
+    "ATR-2026-01904": [
+      "no confidence field",
+      "no wild_fp_rate (never measured)"
+    ],
+    "ATR-2026-01905": [
+      "no confidence field",
+      "no wild_fp_rate (never measured)"
+    ]
+  }
+}

--- a/data/skill-benchmark/benchmark-report.json
+++ b/data/skill-benchmark/benchmark-report.json
@@ -1,5 +1,5 @@
 {
-  "timestamp": "2026-08-08T17:11:43.102Z",
+  "timestamp": "2026-08-09T07:29:32.066Z",
   "corpus_size": 498,
   "rule_count": 783,
   "malicious_count": 32,
@@ -29,8 +29,8 @@
   "false_negatives": 0,
   "expected_rules_accuracy": 1,
   "category_accuracy": 1,
-  "avg_latency_ms": 100.4,
-  "max_latency_ms": 1207.65,
+  "avg_latency_ms": 119.14,
+  "max_latency_ms": 2347.37,
   "results": [
     {
       "file": "malicious/adv-001-context-poisoning-claude-md.md",
@@ -43,7 +43,7 @@
         "ATR-2026-00125"
       ],
       "correct": true,
-      "latency_ms": 365.41,
+      "latency_ms": 1062.99,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -57,7 +57,7 @@
         "ATR-2026-00157"
       ],
       "correct": true,
-      "latency_ms": 251.73,
+      "latency_ms": 686.8,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -71,7 +71,7 @@
         "ATR-2026-00121"
       ],
       "correct": true,
-      "latency_ms": 41.16,
+      "latency_ms": 108.64,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -85,7 +85,7 @@
         "ATR-2026-00149"
       ],
       "correct": true,
-      "latency_ms": 30.99,
+      "latency_ms": 78.93,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -99,7 +99,7 @@
         "ATR-2026-00149"
       ],
       "correct": true,
-      "latency_ms": 34.83,
+      "latency_ms": 90.12,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -113,7 +113,7 @@
         "ATR-2026-00149"
       ],
       "correct": true,
-      "latency_ms": 30.79,
+      "latency_ms": 79.19,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -127,7 +127,7 @@
         "ATR-2026-00162"
       ],
       "correct": true,
-      "latency_ms": 59.76,
+      "latency_ms": 176.99,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -141,7 +141,7 @@
         "ATR-2026-00121"
       ],
       "correct": true,
-      "latency_ms": 27.13,
+      "latency_ms": 86.68,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -156,7 +156,7 @@
         "ATR-2026-00149"
       ],
       "correct": true,
-      "latency_ms": 25.97,
+      "latency_ms": 79.24,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -171,7 +171,7 @@
         "ATR-2026-00149"
       ],
       "correct": true,
-      "latency_ms": 26.46,
+      "latency_ms": 77.52,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -185,7 +185,7 @@
         "ATR-2026-00149"
       ],
       "correct": true,
-      "latency_ms": 27.64,
+      "latency_ms": 71.99,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -199,7 +199,7 @@
         "ATR-2026-00149"
       ],
       "correct": true,
-      "latency_ms": 28.87,
+      "latency_ms": 69.18,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -213,7 +213,7 @@
         "ATR-2026-00149"
       ],
       "correct": true,
-      "latency_ms": 25.79,
+      "latency_ms": 53.69,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -227,7 +227,7 @@
         "ATR-2026-00149"
       ],
       "correct": true,
-      "latency_ms": 28.18,
+      "latency_ms": 68.44,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -244,7 +244,7 @@
         "ATR-2026-00225"
       ],
       "correct": true,
-      "latency_ms": 124.63,
+      "latency_ms": 322.3,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -258,7 +258,7 @@
         "ATR-2026-00121"
       ],
       "correct": true,
-      "latency_ms": 58.5,
+      "latency_ms": 146.71,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -275,7 +275,7 @@
         "ATR-2026-00225"
       ],
       "correct": true,
-      "latency_ms": 68.1,
+      "latency_ms": 144.63,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -289,7 +289,7 @@
         "ATR-2026-00121"
       ],
       "correct": true,
-      "latency_ms": 47.42,
+      "latency_ms": 101.29,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -306,7 +306,7 @@
         "ATR-2026-00225"
       ],
       "correct": true,
-      "latency_ms": 60.97,
+      "latency_ms": 131.05,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -320,7 +320,7 @@
         "ATR-2026-00128"
       ],
       "correct": true,
-      "latency_ms": 46.44,
+      "latency_ms": 100.28,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -336,7 +336,7 @@
         "ATR-2026-00276"
       ],
       "correct": true,
-      "latency_ms": 37.77,
+      "latency_ms": 82.28,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -350,7 +350,7 @@
         "ATR-2026-00135"
       ],
       "correct": true,
-      "latency_ms": 33.4,
+      "latency_ms": 70.32,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -365,7 +365,7 @@
         "ATR-2026-00206"
       ],
       "correct": true,
-      "latency_ms": 24.67,
+      "latency_ms": 51.89,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -382,7 +382,7 @@
         "ATR-2026-00225"
       ],
       "correct": true,
-      "latency_ms": 65.1,
+      "latency_ms": 138.95,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -399,7 +399,7 @@
         "ATR-2026-00225"
       ],
       "correct": true,
-      "latency_ms": 52.28,
+      "latency_ms": 111.46,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -416,7 +416,7 @@
         "ATR-2026-00225"
       ],
       "correct": true,
-      "latency_ms": 97.05,
+      "latency_ms": 211.28,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -430,7 +430,7 @@
         "ATR-2026-00121"
       ],
       "correct": true,
-      "latency_ms": 30.51,
+      "latency_ms": 65.49,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -444,7 +444,7 @@
         "ATR-2026-00121"
       ],
       "correct": true,
-      "latency_ms": 106.28,
+      "latency_ms": 232.97,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -458,7 +458,7 @@
         "ATR-2026-00129"
       ],
       "correct": true,
-      "latency_ms": 26.25,
+      "latency_ms": 57.32,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -472,7 +472,7 @@
         "ATR-2026-00121"
       ],
       "correct": true,
-      "latency_ms": 30.15,
+      "latency_ms": 65.77,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -486,7 +486,7 @@
         "ATR-2026-00121"
       ],
       "correct": true,
-      "latency_ms": 58.41,
+      "latency_ms": 104.08,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -503,7 +503,7 @@
         "ATR-2026-00225"
       ],
       "correct": true,
-      "latency_ms": 119.52,
+      "latency_ms": 259.96,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -514,7 +514,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 19.73,
+      "latency_ms": 42.44,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -525,7 +525,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 19.62,
+      "latency_ms": 40.9,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -536,7 +536,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 20.32,
+      "latency_ms": 40.02,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -547,7 +547,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 19.64,
+      "latency_ms": 38.02,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -558,7 +558,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 19.92,
+      "latency_ms": 38.23,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -569,7 +569,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 19.42,
+      "latency_ms": 39.45,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -580,7 +580,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 19.51,
+      "latency_ms": 37.76,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -591,7 +591,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 19.5,
+      "latency_ms": 38.02,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -602,7 +602,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 19.55,
+      "latency_ms": 42.28,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -613,7 +613,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 88.49,
+      "latency_ms": 183.26,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -624,7 +624,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 161.54,
+      "latency_ms": 399.04,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -635,7 +635,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 132.88,
+      "latency_ms": 291.74,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -646,7 +646,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 113.64,
+      "latency_ms": 247.87,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -657,7 +657,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 66.05,
+      "latency_ms": 143.16,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -668,7 +668,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 86.49,
+      "latency_ms": 188.49,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -679,7 +679,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 57.24,
+      "latency_ms": 121.03,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -690,7 +690,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 177.95,
+      "latency_ms": 364.15,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -701,7 +701,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 55.62,
+      "latency_ms": 130.45,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -712,7 +712,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 63.31,
+      "latency_ms": 150.38,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -723,7 +723,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 69.24,
+      "latency_ms": 149.59,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -734,7 +734,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 48.04,
+      "latency_ms": 103.26,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -745,7 +745,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 39.81,
+      "latency_ms": 86.99,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -756,7 +756,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 187,
+      "latency_ms": 405.63,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -767,7 +767,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 63.86,
+      "latency_ms": 137.81,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -778,7 +778,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 63.33,
+      "latency_ms": 136.41,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -789,7 +789,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 98.62,
+      "latency_ms": 223.31,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -800,7 +800,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 113.87,
+      "latency_ms": 253.68,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -811,7 +811,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 156.49,
+      "latency_ms": 361.83,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -822,7 +822,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 126.07,
+      "latency_ms": 320.32,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -833,7 +833,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 88.47,
+      "latency_ms": 233.06,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -844,7 +844,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 86.05,
+      "latency_ms": 212.02,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -855,7 +855,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 103.19,
+      "latency_ms": 228.43,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -866,7 +866,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 89.13,
+      "latency_ms": 194.76,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -877,7 +877,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 66.34,
+      "latency_ms": 145.94,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -888,7 +888,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 47.6,
+      "latency_ms": 104.23,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -899,7 +899,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 34.2,
+      "latency_ms": 74.15,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -910,7 +910,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 90.78,
+      "latency_ms": 202.33,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -921,7 +921,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 106.12,
+      "latency_ms": 235.13,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -932,7 +932,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 1019.09,
+      "latency_ms": 2347.37,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -943,7 +943,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 170.05,
+      "latency_ms": 366.96,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -954,7 +954,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 53.66,
+      "latency_ms": 105.84,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -965,7 +965,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 151.49,
+      "latency_ms": 292.05,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -976,7 +976,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 74.69,
+      "latency_ms": 136.27,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -987,7 +987,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 98.04,
+      "latency_ms": 185.78,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -998,7 +998,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 104.09,
+      "latency_ms": 191.88,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1009,7 +1009,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 52.95,
+      "latency_ms": 90.04,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1020,7 +1020,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 55.69,
+      "latency_ms": 95.34,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1031,7 +1031,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 69.29,
+      "latency_ms": 120.66,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1042,7 +1042,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 38.65,
+      "latency_ms": 70.37,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1053,7 +1053,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 52.87,
+      "latency_ms": 93,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1064,7 +1064,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 85.32,
+      "latency_ms": 146.58,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1075,7 +1075,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 56.45,
+      "latency_ms": 92.87,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1086,7 +1086,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 65.75,
+      "latency_ms": 116.03,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1097,7 +1097,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 75.15,
+      "latency_ms": 142.97,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1108,7 +1108,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 216.67,
+      "latency_ms": 238.82,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1119,7 +1119,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 62.53,
+      "latency_ms": 104.01,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1130,7 +1130,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 74.95,
+      "latency_ms": 130.86,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1141,7 +1141,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 225.71,
+      "latency_ms": 386.47,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1152,7 +1152,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 384.62,
+      "latency_ms": 655.85,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1163,7 +1163,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 87.51,
+      "latency_ms": 159.59,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1174,7 +1174,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 90.9,
+      "latency_ms": 162.63,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1185,7 +1185,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 88.91,
+      "latency_ms": 128.24,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1196,7 +1196,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 87.46,
+      "latency_ms": 114.42,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1207,7 +1207,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 55.09,
+      "latency_ms": 69.17,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1218,7 +1218,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 34.69,
+      "latency_ms": 40.2,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1229,7 +1229,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 1207.65,
+      "latency_ms": 1324.87,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1240,7 +1240,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 44.44,
+      "latency_ms": 44.34,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1251,7 +1251,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 69.93,
+      "latency_ms": 69.18,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1262,7 +1262,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 108.05,
+      "latency_ms": 105.76,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1273,7 +1273,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 70.07,
+      "latency_ms": 69.15,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1284,7 +1284,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 71.91,
+      "latency_ms": 72.37,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1295,7 +1295,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 71.83,
+      "latency_ms": 70.87,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1306,7 +1306,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 59.04,
+      "latency_ms": 58.26,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1317,7 +1317,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 80.34,
+      "latency_ms": 79.26,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1328,7 +1328,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 156.63,
+      "latency_ms": 154.97,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1339,7 +1339,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 48.37,
+      "latency_ms": 47.69,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1350,7 +1350,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 80.49,
+      "latency_ms": 78.32,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1361,7 +1361,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 96.15,
+      "latency_ms": 95.66,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1372,7 +1372,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 138.41,
+      "latency_ms": 135.55,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1383,7 +1383,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 59.83,
+      "latency_ms": 59.27,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1394,7 +1394,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 105.99,
+      "latency_ms": 104.81,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1405,7 +1405,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 49.47,
+      "latency_ms": 52.46,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1416,7 +1416,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 73.52,
+      "latency_ms": 76.1,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1427,7 +1427,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 84.22,
+      "latency_ms": 84.74,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1438,7 +1438,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 39.28,
+      "latency_ms": 39.2,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1449,7 +1449,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 37.46,
+      "latency_ms": 36.89,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1460,7 +1460,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 75.73,
+      "latency_ms": 74.47,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1471,7 +1471,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 117.54,
+      "latency_ms": 115.5,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1482,7 +1482,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 48.74,
+      "latency_ms": 48.15,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1493,7 +1493,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 57.11,
+      "latency_ms": 57.37,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1504,7 +1504,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 63.7,
+      "latency_ms": 63.22,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1515,7 +1515,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 39.09,
+      "latency_ms": 39.28,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1526,7 +1526,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 78.21,
+      "latency_ms": 77.33,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1537,7 +1537,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 87.27,
+      "latency_ms": 87.67,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1548,7 +1548,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 82.42,
+      "latency_ms": 82.58,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1559,7 +1559,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 36.96,
+      "latency_ms": 37.65,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1570,7 +1570,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 31.57,
+      "latency_ms": 31.45,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1581,7 +1581,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 55.56,
+      "latency_ms": 54.95,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1592,7 +1592,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 63.43,
+      "latency_ms": 60.84,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1603,7 +1603,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 259.94,
+      "latency_ms": 255.89,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1614,7 +1614,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 62.86,
+      "latency_ms": 62.08,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1625,7 +1625,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 114.35,
+      "latency_ms": 113.08,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1636,7 +1636,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 43.89,
+      "latency_ms": 43.73,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1647,7 +1647,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 101.34,
+      "latency_ms": 100.01,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1658,7 +1658,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 67.5,
+      "latency_ms": 66.43,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1669,7 +1669,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 88.86,
+      "latency_ms": 87.14,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1680,7 +1680,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 83.43,
+      "latency_ms": 84.86,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1691,7 +1691,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 37.34,
+      "latency_ms": 37.54,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1702,7 +1702,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 103.06,
+      "latency_ms": 105.03,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1713,7 +1713,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 90.14,
+      "latency_ms": 91.62,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1724,7 +1724,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 46.24,
+      "latency_ms": 47.17,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1735,7 +1735,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 43.84,
+      "latency_ms": 45.73,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1746,7 +1746,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 37.2,
+      "latency_ms": 38.21,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1757,7 +1757,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 161.58,
+      "latency_ms": 161.04,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1768,7 +1768,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 44.66,
+      "latency_ms": 43.73,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1779,7 +1779,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 104.31,
+      "latency_ms": 104.3,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1790,7 +1790,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 96.47,
+      "latency_ms": 96.22,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1801,7 +1801,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 120.76,
+      "latency_ms": 117.9,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1812,7 +1812,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 264.95,
+      "latency_ms": 265.17,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1823,7 +1823,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 107.71,
+      "latency_ms": 107.43,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1834,7 +1834,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 272.03,
+      "latency_ms": 268.95,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1845,7 +1845,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 210.43,
+      "latency_ms": 208.18,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1856,7 +1856,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 193.74,
+      "latency_ms": 191.76,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1867,7 +1867,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 326.76,
+      "latency_ms": 323.24,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1878,7 +1878,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 43.63,
+      "latency_ms": 42.31,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1889,7 +1889,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 34.38,
+      "latency_ms": 33.66,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1900,7 +1900,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 138.41,
+      "latency_ms": 136.58,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1911,7 +1911,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 62.85,
+      "latency_ms": 61.52,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1922,7 +1922,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 64.65,
+      "latency_ms": 62.77,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1933,7 +1933,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 162.66,
+      "latency_ms": 159.56,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1944,7 +1944,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 112.59,
+      "latency_ms": 110.9,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1955,7 +1955,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 447.87,
+      "latency_ms": 443.31,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1966,7 +1966,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 99.76,
+      "latency_ms": 98.96,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1977,7 +1977,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 79.73,
+      "latency_ms": 78.33,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1988,7 +1988,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 93.3,
+      "latency_ms": 92.16,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -1999,7 +1999,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 234.53,
+      "latency_ms": 233.78,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2010,7 +2010,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 39.83,
+      "latency_ms": 40.22,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2021,7 +2021,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 47.49,
+      "latency_ms": 46.72,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2032,7 +2032,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 48.01,
+      "latency_ms": 47.6,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2043,7 +2043,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 81.26,
+      "latency_ms": 80.61,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2054,7 +2054,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 107.28,
+      "latency_ms": 106.29,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2065,7 +2065,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 361.48,
+      "latency_ms": 357.84,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2076,7 +2076,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 59.38,
+      "latency_ms": 58.16,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2087,7 +2087,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 235.66,
+      "latency_ms": 235.64,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2098,7 +2098,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 140.18,
+      "latency_ms": 138.49,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2109,7 +2109,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 78.77,
+      "latency_ms": 78.72,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2120,7 +2120,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 50.64,
+      "latency_ms": 50.76,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2131,7 +2131,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 52.11,
+      "latency_ms": 50.74,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2142,7 +2142,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 46.29,
+      "latency_ms": 45.19,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2153,7 +2153,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 284.41,
+      "latency_ms": 274.35,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2164,7 +2164,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 267.88,
+      "latency_ms": 269.47,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2175,7 +2175,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 43.84,
+      "latency_ms": 43.06,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2186,7 +2186,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 332.51,
+      "latency_ms": 329.35,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2197,7 +2197,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 282.62,
+      "latency_ms": 283.43,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2208,7 +2208,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 49.4,
+      "latency_ms": 49.52,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2219,7 +2219,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 58.63,
+      "latency_ms": 57.94,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2230,7 +2230,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 46.8,
+      "latency_ms": 46.2,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2241,7 +2241,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 36.02,
+      "latency_ms": 35.65,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2252,7 +2252,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 43.11,
+      "latency_ms": 42.89,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2263,7 +2263,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 42.92,
+      "latency_ms": 42.51,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2274,7 +2274,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 41.32,
+      "latency_ms": 40.88,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2285,7 +2285,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 45.74,
+      "latency_ms": 45.05,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2296,7 +2296,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 55.69,
+      "latency_ms": 54.85,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2307,7 +2307,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 37.28,
+      "latency_ms": 37.68,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2318,7 +2318,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 104.05,
+      "latency_ms": 104.93,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2329,7 +2329,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 93.62,
+      "latency_ms": 92.29,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2340,7 +2340,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 79.7,
+      "latency_ms": 79.02,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2351,7 +2351,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 64.81,
+      "latency_ms": 65.65,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2362,7 +2362,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 72.52,
+      "latency_ms": 71.4,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2373,7 +2373,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 52.18,
+      "latency_ms": 51.74,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2384,7 +2384,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 51.83,
+      "latency_ms": 50.58,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2395,7 +2395,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 44.23,
+      "latency_ms": 43.73,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2406,7 +2406,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 64.07,
+      "latency_ms": 63,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2417,7 +2417,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 79.49,
+      "latency_ms": 78.76,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2428,7 +2428,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 234.25,
+      "latency_ms": 232.37,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2439,7 +2439,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 111.94,
+      "latency_ms": 110.59,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2450,7 +2450,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 127.73,
+      "latency_ms": 126.32,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2461,7 +2461,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 223.8,
+      "latency_ms": 217.78,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2472,7 +2472,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 74.72,
+      "latency_ms": 72.4,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2483,7 +2483,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 50.85,
+      "latency_ms": 49.78,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2494,7 +2494,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 235.54,
+      "latency_ms": 230.97,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2505,7 +2505,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 191.9,
+      "latency_ms": 189.26,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2516,7 +2516,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 161.03,
+      "latency_ms": 158.99,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2527,7 +2527,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 143.43,
+      "latency_ms": 141.08,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2538,7 +2538,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 82.14,
+      "latency_ms": 81.04,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2549,7 +2549,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 163.09,
+      "latency_ms": 157.88,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2560,7 +2560,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 79.15,
+      "latency_ms": 77.29,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2571,7 +2571,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 136.24,
+      "latency_ms": 134.83,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2582,7 +2582,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 38.67,
+      "latency_ms": 37.5,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2593,7 +2593,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 155.17,
+      "latency_ms": 152.1,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2604,7 +2604,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 71.82,
+      "latency_ms": 69.78,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2615,7 +2615,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 89.5,
+      "latency_ms": 87.99,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2626,7 +2626,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 121.34,
+      "latency_ms": 119.54,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2637,7 +2637,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 116.42,
+      "latency_ms": 116.27,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2648,7 +2648,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 47.36,
+      "latency_ms": 46.74,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2659,7 +2659,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 100.35,
+      "latency_ms": 98.69,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2670,7 +2670,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 86.99,
+      "latency_ms": 87.63,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2681,7 +2681,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 52.02,
+      "latency_ms": 50.57,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2692,7 +2692,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 117.4,
+      "latency_ms": 115.74,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2703,7 +2703,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 39.86,
+      "latency_ms": 39.07,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2714,7 +2714,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 31.99,
+      "latency_ms": 30.55,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2725,7 +2725,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 33.3,
+      "latency_ms": 32.8,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2736,7 +2736,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 60.55,
+      "latency_ms": 60.17,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2747,7 +2747,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 28.35,
+      "latency_ms": 27.84,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2758,7 +2758,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 109.02,
+      "latency_ms": 106.3,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2769,7 +2769,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 128.27,
+      "latency_ms": 126.02,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2780,7 +2780,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 160.21,
+      "latency_ms": 156.43,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2791,7 +2791,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 148.21,
+      "latency_ms": 148.73,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2802,7 +2802,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 77.04,
+      "latency_ms": 77.08,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2813,7 +2813,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 47.53,
+      "latency_ms": 46.48,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2824,7 +2824,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 669.03,
+      "latency_ms": 619.67,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2835,7 +2835,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 21.52,
+      "latency_ms": 21.93,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2846,7 +2846,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 39.91,
+      "latency_ms": 39.33,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2857,7 +2857,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 75.8,
+      "latency_ms": 74.32,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2868,7 +2868,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 73.13,
+      "latency_ms": 72.02,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2879,7 +2879,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 45.5,
+      "latency_ms": 44.58,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2890,7 +2890,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 76.89,
+      "latency_ms": 75.69,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2901,7 +2901,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 64.32,
+      "latency_ms": 62.87,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2912,7 +2912,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 41.78,
+      "latency_ms": 40.95,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2923,7 +2923,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 80.16,
+      "latency_ms": 80.34,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2934,7 +2934,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 58.02,
+      "latency_ms": 58.76,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2945,7 +2945,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 97.37,
+      "latency_ms": 97.16,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2956,7 +2956,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 119.18,
+      "latency_ms": 114.99,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2967,7 +2967,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 45.21,
+      "latency_ms": 44.33,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2978,7 +2978,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 146.23,
+      "latency_ms": 143.67,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -2989,7 +2989,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 93.46,
+      "latency_ms": 91.61,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3000,7 +3000,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 185.68,
+      "latency_ms": 180.47,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3011,7 +3011,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 117.94,
+      "latency_ms": 118.67,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3022,7 +3022,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 76.88,
+      "latency_ms": 79.12,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3033,7 +3033,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 94.81,
+      "latency_ms": 94.47,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3044,7 +3044,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 71.91,
+      "latency_ms": 73.3,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3055,7 +3055,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 28,
+      "latency_ms": 28.33,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3066,7 +3066,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 88.45,
+      "latency_ms": 87.82,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3077,7 +3077,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 181.04,
+      "latency_ms": 178.14,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3088,7 +3088,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 48,
+      "latency_ms": 47.54,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3099,7 +3099,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 64.12,
+      "latency_ms": 63.49,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3110,7 +3110,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 92.26,
+      "latency_ms": 90.94,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3121,7 +3121,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 362.18,
+      "latency_ms": 357.41,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3132,7 +3132,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 250.16,
+      "latency_ms": 247.67,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3143,7 +3143,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 73.23,
+      "latency_ms": 71.52,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3154,7 +3154,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 52.19,
+      "latency_ms": 51.83,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3165,7 +3165,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 30.86,
+      "latency_ms": 29.96,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3176,7 +3176,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 79.77,
+      "latency_ms": 78.39,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3187,7 +3187,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 122.38,
+      "latency_ms": 121.46,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3198,7 +3198,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 103.69,
+      "latency_ms": 101.66,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3209,7 +3209,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 23.49,
+      "latency_ms": 22.62,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3220,7 +3220,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 298.56,
+      "latency_ms": 296.45,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3231,7 +3231,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 46.06,
+      "latency_ms": 45.08,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3242,7 +3242,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 267.34,
+      "latency_ms": 263.02,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3253,7 +3253,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 53.62,
+      "latency_ms": 52.93,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3264,7 +3264,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 89.19,
+      "latency_ms": 88.85,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3275,7 +3275,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 120.78,
+      "latency_ms": 119.19,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3286,7 +3286,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 201.47,
+      "latency_ms": 198.4,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3297,7 +3297,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 68.14,
+      "latency_ms": 66.97,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3308,7 +3308,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 25.92,
+      "latency_ms": 25.63,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3319,7 +3319,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 26.64,
+      "latency_ms": 25.57,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3330,7 +3330,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 25.68,
+      "latency_ms": 26.03,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3341,7 +3341,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 25.99,
+      "latency_ms": 25.54,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3352,7 +3352,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 23.77,
+      "latency_ms": 22.49,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3363,7 +3363,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 116.2,
+      "latency_ms": 114.49,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3374,7 +3374,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 94.57,
+      "latency_ms": 93.92,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3385,7 +3385,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 76.29,
+      "latency_ms": 74.68,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3396,7 +3396,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 294.49,
+      "latency_ms": 291.54,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3407,7 +3407,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 159.09,
+      "latency_ms": 155.71,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3418,7 +3418,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 98.27,
+      "latency_ms": 97.42,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3429,7 +3429,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 45.45,
+      "latency_ms": 45.42,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3440,7 +3440,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 23.7,
+      "latency_ms": 23.28,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3451,7 +3451,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 37.94,
+      "latency_ms": 37.2,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3462,7 +3462,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 150.97,
+      "latency_ms": 143.87,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3473,7 +3473,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 23.72,
+      "latency_ms": 23.22,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3484,7 +3484,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 193.87,
+      "latency_ms": 187.94,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3495,7 +3495,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 126.81,
+      "latency_ms": 124.69,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3506,7 +3506,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 44.28,
+      "latency_ms": 44.72,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3517,7 +3517,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 125.35,
+      "latency_ms": 123.36,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3528,7 +3528,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 52.25,
+      "latency_ms": 51.32,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3539,7 +3539,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 43.87,
+      "latency_ms": 44.07,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3550,7 +3550,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 62.92,
+      "latency_ms": 62.26,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3561,7 +3561,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 36.95,
+      "latency_ms": 35.9,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3572,7 +3572,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 53.84,
+      "latency_ms": 53.7,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3583,7 +3583,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 80.21,
+      "latency_ms": 78.76,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3594,7 +3594,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 124.62,
+      "latency_ms": 123.21,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3605,7 +3605,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 264.52,
+      "latency_ms": 261.32,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3616,7 +3616,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 468.19,
+      "latency_ms": 470.33,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3627,7 +3627,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 1126.81,
+      "latency_ms": 1117.29,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3638,7 +3638,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 131.13,
+      "latency_ms": 135.74,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3649,7 +3649,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 145.77,
+      "latency_ms": 142.78,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3660,7 +3660,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 191.9,
+      "latency_ms": 186.63,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3671,7 +3671,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 118.03,
+      "latency_ms": 116.57,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3682,7 +3682,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 84.12,
+      "latency_ms": 83.04,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3693,7 +3693,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 38.03,
+      "latency_ms": 37.3,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3704,7 +3704,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 56.93,
+      "latency_ms": 57.58,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3715,7 +3715,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 131.1,
+      "latency_ms": 131.43,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3726,7 +3726,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 194.03,
+      "latency_ms": 191.75,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3737,7 +3737,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 90.88,
+      "latency_ms": 88.22,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3748,7 +3748,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 91.73,
+      "latency_ms": 88.47,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3759,7 +3759,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 97.41,
+      "latency_ms": 96.6,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3770,7 +3770,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 138.24,
+      "latency_ms": 99.62,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3781,7 +3781,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 97.15,
+      "latency_ms": 97.01,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3792,7 +3792,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 96.06,
+      "latency_ms": 95.63,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3803,7 +3803,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 89.32,
+      "latency_ms": 88.19,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3814,7 +3814,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 106.08,
+      "latency_ms": 105.11,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3825,7 +3825,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 34.69,
+      "latency_ms": 34.68,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3836,7 +3836,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 48.16,
+      "latency_ms": 47.16,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3847,7 +3847,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 89.44,
+      "latency_ms": 88.93,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3858,7 +3858,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 72.53,
+      "latency_ms": 71.01,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3869,7 +3869,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 75.31,
+      "latency_ms": 73.91,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3880,7 +3880,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 36.11,
+      "latency_ms": 36.36,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3891,7 +3891,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 84.24,
+      "latency_ms": 85.87,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3902,7 +3902,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 66.4,
+      "latency_ms": 66.6,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3913,7 +3913,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 95.85,
+      "latency_ms": 98.34,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3924,7 +3924,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 53.56,
+      "latency_ms": 53.14,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3935,7 +3935,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 127.32,
+      "latency_ms": 126.6,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3946,7 +3946,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 122.63,
+      "latency_ms": 118.99,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3957,7 +3957,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 174.75,
+      "latency_ms": 166.85,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3968,7 +3968,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 32.64,
+      "latency_ms": 32.25,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3979,7 +3979,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 47.91,
+      "latency_ms": 47.96,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -3990,7 +3990,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 40.94,
+      "latency_ms": 40.81,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4001,7 +4001,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 46.3,
+      "latency_ms": 45.93,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4012,7 +4012,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 26.83,
+      "latency_ms": 26.75,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4023,7 +4023,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 52.69,
+      "latency_ms": 52.67,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4034,7 +4034,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 53.13,
+      "latency_ms": 52.89,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4047,7 +4047,7 @@
         "ATR-2026-00123"
       ],
       "correct": false,
-      "latency_ms": 37.55,
+      "latency_ms": 37.81,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4058,7 +4058,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 71.18,
+      "latency_ms": 70.42,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4069,7 +4069,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 48.81,
+      "latency_ms": 48.7,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4080,7 +4080,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 69.45,
+      "latency_ms": 68.28,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4091,7 +4091,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 70.45,
+      "latency_ms": 69.96,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4102,7 +4102,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 128.44,
+      "latency_ms": 126.32,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4113,7 +4113,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 42.35,
+      "latency_ms": 41.34,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4124,7 +4124,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 224.26,
+      "latency_ms": 219.79,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4135,7 +4135,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 74,
+      "latency_ms": 74.08,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4146,7 +4146,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 119.35,
+      "latency_ms": 118.5,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4157,7 +4157,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 214.63,
+      "latency_ms": 211.58,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4168,7 +4168,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 84.85,
+      "latency_ms": 84.11,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4179,7 +4179,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 85.24,
+      "latency_ms": 83.62,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4190,7 +4190,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 167.81,
+      "latency_ms": 162.18,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4201,7 +4201,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 124.65,
+      "latency_ms": 127.88,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4212,7 +4212,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 66.03,
+      "latency_ms": 66.9,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4223,7 +4223,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 64.87,
+      "latency_ms": 64.84,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4234,7 +4234,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 57.86,
+      "latency_ms": 65.73,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4245,7 +4245,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 68.47,
+      "latency_ms": 68.74,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4256,7 +4256,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 63.72,
+      "latency_ms": 64.8,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4267,7 +4267,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 82.1,
+      "latency_ms": 83,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4278,7 +4278,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 83.5,
+      "latency_ms": 83.76,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4289,7 +4289,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 53.1,
+      "latency_ms": 53.04,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4300,7 +4300,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 34.38,
+      "latency_ms": 34.51,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4311,7 +4311,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 52.68,
+      "latency_ms": 52.88,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4322,7 +4322,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 35.03,
+      "latency_ms": 34.62,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4333,7 +4333,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 34.39,
+      "latency_ms": 34.62,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4344,7 +4344,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 139.18,
+      "latency_ms": 137.11,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4355,7 +4355,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 146.52,
+      "latency_ms": 146.46,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4366,7 +4366,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 46.06,
+      "latency_ms": 46.53,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4377,7 +4377,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 56,
+      "latency_ms": 58.21,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4388,7 +4388,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 56.41,
+      "latency_ms": 56.65,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4399,7 +4399,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 123.31,
+      "latency_ms": 122.86,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4410,7 +4410,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 24.8,
+      "latency_ms": 25.14,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4421,7 +4421,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 249.83,
+      "latency_ms": 248.56,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4432,7 +4432,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 154.98,
+      "latency_ms": 156.52,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4443,7 +4443,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 259.27,
+      "latency_ms": 258.12,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4454,7 +4454,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 40.7,
+      "latency_ms": 40.4,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4465,7 +4465,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 35.89,
+      "latency_ms": 35.81,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4476,7 +4476,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 44.68,
+      "latency_ms": 44.4,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4487,7 +4487,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 41.07,
+      "latency_ms": 40.22,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4498,7 +4498,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 29.3,
+      "latency_ms": 29.02,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4509,7 +4509,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 168.63,
+      "latency_ms": 167.44,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4520,7 +4520,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 58.62,
+      "latency_ms": 58.2,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4531,7 +4531,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 56.25,
+      "latency_ms": 46.7,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4542,7 +4542,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 24.85,
+      "latency_ms": 23.82,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4553,7 +4553,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 60.27,
+      "latency_ms": 59.68,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4564,7 +4564,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 60.98,
+      "latency_ms": 60.67,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4575,7 +4575,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 115.6,
+      "latency_ms": 112.87,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4586,7 +4586,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 100.36,
+      "latency_ms": 96.89,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4597,7 +4597,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 48.26,
+      "latency_ms": 44.74,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4608,7 +4608,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 42.41,
+      "latency_ms": 36.41,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4619,7 +4619,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 42.06,
+      "latency_ms": 38.31,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4630,7 +4630,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 52.01,
+      "latency_ms": 50.31,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4641,7 +4641,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 54.77,
+      "latency_ms": 54.58,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4652,7 +4652,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 48.04,
+      "latency_ms": 47.37,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4663,7 +4663,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 54.79,
+      "latency_ms": 54.24,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4674,7 +4674,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 44.79,
+      "latency_ms": 43.23,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4685,7 +4685,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 27.58,
+      "latency_ms": 27.34,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4696,7 +4696,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 29.24,
+      "latency_ms": 29.14,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4707,7 +4707,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 29.23,
+      "latency_ms": 29.11,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4718,7 +4718,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 102.24,
+      "latency_ms": 99.8,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4729,7 +4729,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 46.69,
+      "latency_ms": 45.99,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4740,7 +4740,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 71.37,
+      "latency_ms": 70.09,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4751,7 +4751,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 84.93,
+      "latency_ms": 84.14,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4762,7 +4762,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 48.41,
+      "latency_ms": 47.99,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4773,7 +4773,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 74.1,
+      "latency_ms": 71.89,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4784,7 +4784,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 60.08,
+      "latency_ms": 60.21,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4795,7 +4795,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 54.18,
+      "latency_ms": 52.99,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4806,7 +4806,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 58.02,
+      "latency_ms": 57.5,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4817,7 +4817,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 45.33,
+      "latency_ms": 45.27,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4828,7 +4828,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 35.75,
+      "latency_ms": 35.9,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4839,7 +4839,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 84.77,
+      "latency_ms": 82.88,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4850,7 +4850,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 73.81,
+      "latency_ms": 73.01,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4861,7 +4861,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 37.63,
+      "latency_ms": 37.91,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4872,7 +4872,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 94.62,
+      "latency_ms": 94.05,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4883,7 +4883,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 48.38,
+      "latency_ms": 48.61,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4894,7 +4894,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 79.38,
+      "latency_ms": 77.66,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4905,7 +4905,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 74.78,
+      "latency_ms": 68.45,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4916,7 +4916,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 61.39,
+      "latency_ms": 60.84,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4927,7 +4927,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 25.36,
+      "latency_ms": 25.79,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4938,7 +4938,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 138.87,
+      "latency_ms": 136.92,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4949,7 +4949,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 250.93,
+      "latency_ms": 248.67,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4960,7 +4960,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 93.61,
+      "latency_ms": 93.4,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4971,7 +4971,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 195.37,
+      "latency_ms": 186.76,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4982,7 +4982,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 27.01,
+      "latency_ms": 25.46,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -4993,7 +4993,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 140.11,
+      "latency_ms": 136.48,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -5004,7 +5004,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 252.04,
+      "latency_ms": 248.12,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -5015,7 +5015,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 240.65,
+      "latency_ms": 234.14,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -5026,7 +5026,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 331.38,
+      "latency_ms": 329.72,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -5037,7 +5037,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 50.68,
+      "latency_ms": 50.79,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -5048,7 +5048,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 83.08,
+      "latency_ms": 82.07,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -5059,7 +5059,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 68.82,
+      "latency_ms": 67.33,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -5070,7 +5070,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 60.57,
+      "latency_ms": 60.08,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -5081,7 +5081,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 291.03,
+      "latency_ms": 287.31,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -5092,7 +5092,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 229.68,
+      "latency_ms": 224.94,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -5103,7 +5103,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 38.86,
+      "latency_ms": 37.75,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -5114,7 +5114,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 52.78,
+      "latency_ms": 51.58,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -5125,7 +5125,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 85.94,
+      "latency_ms": 83.96,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -5136,7 +5136,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 55.85,
+      "latency_ms": 54.35,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -5147,7 +5147,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 171.65,
+      "latency_ms": 167.46,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -5158,7 +5158,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 293.91,
+      "latency_ms": 288.69,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -5169,7 +5169,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 120.43,
+      "latency_ms": 115.75,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -5180,7 +5180,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 120.85,
+      "latency_ms": 113.91,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -5191,7 +5191,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 311.09,
+      "latency_ms": 303.55,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -5202,7 +5202,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 62.92,
+      "latency_ms": 61.9,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -5213,7 +5213,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 69.4,
+      "latency_ms": 69.17,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -5224,7 +5224,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 102.1,
+      "latency_ms": 100.86,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -5235,7 +5235,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 94.67,
+      "latency_ms": 92.87,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -5246,7 +5246,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 119.38,
+      "latency_ms": 117.86,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -5257,7 +5257,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 40.8,
+      "latency_ms": 40.32,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -5268,7 +5268,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 63.21,
+      "latency_ms": 62.89,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -5279,7 +5279,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 120.72,
+      "latency_ms": 119.6,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -5290,7 +5290,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 96.18,
+      "latency_ms": 95.58,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -5301,7 +5301,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 133.93,
+      "latency_ms": 130.41,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -5312,7 +5312,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 70.13,
+      "latency_ms": 68.4,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -5323,7 +5323,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 71.2,
+      "latency_ms": 69.29,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -5334,7 +5334,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 49.74,
+      "latency_ms": 48.67,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -5345,7 +5345,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 209.11,
+      "latency_ms": 201.57,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -5356,7 +5356,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 34.27,
+      "latency_ms": 33.87,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -5367,7 +5367,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 85.31,
+      "latency_ms": 84.21,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -5378,7 +5378,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 47.9,
+      "latency_ms": 47.67,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -5389,7 +5389,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 36.66,
+      "latency_ms": 36.47,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -5400,7 +5400,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 43.46,
+      "latency_ms": 43.1,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -5411,7 +5411,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 102.76,
+      "latency_ms": 101.19,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -5422,7 +5422,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 122.01,
+      "latency_ms": 120.61,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -5433,7 +5433,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 61.47,
+      "latency_ms": 60.94,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -5444,7 +5444,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 60.74,
+      "latency_ms": 60.86,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -5455,7 +5455,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 151.74,
+      "latency_ms": 149.94,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -5466,7 +5466,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 146.03,
+      "latency_ms": 143.52,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -5477,7 +5477,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 39.43,
+      "latency_ms": 38.37,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -5488,7 +5488,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 23.81,
+      "latency_ms": 23.39,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -5499,7 +5499,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 77.62,
+      "latency_ms": 76.7,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -5510,7 +5510,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 55.76,
+      "latency_ms": 54.89,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -5521,7 +5521,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 66.6,
+      "latency_ms": 66.26,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -5532,7 +5532,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 169.58,
+      "latency_ms": 167.93,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -5543,7 +5543,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 76.68,
+      "latency_ms": 76.4,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -5554,7 +5554,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 67.72,
+      "latency_ms": 67.86,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -5565,7 +5565,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 81.41,
+      "latency_ms": 80.59,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -5576,7 +5576,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 159.81,
+      "latency_ms": 159.38,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -5587,7 +5587,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 46.22,
+      "latency_ms": 46.55,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -5598,7 +5598,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 45.42,
+      "latency_ms": 43.69,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -5609,7 +5609,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 39.38,
+      "latency_ms": 38.57,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -5620,7 +5620,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 212.75,
+      "latency_ms": 209.77,
       "expected_rules_matched": true,
       "category_correct": true
     },
@@ -5631,7 +5631,7 @@
       "detected": false,
       "rules_fired": [],
       "correct": true,
-      "latency_ms": 43.2,
+      "latency_ms": 42.79,
       "expected_rules_matched": true,
       "category_correct": true
     }
@@ -5647,7 +5647,7 @@
         "ATR-2026-00123"
       ],
       "correct": false,
-      "latency_ms": 37.55,
+      "latency_ms": 37.81,
       "expected_rules_matched": true,
       "category_correct": true
     }

--- a/scripts/gate-enforce-lane-evidence.ts
+++ b/scripts/gate-enforce-lane-evidence.ts
@@ -1,0 +1,258 @@
+#!/usr/bin/env node
+/**
+ * Enforce-lane evidence ratchet -- CI gate over every `maturity: stable` rule.
+ *
+ * WHAT IT MEASURES
+ *   docs/QUALITY-STANDARD.md defines STABLE as "Wild-validated, enterprise-ready
+ *   / confidence >= 80, wild FP rate <= 0.5%", and STABLE is the enforce lane:
+ *   auto-block, no human in the loop. That is the bar the project published for
+ *   itself.
+ *
+ *   Measured on 2026-08-09: 106 of 106 live stable rules fail it.
+ *
+ *       no `confidence` field at all      87
+ *       confidence < 80                    4
+ *       confidence >= 80, no wild evidence 15
+ *
+ *   None of that means the rules are bad. All 106 measure 0 false positives on
+ *   the 5,352-sample public benign corpus. What they lack is the evidence the
+ *   standard asks for — and the wild corpus that evidence comes from is private
+ *   and unavailable to CI, so the project structurally cannot produce it here.
+ *
+ * WHY THIS IS A RATCHET AND NOT A HARD GATE
+ *   Failing the build on 106 of 106 would either stop all work or, far more
+ *   likely, get the standard quietly edited until the numbers agree. The
+ *   honest options are (a) demote all 106 and empty the enforce lane, or (b)
+ *   change the standard to accept public-corpus evidence. Both are product
+ *   decisions with real consequences, and neither belongs in a gate.
+ *
+ *   So this does the third thing: it freezes the debt at its measured size,
+ *   names every rule in it, and fails the moment it grows. The gap stops being
+ *   silent without anyone having to pretend it is closed.
+ *
+ *   Do NOT widen the baseline to silence this. A new entry means a rule entered
+ *   the auto-block lane without the evidence the standard requires — which is
+ *   the exact thing the standard exists to prevent.
+ *
+ * WHY FULL-SET AND NOT PR-DIFF SCOPED
+ *   Same reasoning as gate-rule-status.ts: rules reach this repo through doors
+ *   no `git diff base...HEAD` can see (untracked files gated before commit, the
+ *   CVE collector committing straight to main). Comparing the working tree
+ *   against a committed baseline sees all of them and needs no git history.
+ *
+ * WHAT FAILS THE BUILD
+ *   - A stable rule fails the standard and is not in the baseline.
+ *   - A rule file cannot be parsed, or carries no `maturity`. "Cannot determine
+ *     the maturity" must never be reported as "not stable" — that is the class
+ *     of silent pass this repo has spent a week removing.
+ *
+ * WHAT DOES NOT FAIL THE BUILD
+ *   - A baselined rule still failing. That is the recorded debt.
+ *   - A baselined rule that now passes. Reported so the baseline can shrink.
+ *
+ * Usage:
+ *   npx tsx scripts/gate-enforce-lane-evidence.ts
+ *   npx tsx scripts/gate-enforce-lane-evidence.ts --write-baseline   # may only shrink
+ */
+import { readFileSync, readdirSync, statSync, writeFileSync, existsSync } from "node:fs";
+import { join, resolve, dirname, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+import { load as parseYaml } from "js-yaml";
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const RULES_DIR = join(REPO_ROOT, "rules");
+const BASELINE = join(REPO_ROOT, "data/enforce-lane-evidence-baseline.json");
+
+/** docs/QUALITY-STANDARD.md, the STABLE row. Not invented here. */
+export const STABLE_MIN_CONFIDENCE = 80;
+export const STABLE_MAX_WILD_FP_PCT = 0.5;
+
+export const EXIT_OK = 0;
+export const EXIT_FAIL = 1;
+
+export interface Shortfall {
+  readonly id: string;
+  readonly file: string;
+  readonly reasons: readonly string[];
+}
+
+interface Baseline {
+  readonly _comment?: string;
+  readonly measured_at?: string;
+  readonly rules?: Record<string, readonly string[]>;
+}
+
+function ruleFiles(dir: string): readonly string[] {
+  const out: string[] = [];
+  for (const e of readdirSync(dir)) {
+    const full = join(dir, e);
+    if (statSync(full).isDirectory()) out.push(...ruleFiles(full));
+    else if (e.endsWith(".yaml") || e.endsWith(".yml")) out.push(full);
+  }
+  return out;
+}
+
+/**
+ * Why a rule in the enforce lane does not meet the published bar.
+ *
+ * Returns an empty array when it does. Absent evidence counts as a shortfall,
+ * never as a pass: a missing `wild_fp_rate` is "never measured", which #433
+ * established after 230 rules carried a `0` that no run ever produced.
+ */
+export function shortfalls(rule: {
+  readonly maturity?: unknown;
+  readonly status?: unknown;
+  readonly confidence?: unknown;
+  readonly wild_fp_rate?: unknown;
+  readonly wild_samples?: unknown;
+}): readonly string[] {
+  const reasons: string[] = [];
+  const confidence = rule.confidence;
+  if (typeof confidence !== "number") {
+    reasons.push("no confidence field");
+  } else if (confidence < STABLE_MIN_CONFIDENCE) {
+    reasons.push(`confidence ${confidence} < ${STABLE_MIN_CONFIDENCE}`);
+  }
+  const wildFp = rule.wild_fp_rate;
+  if (typeof wildFp !== "number") {
+    reasons.push("no wild_fp_rate (never measured)");
+  } else if (wildFp > STABLE_MAX_WILD_FP_PCT) {
+    reasons.push(`wild_fp_rate ${wildFp} > ${STABLE_MAX_WILD_FP_PCT}`);
+  }
+  return Object.freeze(reasons);
+}
+
+function scan(): { readonly shortfalls: readonly Shortfall[]; readonly stableCount: number } {
+  const out: Shortfall[] = [];
+  let stableCount = 0;
+  for (const file of ruleFiles(RULES_DIR)) {
+    let doc: unknown;
+    try {
+      doc = parseYaml(readFileSync(file, "utf-8"));
+    } catch (e) {
+      // Unparseable is a shortfall, not a skip. Cannot-determine must never
+      // read as does-not-apply.
+      out.push({
+        id: relative(RULES_DIR, file),
+        file: relative(REPO_ROOT, file),
+        reasons: [`unparseable: ${String(e).slice(0, 80)}`],
+      });
+      continue;
+    }
+    const r = doc as Record<string, unknown>;
+    if (typeof r?.id !== "string") continue;
+    const maturity = r.maturity;
+    if (typeof maturity !== "string") {
+      out.push({
+        id: r.id,
+        file: relative(REPO_ROOT, file),
+        reasons: ["no maturity field — cannot tell which lane this runs in"],
+      });
+      continue;
+    }
+    if (maturity !== "stable") continue;
+    const status = String(r.status ?? "");
+    if (status === "draft" || status === "deprecated") continue; // inert, no lane
+    stableCount++;
+    const reasons = shortfalls(r as never);
+    if (reasons.length > 0) {
+      out.push({ id: r.id, file: relative(REPO_ROOT, file), reasons });
+    }
+  }
+  return {
+    shortfalls: Object.freeze(out.sort((a, b) => a.id.localeCompare(b.id))),
+    stableCount,
+  };
+}
+
+function readBaseline(): Baseline {
+  if (!existsSync(BASELINE)) return {};
+  try {
+    return JSON.parse(readFileSync(BASELINE, "utf-8")) as Baseline;
+  } catch {
+    return {};
+  }
+}
+
+function main(argv: readonly string[]): number {
+  const { shortfalls: found, stableCount } = scan();
+  const baseline = readBaseline();
+  const known = new Set(Object.keys(baseline.rules ?? {}));
+
+  if (argv.includes("--write-baseline")) {
+    const current = new Set(found.map((s) => s.id));
+    const grown = [...current].filter((id) => !known.has(id));
+    if (known.size > 0 && grown.length > 0) {
+      console.error(
+        `[enforce-evidence] REFUSING to write — the baseline may only shrink.\n` +
+          `${grown.length} rule(s) would be newly recorded as lacking the evidence\n` +
+          `docs/QUALITY-STANDARD.md requires for the auto-block lane:\n` +
+          grown.map((id) => `  + ${id}`).join("\n"),
+      );
+      return EXIT_FAIL;
+    }
+    writeFileSync(
+      BASELINE,
+      JSON.stringify(
+        {
+          _comment:
+            "Rules in the enforce (auto-block) lane that do not meet the STABLE bar " +
+            "published in docs/QUALITY-STANDARD.md (confidence >= 80, wild FP rate <= 0.5%). " +
+            "This file records existing debt so it stops being silent. Do NOT add entries " +
+            "to silence the gate — a new entry means a rule reached the auto-block lane " +
+            "without the evidence the standard requires. Entries may only be removed, by " +
+            "producing the evidence or by demoting the rule.",
+          measured_at: new Date().toISOString().slice(0, 10),
+          stable_rules_total: stableCount,
+          rules: Object.fromEntries(found.map((s) => [s.id, s.reasons])),
+        },
+        null,
+        2,
+      ) + "\n",
+    );
+    console.log(
+      `[enforce-evidence] baseline written: ${found.length} of ${stableCount} stable rule(s)`,
+    );
+    return EXIT_OK;
+  }
+
+  const novel = found.filter((s) => !known.has(s.id));
+  const fixed = [...known].filter((id) => !found.some((s) => s.id === id));
+
+  console.log(
+    `[enforce-evidence] ${stableCount} rule(s) in the enforce lane; ` +
+      `${found.length} do not meet docs/QUALITY-STANDARD.md (baseline ${known.size})`,
+  );
+  if (fixed.length > 0) {
+    console.log(
+      `\nRATCHET — these now meet the bar and should be removed from the baseline:`,
+    );
+    for (const id of fixed.sort()) console.log(`  + ${id}`);
+    console.log(`  (run --write-baseline to tighten)`);
+  }
+  if (novel.length === 0) {
+    console.log(
+      `\nGATE PASS -- no rule newly entered the auto-block lane without evidence.`,
+    );
+    return EXIT_OK;
+  }
+  console.error(
+    `\n[enforce-evidence] FAIL — ${novel.length} rule(s) are in the enforce lane ` +
+      `(maturity: stable = auto-block, no human in the loop) without the evidence\n` +
+      `docs/QUALITY-STANDARD.md requires. Absent evidence is not clean evidence:`,
+  );
+  for (const s of novel) {
+    console.error(`  ${s.id}  ${s.file}`);
+    for (const r of s.reasons) console.error(`      ${r}`);
+  }
+  console.error(
+    `\nEither produce the evidence, or set maturity to test/experimental until it exists.\n` +
+      `Do NOT widen the baseline to silence this.`,
+  );
+  return EXIT_FAIL;
+}
+
+const INVOKED_DIRECTLY =
+  process.argv[1] !== undefined &&
+  resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url));
+if (INVOKED_DIRECTLY) process.exitCode = main(process.argv.slice(2));


### PR DESCRIPTION
`docs/QUALITY-STANDARD.md` defines STABLE as *"Wild-validated, enterprise-ready / confidence >= 80, wild FP rate <= 0.5%"*, and STABLE **is** the enforce lane — auto-block, no human in the loop.

**106 of 106 live stable rules fail that bar.**

```
no confidence field at all        87
confidence < 80                    4
confidence >= 80, no wild evidence 15
```

## The rules are not bad

All 106 measure **zero false positives** on the 5,352-sample public benign corpus. What they lack is the *evidence the standard asks for* — and the wild corpus that evidence comes from is private and unreachable from CI, so the project structurally cannot produce it here.

The last group only became visible when #433 stripped 230 `wild_fp_rate: 0` values that no run ever produced. Before that they "passed" on a number nobody measured. **#433 did not create this gap; it made it legible.**

## Why a ratchet and not a hard gate

A hard gate on 106 of 106 would either stop all work or — far more likely — get the standard quietly edited until the numbers agree. That second outcome is the one worth naming, because it is how a bar becomes decorative.

The two honest fixes are both product decisions:

- **demote all 106** — the enforce lane goes to zero, and PanGuard's auto-block mode loses all detection
- **change the standard** — accept public-corpus evidence as sufficient for STABLE, which lowers a bar the project set deliberately (5,352 clean samples only establishes a true rate below roughly 0.056% by rule of three)

Neither belongs in a gate. So this does the third thing: **freeze the debt at its measured size, name every rule in it, and fail the moment it grows.** The gap stops being silent without anyone pretending it is closed.

Same shape as `rule-status-gate.yml` and `re2-portability.yml`, which exist for the same reason.

## Verified by breaking it, both directions

```
promote an unmeasured rule to stable        exit 1   (blocked)
launder it via --write-baseline             exit 1   (refused — baseline may only shrink)
restore                                     exit 0
```

## Absent evidence is a shortfall, never a pass

Including an unparseable rule file, or one with no `maturity`. **"Cannot determine which lane this runs in" must not read as "does not apply"** — that is precisely the class of silent pass this repo has spent the week removing (`?? 0` in `compute-confidence`, the non-recursive corpus loader, the shadow matcher, the truncated id list).

## What this does not do

It does not demote anything, does not touch a single rule file, and does not change what the engine detects. `data/enforce-lane-evidence-baseline.json` is a record, not an exemption — and the file says so in its own `_comment`, because the next person to hit a red build will be tempted to add a line.

## Verification

```
validate-rules   783 passed
vitest           945 passed, 3 skipped
tsc              clean
gate             106 recorded, exit 0 frozen; exit 1 on growth
```
