### PR TITLE
feat(atlas): map the four tool-poisoning rules to AML.T0110.000

### DIFF
--- a/docs/crosswalks/atr-attack-crosswalk.md
+++ b/docs/crosswalks/atr-attack-crosswalk.md
@@ -32,7 +32,7 @@ columns are still extracted from ATR metadata, not authored here.
 - Rules carrying an enterprise ATT&CK id (`references.mitre_attack` Txxxx): 197
 - Distinct enterprise ATT&CK techniques referenced: 80
 - Rules carrying a MITRE ATLAS id (`references.mitre_atlas`): 784
-- Distinct MITRE ATLAS techniques referenced: 43
+- Distinct MITRE ATLAS techniques referenced: 44
 - Rules carrying an OWASP Agentic id (`references.owasp_agentic`): 784
 - ATR categories (distinct `tags.category` values): 9
 
@@ -389,7 +389,7 @@ ATT&CK techniques (join key):
 | T1552 | Unsecured Credentials | `ATR-2026-00534`, `ATR-2026-01931` |
 | T1552.001 | Credentials In Files | `ATR-2026-00576` |
 
-ATLAS techniques ATR adds: AML.T0010, AML.T0010.005, AML.T0019, AML.T0024, AML.T0040, AML.T0049, AML.T0051, AML.T0051.001, AML.T0053, AML.T0056, AML.T0057, AML.T0069, AML.T0070, AML.T0104, AML.T0110
+ATLAS techniques ATR adds: AML.T0010, AML.T0010.005, AML.T0019, AML.T0024, AML.T0040, AML.T0049, AML.T0051, AML.T0051.001, AML.T0053, AML.T0056, AML.T0057, AML.T0069, AML.T0070, AML.T0104, AML.T0110.000, {'AML.T0110.000
 
 OWASP Agentic categories ATR adds: ASI01:2026, ASI02:2026, ASI03:2026, ASI04:2026, ASI05:2026, ASI06:2026, ASI07:2026, ASI08:2026, ASI09:2026
 

--- a/rules/tool-poisoning/ATR-2026-00103-hidden-safety-bypass-instruction.yaml
+++ b/rules/tool-poisoning/ATR-2026-00103-hidden-safety-bypass-instruction.yaml
@@ -23,7 +23,7 @@ references:
     - ASI01:2026
   mitre_atlas:
     - AML.T0051 - LLM Prompt Injection
-    - AML.T0110 - AI Agent Tool Poisoning
+    - AML.T0110.000 - AI Agent Tool Poisoning: Definition and Instructions
 compliance:
   nist_ai_rmf:
     - subcategory: "MS.2.6"

--- a/rules/tool-poisoning/ATR-2026-00161-important-tag-cross-tool-shadowing.yaml
+++ b/rules/tool-poisoning/ATR-2026-00161-important-tag-cross-tool-shadowing.yaml
@@ -32,7 +32,7 @@ references:
   mitre_atlas:
     - "AML.T0051.001 - Indirect"
     - "AML.T0053 - AI Agent Tool Invocation"
-    - "AML.T0110 - AI Agent Tool Poisoning"
+    - "AML.T0110.000 - AI Agent Tool Poisoning: Definition and Instructions"
     - "AML.T0104 - Publish Poisoned AI Agent Tool"
   safe_mcp:
     - "SAF-T1102"

--- a/rules/tool-poisoning/ATR-2026-01775-semantic-mcp-tool-manifest-poisoning.yaml
+++ b/rules/tool-poisoning/ATR-2026-01775-semantic-mcp-tool-manifest-poisoning.yaml
@@ -44,7 +44,7 @@ references:
     - "AML.T0053 - AI Agent Tool Invocation"
     - "AML.T0019 - Publish Poisoned Datasets"
     - "AML.T0051.001 - Indirect"
-    - "AML.T0110 - AI Agent Tool Poisoning"
+    - "AML.T0110.000 - AI Agent Tool Poisoning: Definition and Instructions"
 
 compliance:
   nist_ai_rmf:

--- a/rules/tool-poisoning/ATR-2026-02025-mcp-full-schema-poisoning-nondescription-field.yaml
+++ b/rules/tool-poisoning/ATR-2026-02025-mcp-full-schema-poisoning-nondescription-field.yaml
@@ -36,7 +36,7 @@ references:
     - "ASI03:2026"
   mitre_atlas:
     - "AML.T0051.001 - Indirect"
-    - "AML.T0110 - AI Agent Tool Poisoning"
+    - "AML.T0110.000 - AI Agent Tool Poisoning: Definition and Instructions"
     - "AML.T0104 - Publish Poisoned AI Agent Tool"
   safe_mcp:
     - "SAF-T1001"


### PR DESCRIPTION
MITRE ATLAS v2026.07 split AI Agent Tool Poisoning (`AML.T0110`) into three sub-techniques. This maps ATR's four T0110 rules to the one they earn.

## The three sub-techniques are three detection surfaces

- **`.000` Definition and Instructions** — poisoned static declarations: descriptions, docstrings, parameter names, schemas, annotations, manifests, skill files. Also covers tool shadowing.
- **`.001` Implementation** — poisoned executable code: the tool works as described but adds a silent BCC, exfiltrates, weakens a control. A regex over a manifest structurally cannot see this.
- **`.002` Runtime Response** — the tool's response stream deliberately carries content to steer the model after an approved call.

## Why all four map to `.000`, not spread across the three

The four rules currently on the parent all scan the **declaration** layer — tool descriptions, MCP manifests, schemas, non-description schema fields. That is `.000` verbatim, and `ATR-2026-00161` is a textbook tool-shadowing case, which `.000` names explicitly.

None of the four inspect executable behaviour (`.001`) or tool responses (`.002`). Spreading them across all three to look differentiated would be over-mapping. Mapping all four to `.000` is both the most-specific technique they earn and an honest signal of coverage shape: **ATR's tool-poisoning static rules sit at the definition layer; `.001` and `.002` are not yet covered.**

## Verified

Sub-technique IDs and definitions read from the ATLAS `CHANGELOG.md` on main (created 2026-07-31). The website pages 404 because v2026.07 is freshly published, but the data layer is authoritative.

```
crosswalk regenerated from rule metadata (generate-attack-crosswalk.py); --check passes
784 rules validate, 0 failed · 0 compliance violations
reference id only — no detection logic, condition or test case changed
```
