### PR TITLE
docs(rules): cite empirical basis for the Article 50 marking-removal threat model

### DIFF
--- a/rules/model-abuse/ATR-2026-02411-ai-provenance-metadata-stripping.yaml
+++ b/rules/model-abuse/ATR-2026-02411-ai-provenance-metadata-stripping.yaml
@@ -48,6 +48,14 @@ references:
     - "https://exiftool.org/"
     - "https://spec.c2pa.org/specifications/specifications/2.1/specs/C2PA_Specification.html"
     - "https://cv.iptc.org/newscodes/digitalsourcetype/"
+    # Rijsbosch, van Dijck & Kollnig (Maastricht Law & Tech Lab), "Missing the
+    # Mark", Policy & Internet 2026 (DOI 10.1002/poi3.70041). Empirical basis
+    # for this rule's threat model: measuring 50 generative-image systems, it
+    # finds provenance metadata "can be easily manipulated or removed" and is
+    # "automatically stripped" when shared to platforms, and marking "easy to
+    # disable by commenting out a line of code". Motivates why removal
+    # detection is necessary; not a source for the detection technique itself.
+    - "https://arxiv.org/abs/2503.18156"
 
 compliance:
   eu_ai_act:

--- a/rules/model-abuse/ATR-2026-02412-generative-watermark-removal-tooling.yaml
+++ b/rules/model-abuse/ATR-2026-02412-generative-watermark-removal-tooling.yaml
@@ -41,6 +41,11 @@ references:
   external:
     - "https://deepmind.google/technologies/synthid/"
     - "https://github.com/adobe/trustmark"
+    # Rijsbosch, van Dijck & Kollnig, "Missing the Mark", Policy & Internet
+    # 2026 (DOI 10.1002/poi3.70041): of 50 generative-image systems, only 38%
+    # carried a conformant machine-readable watermark — context for why a
+    # marking that is present is worth defending against removal tooling.
+    - "https://arxiv.org/abs/2503.18156"
 
 compliance:
   eu_ai_act:


### PR DESCRIPTION
When ATR-2026-02411 and 02412 were written, their threat model — that Article 50(2) machine-readable markings are, in practice, easy to strip — was argued structurally (the trailing `=` that separates an exiftool read from a delete) but had no external empirical anchor. The PR body at the time said as much.

This adds one, surfaced since: **Rijsbosch, van Dijck & Kollnig, "Missing the Mark: Adoption of Watermarking for Generative AI Systems in Practice and Implications Under the New EU AI Act"** — Maastricht University Law & Tech Lab, peer-reviewed in *Policy & Internet* 2026 (DOI [10.1002/poi3.70041](https://doi.org/10.1002/poi3.70041), preprint [arXiv 2503.18156](https://arxiv.org/abs/2503.18156)).

Across 50 generative-image systems it finds only 38% carry a conformant machine-readable watermark, that provenance metadata is "automatically stripped" on platform upload, and that marking is "easy to disable by commenting out a line of code". That is exactly the premise these two rules act on.

## Scope

- Added to the `external` references of **02411** (metadata stripping — the paper's metadata-strip finding maps directly) and **02412** (watermark removal tooling — weaker but relevant: it quantifies how rarely a robust mark is even present).
- **Not** added to 02413 (AI-text detection evasion). The paper is about image watermarking; citing it there would be a stretch.
- Each reference carries a comment scoping it: it motivates *why* removal detection is necessary (threat premise); it is **not** a source for the detection technique. A policy-and-measurement paper cannot validate detection logic, and this repo does not pretend otherwise.

## Why it clears the citeability bar

This repo spent last week removing references to identifiers and sources that could not be verified. This one is peer-reviewed with a resolvable DOI and a live arXiv id — the standard the cleanup set.

## Checks

```
tests/validate-rules.ts        783 passed, 0 failed
scripts/validate-compliance.ts 0 violations
diff                           2 files, 13 insertions, comment + one URL each
```

No detection logic, condition, test case or severity is touched.
