### PR TITLE
docs(maestro): refresh the CSA MAESTRO mapping to current corpus

### DIFF
--- a/docs/CSA-MAESTRO-MAPPING.md
+++ b/docs/CSA-MAESTRO-MAPPING.md
@@ -1,7 +1,8 @@
 # ATR → CSA MAESTRO Layer Mapping
 
-Last updated: 2026-07-12
-ATR corpus: v3.5.8, 747 rules (10 categories)
+Last updated: 2026-08-11
+ATR corpus: v3.5.12, 777 effective rules (784 files, 10 categories)
+> Rule counts are a dated snapshot and move daily (auto-crystallize + ecosystem PRs); for the live figure see stats.json on the ATR repo.
 Source framework: **MAESTRO — Multi-Agent Environment, Security, Threat, Risk & Outcome**,
 Cloud Security Alliance (2025). A layered threat-modeling framework for agentic AI that
 decomposes an agent system into seven architectural layers, each with its own threat
@@ -28,13 +29,13 @@ surface. Reference: https://cloudsecurityalliance.org/blog/2025/02/06/agentic-ai
 
 | MAESTRO layer | Threat surface | Primary ATR categories | Rules |
 |---|---|---|---|
-| **L1 Foundation Models** | The LLM itself: jailbreak, model manipulation, behavior extraction | model-abuse, model-security, prompt-injection (direct) | 41 + PI |
-| **L2 Data Operations** | RAG, memory, embeddings, training/ingested data | data-poisoning, context-exfiltration, prompt-injection (indirect) | 126 + PI |
-| **L3 Agent Frameworks** | Tool-calling, planning, skill/plugin runtime | tool-poisoning, excessive-autonomy, skill-compromise | 175 |
-| **L4 Deployment & Infrastructure** | Hosting, sandboxing, host privileges, persistence | privilege-escalation | 51 |
-| **L5 Evaluation & Observability** | Detection, monitoring, runtime evidence | *(ATR is this layer)* — all 747 | 747 |
-| **L6 Security & Compliance** *(cross-cutting)* | Regulatory obligation + control evidence across all layers | *(ATR compliance block)* — all 747 | 747 |
-| **L7 Agent Ecosystem** | Multi-agent interaction, inter-agent trust, marketplace/supply chain | agent-manipulation, skill-compromise (supply chain) | 153 |
+| **L1 Foundation Models** | The LLM itself: jailbreak, model manipulation, behavior extraction | model-abuse, model-security, prompt-injection (direct) | 44 + PI |
+| **L2 Data Operations** | RAG, memory, embeddings, training/ingested data | data-poisoning, context-exfiltration, prompt-injection (indirect) | 134 + PI |
+| **L3 Agent Frameworks** | Tool-calling, planning, skill/plugin runtime | tool-poisoning, excessive-autonomy, skill-compromise | 189 |
+| **L4 Deployment & Infrastructure** | Hosting, sandboxing, host privileges, persistence | privilege-escalation | 60 |
+| **L5 Evaluation & Observability** | Detection, monitoring, runtime evidence | *(ATR is this layer)* — all 777 | 777 |
+| **L6 Security & Compliance** *(cross-cutting)* | Regulatory obligation + control evidence across all layers | *(ATR compliance block)* — all 777 | 777 |
+| **L7 Agent Ecosystem** | Multi-agent interaction, inter-agent trust, marketplace/supply chain | agent-manipulation, skill-compromise (supply chain) | 156 |
 
 Every ATR rule maps to at least one horizontal layer (L1–L4, L7) **and** contributes to the two
 cross-cutting layers (L5 detection, L6 compliance), which is MAESTRO's intended shape: the
@@ -47,15 +48,15 @@ security/observability layers are vertical concerns that intersect every functio
 ### L1 — Foundation Models
 The model's own attack surface: adversarial prompts that alter model behavior, jailbreaks that
 defeat safety training, and extraction of model behavior or system configuration.
-- **model-abuse** (38) — jailbreak, safety-bypass, adversarial output shaping
+- **model-abuse** (41) — jailbreak, safety-bypass, adversarial output shaping
 - **model-security** (3) — model tampering / deserialization / weight-level threats
-- **prompt-injection** (direct subset of 246) — instruction-override delivered straight to the model input
+- **prompt-injection** (direct subset of 249) — instruction-override delivered straight to the model input
 
 ### L2 — Data Operations
 Threats in the data plane the agent reads and writes: RAG corpora, long-term memory, embeddings,
 and any ingested content the model treats as trusted context.
-- **data-poisoning** (7) — RAG / knowledge-base / memory contamination
-- **context-exfiltration** (119) — credential/secret/PII leaving through the agent's context
+- **data-poisoning** (9) — RAG / knowledge-base / memory contamination
+- **context-exfiltration** (125) — credential/secret/PII leaving through the agent's context
 - **prompt-injection** (indirect subset) — payloads embedded in retrieved documents, tool output, or memory
 
 ### L3 — Agent Frameworks
@@ -70,7 +71,7 @@ The host the agent runs on: sandbox escape, privilege boundaries, and startup/pe
 - **privilege-escalation** (51) — scope escalation, sandbox escape, autostart/persistence, host-level RCE
 
 ### L5 — Evaluation & Observability *(cross-cutting)*
-MAESTRO's detection and monitoring layer. **ATR is a realization of this layer**: 747 deterministic
+MAESTRO's detection and monitoring layer. **ATR is a realization of this layer**: 777 deterministic
 rules that run over SKILL.md files, MCP tool descriptions, tool arguments, agent I/O, and behavioral
 traces, emitting rule-ID-tagged findings suitable for SIEM ingestion (MISP taxonomy, Sigma).
 
@@ -89,7 +90,7 @@ trust, and the skill/tool marketplace supply chain.
 ---
 
 ## Notes & caveats
-- This is a first-pass architectural mapping produced against ATR v3.5.8 (747 rules). MAESTRO layer
+- This is a first-pass architectural mapping produced against ATR v3.5.12 (777 effective rules). MAESTRO layer
   names follow the CSA 2025 framework; MAESTRO V2 (expected 2026) may refine per-layer threat detail,
   at which point this crosswalk should be re-validated.
 - "Rules" counts are the size of each contributing ATR category, not a per-rule layer-exclusivity claim.


### PR DESCRIPTION
The ATR->MAESTRO layer mapping was pinned at v3.5.8 / 747 rules. Re-synced to current main (v3.5.12, 777 effective / 784 files). Numbers only — layer structure and the cross-layer argument unchanged. Added a line noting the counts are a dated snapshot that moves daily, pointing readers to stats.json for the live figure.

Refreshed ahead of surfacing this mapping in CSA/MAESTRO issue #5 so the linked figures resolve against the current corpus.