### PR TITLE
atd: CVE ingest 2026-08-13 — {proposalsConsidered:3968,enrichments:2135,techniquesTouched:24,newTechniqueCandidatesRaw:1164,eligibleClusters:57,newTechniqueDraftsGenerated:0,newTechniqueDraftsDropped:10}

### DIFF
--- a/data/atd-ingest/candidates-2026-08-13.json
+++ b/data/atd-ingest/candidates-2026-08-13.json
@@ -1,0 +1,11742 @@
+{
+  "generated": "2026-08-13T07:21:59.991Z",
+  "candidates": [
+    {
+      "cve": "CVE-2024-0132",
+      "cwes": [
+        "CWE-367"
+      ],
+      "title": "NVIDIA Container Toolkit 1 (AVID-2026-R0001)",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "critical",
+      "file": "avid/AVID-2026-R0001.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2024-10513",
+      "cwes": [
+        "CWE-23"
+      ],
+      "title": "A path traversal vulnerability exists in the 'document uploads manager' feature  (AVID-2026-R0006)",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "avid/AVID-2026-R0006.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2024-10831",
+      "cwes": [
+        "CWE-36"
+      ],
+      "title": "In eosphoros-ai/db-gpt version 0 (AVID-2026-R0011)",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "critical",
+      "file": "avid/AVID-2026-R0011.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2024-10833",
+      "cwes": [
+        "CWE-36"
+      ],
+      "title": "eosphoros-ai/db-gpt version 0 (AVID-2026-R0012)",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "critical",
+      "file": "avid/AVID-2026-R0012.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-23359",
+      "cwes": [
+        "CWE-367"
+      ],
+      "title": "NVIDIA Container Toolkit for Linux contains a Time-of-Check Time-of-Use (TOCTOU) (AVID-2026-R0042)",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "avid/AVID-2026-R0042.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-2450",
+      "cwes": [
+        "CWE-356"
+      ],
+      "title": "NI Vision Builder AI VBAI File Processing Missing Warning Remote Code Execution  (AVID-2026-R0043)",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "avid/AVID-2026-R0043.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2021-21677",
+      "cwes": [],
+      "title": "Jenkins Code Coverage API Plugin 1 (AVID-2026-R0716)",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "avid/AVID-2026-R0716.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2021-22205",
+      "cwes": [],
+      "title": "An issue has been discovered in GitLab CE/EE affecting all versions starting fro (AVID-2026-R0717)",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "critical",
+      "file": "avid/AVID-2026-R0717.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2021-23338",
+      "cwes": [],
+      "title": "This affects all versions of package qlib (AVID-2026-R0719)",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "avid/AVID-2026-R0719.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2021-25646",
+      "cwes": [],
+      "title": "Apache Druid includes the ability to execute user-provided JavaScript code embed (AVID-2026-R0720)",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "avid/AVID-2026-R0720.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2021-26919",
+      "cwes": [],
+      "title": "Apache Druid allows users to read data from other database systems using JDBC (AVID-2026-R0722)",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "avid/AVID-2026-R0722.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2021-29730",
+      "cwes": [],
+      "title": "IBM InfoSphere Information Server 11 (AVID-2026-R0811)",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "avid/AVID-2026-R0811.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2021-31681",
+      "cwes": [],
+      "title": "Deserialization of Untrusted Data vulnerability in yolo 3 allows attackers to ex (AVID-2026-R0812)",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "avid/AVID-2026-R0812.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2021-32635",
+      "cwes": [
+        "CWE-923",
+        "CWE-20"
+      ],
+      "title": "Singularity is an open source container platform (AVID-2026-R0813)",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "avid/AVID-2026-R0813.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2021-36774",
+      "cwes": [],
+      "title": "Apache Kylin allows users to read data from other database systems using JDBC (AVID-2026-R0821)",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "avid/AVID-2026-R0821.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2021-37663",
+      "cwes": [
+        "CWE-20"
+      ],
+      "title": "TensorFlow is an end-to-end open source platform for machine learning (AVID-2026-R0853)",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "avid/AVID-2026-R0853.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2021-37665",
+      "cwes": [
+        "CWE-20"
+      ],
+      "title": "TensorFlow is an end-to-end open source platform for machine learning (AVID-2026-R0855)",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "avid/AVID-2026-R0855.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2021-37673",
+      "cwes": [
+        "CWE-20"
+      ],
+      "title": "TensorFlow is an end-to-end open source platform for machine learning (AVID-2026-R0863)",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "avid/AVID-2026-R0863.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2021-37674",
+      "cwes": [
+        "CWE-20"
+      ],
+      "title": "TensorFlow is an end-to-end open source platform for machine learning (AVID-2026-R0864)",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "avid/AVID-2026-R0864.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2021-37677",
+      "cwes": [
+        "CWE-20"
+      ],
+      "title": "TensorFlow is an end-to-end open source platform for machine learning (AVID-2026-R0867)",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "avid/AVID-2026-R0867.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2021-37692",
+      "cwes": [
+        "CWE-20"
+      ],
+      "title": "TensorFlow is an end-to-end open source platform for machine learning (AVID-2026-R0878)",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "avid/AVID-2026-R0878.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2021-38294",
+      "cwes": [
+        "CWE-74"
+      ],
+      "title": "A Command Injection vulnerability exists in the getTopologyHistory service of th (AVID-2026-R0879)",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "avid/AVID-2026-R0879.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2021-3869",
+      "cwes": [
+        "CWE-611"
+      ],
+      "title": "corenlp is vulnerable to Improper Restriction of XML External Entity Reference R (AVID-2026-R0881)",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "avid/AVID-2026-R0881.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2021-3878",
+      "cwes": [
+        "CWE-611"
+      ],
+      "title": "corenlp is vulnerable to Improper Restriction of XML External Entity Reference R (AVID-2026-R0882)",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "critical",
+      "file": "avid/AVID-2026-R0882.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2021-41215",
+      "cwes": [
+        "CWE-476"
+      ],
+      "title": "TensorFlow is an open source platform for machine learning (AVID-2026-R0906)",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "avid/AVID-2026-R0906.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2021-41561",
+      "cwes": [
+        "CWE-20"
+      ],
+      "title": "Improper Input Validation vulnerability in Parquet-MR of Apache Parquet allows a (AVID-2026-R0919)",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "avid/AVID-2026-R0919.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2021-42343",
+      "cwes": [],
+      "title": "An issue was discovered in the Dask distributed package before 2021 (AVID-2026-R0920)",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "avid/AVID-2026-R0920.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2021-42951",
+      "cwes": [],
+      "title": "A Remote Code Execution (RCE) vulnerability exists in Algorithmia MSOL all versi (AVID-2026-R0921)",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "avid/AVID-2026-R0921.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2021-42969",
+      "cwes": [],
+      "title": "Certain Anaconda3 2021 (AVID-2026-R0922)",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "avid/AVID-2026-R0922.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2021-43225",
+      "cwes": [],
+      "title": "Bot Framework SDK Remote Code Execution Vulnerability Reason for inclusion in AV (AVID-2026-R0923)",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "avid/AVID-2026-R0923.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2021-44164",
+      "cwes": [
+        "CWE-434"
+      ],
+      "title": "Chain Sea ai chatbot system’s file upload function has insufficient filtering fo (AVID-2026-R0926)",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "critical",
+      "file": "avid/AVID-2026-R0926.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2021-44832",
+      "cwes": [
+        "CWE-20",
+        "CWE-74"
+      ],
+      "title": "Apache Log4j2 versions 2 (AVID-2026-R0928)",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "avid/AVID-2026-R0928.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2022-0198",
+      "cwes": [
+        "CWE-611"
+      ],
+      "title": "corenlp is vulnerable to Improper Restriction of XML External Entity Reference R (AVID-2026-R0932)",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "avid/AVID-2026-R0932.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2022-1423",
+      "cwes": [],
+      "title": "Improper access control in the CI/CD cache mechanism in GitLab CE/EE affecting a (AVID-2026-R0936)",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "avid/AVID-2026-R0936.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2022-21820",
+      "cwes": [
+        "CWE-20"
+      ],
+      "title": "NVIDIA DCGM contains a vulnerability in nvhostengine, where a network user can c (AVID-2026-R0956)",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "avid/AVID-2026-R0956.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2022-21821",
+      "cwes": [
+        "CWE-1285"
+      ],
+      "title": "NVIDIA CUDA Toolkit SDK contains an integer overflow vulnerability in cuobjdump (AVID-2026-R0957)",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "avid/AVID-2026-R0957.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2022-2185",
+      "cwes": [],
+      "title": "A critical issue has been discovered in GitLab affecting all versions starting f (AVID-2026-R0959)",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "critical",
+      "file": "avid/AVID-2026-R0959.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2022-22984",
+      "cwes": [],
+      "title": "The package snyk before 1 (AVID-2026-R0961)",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "avid/AVID-2026-R0961.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2022-24280",
+      "cwes": [
+        "CWE-20"
+      ],
+      "title": "Improper Input Validation vulnerability in Proxy component of Apache Pulsar allo (AVID-2026-R0997)",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "avid/AVID-2026-R0997.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2022-25201",
+      "cwes": [],
+      "title": "Missing permission checks in Jenkins Checkmarx Plugin 2022 (AVID-2026-R1002)",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "avid/AVID-2026-R1002.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-18656",
+      "cwes": [],
+      "title": "CVE-2026-18656 & CVE-2026-18657 - Issue with Kiro IDE and CLI - Executable Resolution from Untrusted Project Directory o",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "aws-psirt/CVE-2026-18656.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-18953",
+      "cwes": [],
+      "title": "CVE-2026-18953 - Improper limitation of a pathname in AWS Transform MCP Server",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "aws-psirt/CVE-2026-18953.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-4295",
+      "cwes": [],
+      "title": "Arbitrary code execution via crafted project files in Kiro IDE",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "aws-psirt/CVE-2026-4295.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-7191",
+      "cwes": [],
+      "title": "CVE-2026-7191- Arbitrary Code Execution via Sandbox Bypass in QnABot on AWS",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "aws-psirt/CVE-2026-7191.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-14890",
+      "cwes": [],
+      "title": "SGLang contains a vulnerable pickle deserialization vulnerability through the expert-parallel subsystem",
+      "proposedTactic": "ATD-TA4",
+      "category": "privilege-escalation",
+      "severity": "critical",
+      "file": "certcc/CVE-2026-14890.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-30040",
+      "cwes": [],
+      "title": "Multiple file parsing vulnerabilities in FastStone Image Viewer 8.3.0.0",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "critical",
+      "file": "certcc/CVE-2026-30040.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-5757",
+      "cwes": [],
+      "title": "Ollama GGUF Quantization Remote Memory Leak",
+      "proposedTactic": "ATD-TA2",
+      "category": "context-exfiltration",
+      "severity": "high",
+      "file": "certcc/CVE-2026-5757.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-7301",
+      "cwes": [],
+      "title": "SGLang contains two remote code execution and one path traversal vulnerability",
+      "proposedTactic": "ATD-TA2",
+      "category": "context-exfiltration",
+      "severity": "critical",
+      "file": "certcc/CVE-2026-7301.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2024-8695",
+      "cwes": [],
+      "title": "Docker Desktop 4.34.2 Security Update: CVE-2024-8695 and CVE-2024-8696",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "critical",
+      "file": "docker-psirt/CVE-2024-8695.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2024-8696",
+      "cwes": [],
+      "title": "Docker Desktop 4.34.2 Security Update: CVE-2024-8695 and CVE-2024-8696",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "critical",
+      "file": "docker-psirt/CVE-2024-8696.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-33990",
+      "cwes": [],
+      "title": "Docker Desktop 4.67.0 security update: CVE-2026-33990",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "docker-psirt/CVE-2026-33990.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-5843",
+      "cwes": [],
+      "title": "Docker Desktop 4.71.0 security update: CVE-2026-5843",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "critical",
+      "file": "docker-psirt/CVE-2026-5843.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2002-2179",
+      "cwes": [],
+      "title": "The dynamic initialization feature of the ClearPath MCP environment allows remote attackers to cause a denial of service",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2002-2179.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2005-2321",
+      "cwes": [],
+      "title": "PHP remote file inclusion vulnerability in CaLogic 1",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2005-2321.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2006-2085",
+      "cwes": [],
+      "title": "Multiple buffer overflows in (1) CxAce60",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2006-2085.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2006-2263",
+      "cwes": [],
+      "title": "SQL injection vulnerability in shopcurrency",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2006-2263.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2006-3270",
+      "cwes": [],
+      "title": "SQL injection vulnerability in cms_admin",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2006-3270.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2006-5383",
+      "cwes": [],
+      "title": "SQL injection vulnerability in comadd",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2006-5383.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2008-2742",
+      "cwes": [],
+      "title": "Unrestricted file upload in the mcpuk file editor (atk/attributes/fck/editor/filemanager/browser/mcpuk/connectors/php/co",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2008-2742.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2009-0341",
+      "cwes": [],
+      "title": "The shell32 module in Microsoft Internet Explorer 7",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2009-0341.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2009-1608",
+      "cwes": [],
+      "title": "Multiple buffer overflows in Microchip MPLAB IDE 8",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2009-1608.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2009-1674",
+      "cwes": [],
+      "title": "Stack-based buffer overflow in Microchip MPLAB IDE 8",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2009-1674.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2011-0516",
+      "cwes": [],
+      "title": "SQL injection vulnerability in mainx_a",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2011-0516.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2011-0657",
+      "cwes": [],
+      "title": "DNSAPI",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "critical",
+      "file": "euvd/CVE-2011-0657.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2013-3602",
+      "cwes": [],
+      "title": "SQL injection vulnerability in admindocumentworker",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2013-3602.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2014-4060",
+      "cwes": [],
+      "title": "Use-after-free vulnerability in MCPlayer",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2014-4060.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2015-20121",
+      "cwes": [],
+      "title": "Next Click Ventures RealtyScript 4",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2015-20121.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2015-4049",
+      "cwes": [],
+      "title": "Unisys Libra 43xx, 63xx, and 83xx, and FS600 class systems with MCP-FIRMWARE 40",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2015-4049.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2016-1714",
+      "cwes": [],
+      "title": "The (1) fw_cfg_write and (2) fw_cfg_read functions in hw/nvram/fw_cfg",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2016-1714.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2016-2008",
+      "cwes": [],
+      "title": "HPE Data Protector before 7",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2016-2008.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2017-9828",
+      "cwes": [],
+      "title": "'/cgi-bin/admin/testserver",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2017-9828.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2018-16525",
+      "cwes": [],
+      "title": "Amazon Web Services (AWS) FreeRTOS through 1",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2018-16525.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2018-5314",
+      "cwes": [],
+      "title": "Command injection vulnerability in Citrix NetScaler ADC and NetScaler Gateway 11",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2018-5314.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2019-25479",
+      "cwes": [],
+      "title": "Inout RealEstate contains an SQL injection vulnerability that allows unauthenticated attackers to manipulate database qu",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2019-25479.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2019-25504",
+      "cwes": [],
+      "title": "NCrypted Jobgator contains an SQL injection vulnerability that allows unauthenticated attackers to manipulate database q",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2019-25504.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2020-10106",
+      "cwes": [],
+      "title": "PHPGurukul Daily Expense Tracker System 1",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2020-10106.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2020-11545",
+      "cwes": [],
+      "title": "Project Worlds Official Car Rental System 1 is vulnerable to multiple SQL injection issues, as demonstrated by the email",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2020-11545.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2020-17500",
+      "cwes": [],
+      "title": "Barco TransForm NDN-210 Lite, NDN-210 Pro, NDN-211 Lite, and NDN-211 Pro before 3",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2020-17500.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2020-36953",
+      "cwes": [],
+      "title": "MiniTool ShadowMaker 3",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2020-36953.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2021-21960",
+      "cwes": [],
+      "title": "A stack-based buffer overflow vulnerability exists in both the LLMNR functionality of Sealevel Systems, Inc",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "critical",
+      "file": "euvd/CVE-2021-21960.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2021-3942",
+      "cwes": [],
+      "title": "Certain HP Print products and Digital Sending products may be vulnerable to potential remote code execution and buffer o",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "critical",
+      "file": "euvd/CVE-2021-3942.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2022-22019",
+      "cwes": [],
+      "title": "Remote Procedure Call Runtime Remote Code Execution Vulnerability",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2022-22019.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2022-22744",
+      "cwes": [],
+      "title": "The constructed curl command from the \"Copy as curl\" feature in DevTools was not properly escaped for PowerShell",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2022-22744.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2022-4494",
+      "cwes": [],
+      "title": "A vulnerability, which was classified as critical, has been found in bspkrs MCPMappingViewer",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2022-4494.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2022-50131",
+      "cwes": [],
+      "title": "In the Linux kernel, the following vulnerability has been resolved:",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "low",
+      "file": "euvd/CVE-2022-50131.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2023-29468",
+      "cwes": [],
+      "title": "The Texas Instruments (TI) WiLink WL18xx MCP driver does not limit the number of information elements (IEs) of type XCC_",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "critical",
+      "file": "euvd/CVE-2023-29468.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2023-37274",
+      "cwes": [],
+      "title": "Auto-GPT is an experimental open-source application showcasing the capabilities of the GPT-4 language model",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2023-37274.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2023-38887",
+      "cwes": [],
+      "title": "File Upload vulnerability in Dolibarr ERP CRM v",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2023-38887.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2023-4897",
+      "cwes": [],
+      "title": "Relative Path Traversal in GitHub repository mintplex-labs/anything-llm prior to 0",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2023-4897.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2023-4899",
+      "cwes": [],
+      "title": "SQL Injection in GitHub repository mintplex-labs/anything-llm prior to 0",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2023-4899.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2023-51664",
+      "cwes": [],
+      "title": "tj-actions/changed-files is a Github action to retrieve all files and directories",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2023-51664.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2023-53459",
+      "cwes": [],
+      "title": "In the Linux kernel, the following vulnerability has been resolved:",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "low",
+      "file": "euvd/CVE-2023-53459.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2024-0378",
+      "cwes": [],
+      "title": "The AI Engine: Chatbots, Generators, Assistants, GPT 4 and more! plugin for WordPress is vulnerable to Stored Cross-Site",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2024-0378.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2024-0549",
+      "cwes": [],
+      "title": "mintplex-labs/anything-llm is vulnerable to a relative path traversal attack, allowing unauthorized attackers with a def",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2024-0549.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2024-0699",
+      "cwes": [],
+      "title": "The AI Engine: Chatbots, Generators, Assistants, GPT 4 and more! plugin for WordPress is vulnerable to arbitrary file up",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2024-0699.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2024-0763",
+      "cwes": [],
+      "title": "Any user can delete an arbitrary folder (recursively) on a remote server due to bad input sanitization leading to path t",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2024-0763.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2024-0765",
+      "cwes": [],
+      "title": "As a default user on a multi-user instance of AnythingLLM, you could execute a call to the `/export-data` endpoint of th",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "critical",
+      "file": "euvd/CVE-2024-0765.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2024-10131",
+      "cwes": [],
+      "title": "The `add_llm` function in `llm_app",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2024-10131.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2024-12366",
+      "cwes": [],
+      "title": "PandasAI uses an interactive prompt function that is vulnerable to prompt injection and run arbitrary Python code that c",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "critical",
+      "file": "euvd/CVE-2024-12366.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2024-13059",
+      "cwes": [],
+      "title": "A vulnerability in mintplex-labs/anything-llm prior to version 1",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2024-13059.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2024-25639",
+      "cwes": [],
+      "title": "Khoj is an application that creates personal AI agents",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2024-25639.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2024-3025",
+      "cwes": [],
+      "title": "mintplex-labs/anything-llm is vulnerable to path traversal attacks due to insufficient validation of user-supplied input",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "critical",
+      "file": "euvd/CVE-2024-3025.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2024-30256",
+      "cwes": [],
+      "title": "Open WebUI is a user-friendly WebUI for LLMs",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2024-30256.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2024-3104",
+      "cwes": [],
+      "title": "A remote code execution vulnerability exists in mintplex-labs/anything-llm due to improper handling of environment varia",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "critical",
+      "file": "euvd/CVE-2024-3104.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2024-3149",
+      "cwes": [],
+      "title": "A Server-Side Request Forgery (SSRF) vulnerability exists in the upload link feature of mintplex-labs/anything-llm",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "critical",
+      "file": "euvd/CVE-2024-3149.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2024-3152",
+      "cwes": [],
+      "title": "mintplex-labs/anything-llm is vulnerable to multiple security issues due to improper input validation in several endpoin",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2024-3152.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2024-3166",
+      "cwes": [],
+      "title": "A Cross-Site Scripting (XSS) vulnerability exists in mintplex-labs/anything-llm, affecting both the desktop application ",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "low",
+      "file": "euvd/CVE-2024-3166.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2024-32878",
+      "cwes": [],
+      "title": "Llama",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2024-32878.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2024-3303",
+      "cwes": [],
+      "title": "An issue was discovered in GitLab EE affecting all versions starting from 16",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2024-3303.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2024-37058",
+      "cwes": [],
+      "title": "Deserialization of untrusted data can occur in versions of the MLflow platform running version 2",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2024-37058.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2024-37895",
+      "cwes": [],
+      "title": "Lobe Chat is an open-source LLMs/AI chat framework",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2024-37895.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2024-4084",
+      "cwes": [],
+      "title": "A Server-Side Request Forgery (SSRF) vulnerability exists in the latest version of mintplex-labs/anything-llm, allowing ",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2024-4084.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2024-4099",
+      "cwes": [],
+      "title": "An issue has been discovered in GitLab EE affecting all versions starting from 16",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "low",
+      "file": "euvd/CVE-2024-4099.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2024-4343",
+      "cwes": [],
+      "title": "A Python command injection vulnerability exists in the `SagemakerLLM` class's `complete()` method within `",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "critical",
+      "file": "euvd/CVE-2024-4343.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2024-45989",
+      "cwes": [],
+      "title": "Monica AI Assistant desktop application v2",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2024-45989.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2024-47091",
+      "cwes": [],
+      "title": "Privilege escalation in the mk_mysql agent plugin on Windows in Checkmk <2",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2024-47091.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2024-48139",
+      "cwes": [],
+      "title": "A prompt injection vulnerability in the chatbox of Blackbox AI v1",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2024-48139.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2024-48140",
+      "cwes": [],
+      "title": "A prompt injection vulnerability in the chatbox of Butterfly Effect Limited Monica Your AI Copilot powered by ChatGPT4 v",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2024-48140.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2024-48141",
+      "cwes": [],
+      "title": "A prompt injection vulnerability in the chatbox of Zhipu AI CodeGeeX v2",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2024-48141.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2024-48142",
+      "cwes": [],
+      "title": "A prompt injection vulnerability in the chatbox of Butterfly Effect Limited Monica ChatGPT AI Assistant v2",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2024-48142.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2024-4889",
+      "cwes": [],
+      "title": "A code injection vulnerability exists in the berriai/litellm application, version 1",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2024-4889.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2024-5211",
+      "cwes": [],
+      "title": "A path traversal vulnerability in mintplex-labs/anything-llm allowed a manager to bypass the `normalizePath()` function,",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "critical",
+      "file": "euvd/CVE-2024-5211.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2024-53844",
+      "cwes": [],
+      "title": "E",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2024-53844.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2024-55241",
+      "cwes": [],
+      "title": "An issue in deep-diver LLM-As-Chatbot before commit 99c2c03 allows a remote attacker to execute arbitrary code via the m",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2024-55241.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2024-5565",
+      "cwes": [],
+      "title": "The Vanna library uses a prompt function to present the user with visualized results, it is possible to alter the prompt",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2024-5565.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2024-5826",
+      "cwes": [],
+      "title": "In the latest version of vanna-ai/vanna, the `vanna",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "critical",
+      "file": "euvd/CVE-2024-5826.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2024-58340",
+      "cwes": [],
+      "title": "LangChain versions up to and including 0",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2024-58340.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2024-6127",
+      "cwes": [],
+      "title": "BC Security Empire before 5",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "critical",
+      "file": "euvd/CVE-2024-6127.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2024-6331",
+      "cwes": [],
+      "title": "stitionai/devika main branch as of commit cdfb782b0e634b773b10963c8034dc9207ba1f9f is vulnerable to Local File Read (LFI",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2024-6331.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2024-7110",
+      "cwes": [],
+      "title": "An issue was discovered in GitLab EE affecting all versions starting 17",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2024-7110.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2024-7764",
+      "cwes": [],
+      "title": "Vanna-ai v0",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2024-7764.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2024-7987",
+      "cwes": [],
+      "title": "A remote code execution vulnerability exists in the Rockwell Automation ThinManager® ThinServer™",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2024-7987.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2024-8248",
+      "cwes": [],
+      "title": "A vulnerability in the normalizePath function in mintplex-labs/anything-llm version git 296f041 allows for path traversa",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2024-8248.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-10619",
+      "cwes": [],
+      "title": "A vulnerability was detected in sequa-ai sequa-mcp up to 1",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2025-10619.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-11202",
+      "cwes": [],
+      "title": "win-cli-mcp-server resolveCommandPath Command Injection Remote Code Execution Vulnerability",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "critical",
+      "file": "euvd/CVE-2025-11202.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-11204",
+      "cwes": [],
+      "title": "The RegistrationMagic – Custom Registration Forms, User Registration, Payment, and User Login plugin for WordPress is vu",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2025-11204.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-11273",
+      "cwes": [],
+      "title": "A vulnerability was found in LaChatterie Verger up to 1",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2025-11273.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-11285",
+      "cwes": [],
+      "title": "A vulnerability was found in samanhappy MCPHub up to 0",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2025-11285.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-11286",
+      "cwes": [],
+      "title": "A vulnerability was determined in samanhappy MCPHub up to 0",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2025-11286.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-11749",
+      "cwes": [],
+      "title": "The AI Engine plugin for WordPress is vulnerable to Sensitive Information Exposure in all versions up to, and including,",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "critical",
+      "file": "euvd/CVE-2025-11749.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-12189",
+      "cwes": [],
+      "title": "The Bread & Butter: Gate content + Capture leads + Collect first-party data + Nurture with Ai agents plugin for WordPres",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2025-12189.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-12489",
+      "cwes": [],
+      "title": "evernote-mcp-server openBrowser Command Injection Privilege Escalation Vulnerability",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2025-12489.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-12844",
+      "cwes": [],
+      "title": "The AI Engine plugin for WordPress is vulnerable to PHP Object Injection via PHAR Deserialization in all versions up to,",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2025-12844.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-12973",
+      "cwes": [],
+      "title": "The S2B AI Assistant – ChatBot, ChatGPT, OpenAI, Content & Image Generator plugin for WordPress is vulnerable to arbitra",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2025-12973.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-13374",
+      "cwes": [],
+      "title": "The Kalrav AI Agent plugin for WordPress is vulnerable to arbitrary file uploads due to missing file type validation in ",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "critical",
+      "file": "euvd/CVE-2025-13374.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-14660",
+      "cwes": [],
+      "title": "A flaw has been found in DecoCMS Mesh up to 1",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2025-14660.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-1497",
+      "cwes": [],
+      "title": "A vulnerability, that could result in Remote Code Execution (RCE), has been found in PlotAI",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "critical",
+      "file": "euvd/CVE-2025-1497.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-15063",
+      "cwes": [],
+      "title": "Ollama MCP Server execAsync Command Injection Remote Code Execution Vulnerability",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "critical",
+      "file": "euvd/CVE-2025-15063.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-15612",
+      "cwes": [],
+      "title": "Wazuh provisioning scripts and Dockerfiles contain an insecure transport vulnerability where curl is invoked with the -k",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2025-15612.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-15616",
+      "cwes": [],
+      "title": "Wazuh wazuh-agent and wazuh-manager versions 2",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2025-15616.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-1753",
+      "cwes": [],
+      "title": "LLama-Index CLI version v0",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2025-1753.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-20381",
+      "cwes": [],
+      "title": "In Splunk MCP Server app versions below 0",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2025-20381.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-23254",
+      "cwes": [],
+      "title": "NVIDIA TensorRT-LLM for any platform contains a vulnerability in python executor where an attacker may cause a data vali",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2025-23254.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-24357",
+      "cwes": [],
+      "title": "vLLM is a library for LLM inference and serving",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2025-24357.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-25362",
+      "cwes": [],
+      "title": "A Server-Side Template Injection (SSTI) vulnerability in Spacy-LLM v0",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "critical",
+      "file": "euvd/CVE-2025-25362.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-2733",
+      "cwes": [],
+      "title": "A vulnerability classified as critical has been found in mannaandpoem OpenManus up to 2025",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2025-2733.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-29783",
+      "cwes": [],
+      "title": "vLLM is a high-throughput and memory-efficient inference and serving engine for LLMs",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "critical",
+      "file": "euvd/CVE-2025-29783.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-31363",
+      "cwes": [],
+      "title": "Mattermost versions 10",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "low",
+      "file": "euvd/CVE-2025-31363.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-32444",
+      "cwes": [],
+      "title": "vLLM is a high-throughput and memory-efficient inference and serving engine for LLMs",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "critical",
+      "file": "euvd/CVE-2025-32444.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-32779",
+      "cwes": [],
+      "title": "E",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2025-32779.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-33204",
+      "cwes": [],
+      "title": "NVIDIA NeMo Framework for all platforms contains a vulnerability in the NLP and LLM components, where malicious data cre",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2025-33204.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-33255",
+      "cwes": [],
+      "title": "NVIDIA TRT-LLM for any platform contains a vulnerability in MPI server, where an attacker could cause an unsafe deserial",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2025-33255.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-34072",
+      "cwes": [],
+      "title": "A data exfiltration vulnerability exists in Anthropic’s deprecated Slack Model Context Protocol (MCP) Server via automat",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "critical",
+      "file": "euvd/CVE-2025-34072.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-35028",
+      "cwes": [],
+      "title": "By providing a command-line argument starting with a semi-colon ; to an API endpoint created by the EnhancedCommandExecu",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "critical",
+      "file": "euvd/CVE-2025-35028.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-3578",
+      "cwes": [],
+      "title": "A malicious, authenticated user in Aidex, versions prior to 1",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "critical",
+      "file": "euvd/CVE-2025-3578.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-3579",
+      "cwes": [],
+      "title": "In versions prior to Aidex 1",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "critical",
+      "file": "euvd/CVE-2025-3579.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-3893",
+      "cwes": [],
+      "title": "While editing pages managed by MegaBIP a user with high privileges is prompted to give a reasoning for performing this a",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2025-3893.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-4143",
+      "cwes": [],
+      "title": "The OAuth implementation in workers-oauth-provider that is part of  MCP framework https://github",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2025-4143.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-4144",
+      "cwes": [],
+      "title": "PKCE was implemented in the OAuth implementation in workers-oauth-provider that is part of  MCP framework https://github",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2025-4144.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-4285",
+      "cwes": [],
+      "title": "Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection') vulnerability in Rolantis Informati",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "critical",
+      "file": "euvd/CVE-2025-4285.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-44179",
+      "cwes": [],
+      "title": "Hitron CGNF-TWN 3",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2025-44179.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-45809",
+      "cwes": [],
+      "title": "SQL Injection vulnerability in BerriAI LiteLLM before 1",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2025-45809.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-46059",
+      "cwes": [],
+      "title": "langchain-ai v0",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "critical",
+      "file": "euvd/CVE-2025-46059.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-46735",
+      "cwes": [],
+      "title": "Terraform WinDNS Provider allows users to manage their Windows DNS server resources through Terraform",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "low",
+      "file": "euvd/CVE-2025-46735.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-47274",
+      "cwes": [],
+      "title": "ToolHive is a utility designed to simplify the deployment and management of Model Context Protocol (MCP) servers",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "low",
+      "file": "euvd/CVE-2025-47274.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-47777",
+      "cwes": [],
+      "title": "5ire is a cross-platform desktop artificial intelligence assistant and model context protocol client",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "critical",
+      "file": "euvd/CVE-2025-47777.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-48887",
+      "cwes": [],
+      "title": "vLLM, an inference and serving engine for large language models (LLMs), has a Regular Expression Denial of Service (ReDo",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2025-48887.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-48957",
+      "cwes": [],
+      "title": "AstrBot is a large language model chatbot and development framework",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2025-48957.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-49619",
+      "cwes": [],
+      "title": "Skyvern through 0",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2025-49619.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-5071",
+      "cwes": [],
+      "title": "The AI Engine plugin for WordPress is vulnerable to unauthorized modification of data and loss of data due to a missing ",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2025-5071.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-51859",
+      "cwes": [],
+      "title": "Stored Cross-Site Scripting (XSS) vulnerability in Chaindesk thru 2025-05-26 in its agent chat component",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2025-51859.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-51860",
+      "cwes": [],
+      "title": "Stored Cross-Site Scripting (XSS) in TelegAI (telegai",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2025-51860.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-52573",
+      "cwes": [],
+      "title": "iOS Simulator MCP Server (ios-simulator-mcp) is a Model Context Protocol (MCP) server for interacting with iOS simulator",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2025-52573.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-5273",
+      "cwes": [],
+      "title": "All versions of the package mcp-markdownify-server are vulnerable to Files or Directories Accessible to External Parties",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2025-5273.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-5276",
+      "cwes": [],
+      "title": "All versions of the package mcp-markdownify-server are vulnerable to Server-Side Request Forgery (SSRF) via the Markdown",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2025-5276.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-5277",
+      "cwes": [],
+      "title": "aws-mcp-server MCP server is vulnerable to command injection",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "critical",
+      "file": "euvd/CVE-2025-5277.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-53100",
+      "cwes": [],
+      "title": "RestDB's Codehooks",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2025-53100.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-53107",
+      "cwes": [],
+      "title": "@cyanheads/git-mcp-server is an MCP server designed to interact with Git repositories",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2025-53107.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-53818",
+      "cwes": [],
+      "title": "GitHub Kanban MCP Server is a Model Context Protocol (MCP) server for managing GitHub issues in Kanban board format and ",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2025-53818.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-53832",
+      "cwes": [],
+      "title": "Lara Translate MCP Server is a Model Context Protocol (MCP) Server for Lara Translate API",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2025-53832.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-53928",
+      "cwes": [],
+      "title": "MaxKB is an open-source AI assistant for enterprise",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2025-53928.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-54063",
+      "cwes": [],
+      "title": "Cherry Studio is a desktop client that supports for multiple LLM providers",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2025-54063.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-54073",
+      "cwes": [],
+      "title": "mcp-package-docs is an MCP (Model Context Protocol) server that provides LLMs with efficient access to package documenta",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2025-54073.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-54074",
+      "cwes": [],
+      "title": "Cherry Studio is a desktop client that supports for multiple LLM providers",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2025-54074.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-54131",
+      "cwes": [],
+      "title": "Cursor is a code editor built for programming with AI",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2025-54131.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-54132",
+      "cwes": [],
+      "title": "Cursor is a code editor built for programming with AI",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2025-54132.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-54133",
+      "cwes": [],
+      "title": "Cursor is a code editor built for programming with AI",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2025-54133.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-54135",
+      "cwes": [],
+      "title": "Cursor is a code editor built for programming with AI",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2025-54135.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-54382",
+      "cwes": [],
+      "title": "Cherry Studio is a desktop client that supports for multiple LLM providers",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "critical",
+      "file": "euvd/CVE-2025-54382.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-54424",
+      "cwes": [],
+      "title": "1Panel is a web interface and MCP Server that manages websites, files, containers, databases, and LLMs on a Linux server",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2025-54424.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-5570",
+      "cwes": [],
+      "title": "The AI Engine plugin for WordPress is vulnerable to Stored Cross-Site Scripting via the mwai_chatbot shortcode 'id' para",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2025-5570.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-56404",
+      "cwes": [],
+      "title": "An issue was discovered in MariaDB MCP 0",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2025-56404.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-56405",
+      "cwes": [],
+      "title": "An issue was discovered in litmusautomation litmus-mcp-server thru 0",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2025-56405.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-56406",
+      "cwes": [],
+      "title": "An issue was discovered in mcp-neo4j 0",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2025-56406.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-57818",
+      "cwes": [],
+      "title": "Firecrawl turns entire websites into LLM-ready markdown or structured data",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2025-57818.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-58062",
+      "cwes": [],
+      "title": "LSTM-Kirigaya's openmcp-client is a vscode plugin for mcp developer",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2025-58062.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-5817",
+      "cwes": [],
+      "title": "The Amazon Products to WooCommerce plugin for WordPress is vulnerable to Server-Side Request Forgery in all versions up ",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2025-5817.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-58176",
+      "cwes": [],
+      "title": "Dive is an open-source MCP Host Desktop Application that enables integration with function-calling LLMs",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2025-58176.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-58337",
+      "cwes": [],
+      "title": "An attacker with a valid read-only account can bypass Doris MCP Server’s read-only mode due to improper access control, ",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2025-58337.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-58357",
+      "cwes": [],
+      "title": "5ire is a cross-platform desktop artificial intelligence assistant and model context protocol client",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "critical",
+      "file": "euvd/CVE-2025-58357.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-58358",
+      "cwes": [],
+      "title": "Markdownify is a Model Context Protocol server for converting almost anything to Markdown",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2025-58358.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-58747",
+      "cwes": [],
+      "title": "Dify is an LLM application development platform",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "low",
+      "file": "euvd/CVE-2025-58747.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-59046",
+      "cwes": [],
+      "title": "The npm package `interactive-git-checkout` is an interactive command-line tool that allows users to checkout a git branc",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "critical",
+      "file": "euvd/CVE-2025-59046.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-59146",
+      "cwes": [],
+      "title": "New API is a large language mode (LLM) gateway and artificial intelligence (AI) asset management system",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2025-59146.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-59155",
+      "cwes": [],
+      "title": "hackmd-mcp is a Model Context Protocol server for integrating HackMD's note-taking platform with AI assistants",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2025-59155.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-59333",
+      "cwes": [],
+      "title": "The mcp-database-server (MCP Server) 1",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2025-59333.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-59376",
+      "cwes": [],
+      "title": "feiskyer mcp-kubernetes-server through 0",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "low",
+      "file": "euvd/CVE-2025-59376.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-59377",
+      "cwes": [],
+      "title": "feiskyer mcp-kubernetes-server through 0",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "low",
+      "file": "euvd/CVE-2025-59377.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-59417",
+      "cwes": [],
+      "title": "Lobe Chat is an open-source artificial intelligence chat framework",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2025-59417.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-59834",
+      "cwes": [],
+      "title": "ADB MCP Server is a MCP (Model Context Protocol) server for interacting with Android devices through ADB",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "critical",
+      "file": "euvd/CVE-2025-59834.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-60357",
+      "cwes": [],
+      "title": "AhnLab EPP Management v1",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2025-60357.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-61489",
+      "cwes": [],
+      "title": "A command injection vulnerability in the shell_exec function of sonirico mcp-shell v0",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2025-61489.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-61492",
+      "cwes": [],
+      "title": "A command injection vulnerability in the execute_command function of terminal-controller-mcp 0",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "critical",
+      "file": "euvd/CVE-2025-61492.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-61589",
+      "cwes": [],
+      "title": "Cursor is a code editor built for programming with AI",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2025-61589.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-61929",
+      "cwes": [],
+      "title": "Cherry Studio is a desktop client that supports for multiple LLM providers",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "critical",
+      "file": "euvd/CVE-2025-61929.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-62155",
+      "cwes": [],
+      "title": "New API is a large language mode (LLM) gateway and artificial intelligence (AI) asset management system",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2025-62155.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-62164",
+      "cwes": [],
+      "title": "vLLM is an inference and serving engine for large language models (LLMs)",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2025-62164.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-62353",
+      "cwes": [],
+      "title": "A path traversal vulnerability in all versions of the Windsurf IDE enables a threat actor to read and write arbitrary lo",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "critical",
+      "file": "euvd/CVE-2025-62353.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-62356",
+      "cwes": [],
+      "title": "A path traversal vulnerability in all versions of the Qodo Qodo Gen IDE enables a threat actor to read arbitrary local f",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2025-62356.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-62373",
+      "cwes": [],
+      "title": "Pipecat is an open-source Python framework for building real-time voice and multimodal conversational agents",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "critical",
+      "file": "euvd/CVE-2025-62373.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-6308",
+      "cwes": [],
+      "title": "A vulnerability classified as critical has been found in PHPGurukul Emergency Ambulance Hiring Portal 1",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2025-6308.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-63603",
+      "cwes": [],
+      "title": "A command injection vulnerability exists in the MCP Data Science Server's (reading-plus-ai/mcp-server-data-exploration) ",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2025-63603.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-63604",
+      "cwes": [],
+      "title": "A code injection vulnerability exists in baryhuang/mcp-server-aws-resources-python 0",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2025-63604.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-64104",
+      "cwes": [],
+      "title": "LangGraph SQLite Checkpoint is an implementation of LangGraph CheckpointSaver that uses SQLite DB (both sync and async, ",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2025-64104.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-64106",
+      "cwes": [],
+      "title": "Cursor is a code editor built for programming with AI",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2025-64106.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-64107",
+      "cwes": [],
+      "title": "Cursor is a code editor built for programming with AI",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2025-64107.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-64108",
+      "cwes": [],
+      "title": "Cursor is a code editor built for programming with AI",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2025-64108.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-64109",
+      "cwes": [],
+      "title": "Cursor is a code editor built for programming with AI",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2025-64109.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-64132",
+      "cwes": [],
+      "title": "Jenkins MCP Server Plugin 0",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2025-64132.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-64439",
+      "cwes": [],
+      "title": "LangGraph SQLite Checkpoint is an implementation of LangGraph CheckpointSaver that uses SQLite DB (both sync and async, ",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2025-64439.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-64443",
+      "cwes": [],
+      "title": "MCP Gateway allows easy and secure running and deployment of MCP servers",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2025-64443.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-64756",
+      "cwes": [],
+      "title": "Glob matches files using patterns the shell uses",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2025-64756.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-6515",
+      "cwes": [],
+      "title": "The MCP SSE endpoint in oatpp-mcp returns an instance pointer as the session ID, which is not unique nor cryptographical",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2025-6515.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-65512",
+      "cwes": [],
+      "title": "A Server-Side Request Forgery (SSRF) vulnerability was discovered in the webpage-to-markdown conversion feature of markd",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2025-65512.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-66201",
+      "cwes": [],
+      "title": "LibreChat is a ChatGPT clone with additional features",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2025-66201.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-66222",
+      "cwes": [],
+      "title": "DeepChat is a smart assistant uses artificial intelligence",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "critical",
+      "file": "euvd/CVE-2025-66222.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-66401",
+      "cwes": [],
+      "title": "MCP Watch is a comprehensive security scanner for Model Context Protocol (MCP) servers",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "critical",
+      "file": "euvd/CVE-2025-66401.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-66404",
+      "cwes": [],
+      "title": "MCP Server Kubernetes is an MCP Server that can connect to a Kubernetes cluster and manage it",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2025-66404.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-66448",
+      "cwes": [],
+      "title": "vLLM is an inference and serving engine for large language models (LLMs)",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2025-66448.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-66454",
+      "cwes": [],
+      "title": "Arcade MCP allows you to to create, deploy, and share MCP Servers",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2025-66454.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-66481",
+      "cwes": [],
+      "title": "DeepChat is an open-source AI chat platform that supports cloud models and LLMs",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "critical",
+      "file": "euvd/CVE-2025-66481.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-66562",
+      "cwes": [],
+      "title": "TUUI is a desktop MCP client designed as a tool unitary utility integration",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2025-66562.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-66580",
+      "cwes": [],
+      "title": "Dive is an open-source MCP Host Desktop Application that enables integration with function-calling LLMs",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "critical",
+      "file": "euvd/CVE-2025-66580.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-67364",
+      "cwes": [],
+      "title": "fast-filesystem-mcp version 3",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2025-67364.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-67509",
+      "cwes": [],
+      "title": "Neuron is a PHP framework for creating and orchestrating AI Agents",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2025-67509.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-67510",
+      "cwes": [],
+      "title": "Neuron is a PHP framework for creating and orchestrating AI Agents",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "critical",
+      "file": "euvd/CVE-2025-67510.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-67644",
+      "cwes": [],
+      "title": "LangGraph SQLite Checkpoint is an implementation of LangGraph CheckpointSaver that uses SQLite DB (both sync and async, ",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2025-67644.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-67729",
+      "cwes": [],
+      "title": "LMDeploy is a toolkit for compressing, deploying, and serving LLMs",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2025-67729.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-68205",
+      "cwes": [],
+      "title": "In the Linux kernel, the following vulnerability has been resolved:",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "low",
+      "file": "euvd/CVE-2025-68205.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-68433",
+      "cwes": [],
+      "title": "Zed, a code editor, has an aribtrary code execution vulnerability in versions prior to 0",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2025-68433.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-6853",
+      "cwes": [],
+      "title": "A vulnerability classified as critical has been found in chatchat-space Langchain-Chatchat up to 0",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2025-6853.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-6854",
+      "cwes": [],
+      "title": "A vulnerability classified as problematic was found in chatchat-space Langchain-Chatchat up to 0",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2025-6854.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-6855",
+      "cwes": [],
+      "title": "A vulnerability, which was classified as critical, has been found in chatchat-space Langchain-Chatchat up to 0",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2025-6855.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-68669",
+      "cwes": [],
+      "title": "5ire is a cross-platform desktop artificial intelligence assistant and model context protocol client",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "critical",
+      "file": "euvd/CVE-2025-68669.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-69256",
+      "cwes": [],
+      "title": "The Serverless Framework is a framework for using AWS Lambda and other managed cloud services to build applications",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2025-69256.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-69902",
+      "cwes": [],
+      "title": "A command injection vulnerability in the minimal_wrapper",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "critical",
+      "file": "euvd/CVE-2025-69902.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-7780",
+      "cwes": [],
+      "title": "The AI Engine plugin for WordPress is vulnerable to Sensitive Information Exposure in all versions up to, and including,",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2025-7780.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-8084",
+      "cwes": [],
+      "title": "The AI Engine plugin for WordPress is vulnerable to Server-Side Request Forgery in all versions up to, and including, 3",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2025-8084.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-8268",
+      "cwes": [],
+      "title": "The AI Engine plugin for WordPress is vulnerable to unauthorized access and loss of data due to a missing capability che",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2025-8268.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-8665",
+      "cwes": [],
+      "title": "A vulnerability, which was classified as critical, has been found in agno-agi agno up to 1",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2025-8665.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-8697",
+      "cwes": [],
+      "title": "A vulnerability was found in agentUniverse up to 0",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2025-8697.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-8709",
+      "cwes": [],
+      "title": "A SQL injection vulnerability exists in the langchain-ai/langchain repository, specifically in the LangGraph's SQLite st",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2025-8709.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-8943",
+      "cwes": [],
+      "title": "The Custom MCPs feature is designed to execute OS commands, for instance, using tools like `npx` to spin up local MCP Se",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "critical",
+      "file": "euvd/CVE-2025-8943.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-9262",
+      "cwes": [],
+      "title": "A flaw has been found in wong2 mcp-cli 1",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2025-9262.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-9611",
+      "cwes": [],
+      "title": "Microsoft Playwright MCP Server versions prior to 0",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2025-9611.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-9654",
+      "cwes": [],
+      "title": "A security flaw has been discovered in AiondaDotCom mcp-ssh up to 1",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2025-9654.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-9959",
+      "cwes": [],
+      "title": "Incomplete validation of dunder attributes allows an attacker to escape from the Local Python execution environment sand",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2025-9959.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-0246",
+      "cwes": [],
+      "title": "A vulnerability with a privilege management mechanism in the Palo Alto Networks Prisma Access Agent® enables a locally a",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2026-0246.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-0288",
+      "cwes": [],
+      "title": "Multiple buffer overflow vulnerabilities in the User-ID Terminal Server Agent (TSA) component of Palo Alto Networks PAN-",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2026-0288.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-0746",
+      "cwes": [],
+      "title": "The AI Engine plugin for WordPress is vulnerable to Server-Side Request Forgery in all versions up to, and including, 3",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2026-0746.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-0757",
+      "cwes": [],
+      "title": "MCP Manager for Claude Desktop execute-command Command Injection Sandbox Escape Vulnerability",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2026-0757.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-0758",
+      "cwes": [],
+      "title": "mcp-server-siri-shortcuts shortcutName Command Injection Privilege Escalation Vulnerability",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2026-0758.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-10214",
+      "cwes": [],
+      "title": "A weakness has been identified in zhayujie chatgpt-on-wechat up to 2",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2026-10214.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-10264",
+      "cwes": [],
+      "title": "A vulnerability was determined in lharries whatsapp-mcp 0",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2026-10264.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-10274",
+      "cwes": [],
+      "title": "A vulnerability was determined in indrasishbanerjee aem-mcp-server up to b5f833aef9b5dfd17a5991b3b18a8a11edbdc583",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2026-10274.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-10276",
+      "cwes": [],
+      "title": "A vulnerability has been found in hekmon8 Jenkins-server-mcp 0",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2026-10276.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-10278",
+      "cwes": [],
+      "title": "A vulnerability was determined in ishayoyo excel-mcp up to 1",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2026-10278.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-10279",
+      "cwes": [],
+      "title": "A vulnerability was identified in hiraishikentaro wezterm-mcp 0",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2026-10279.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-10621",
+      "cwes": [],
+      "title": "Path traversal in restore handler in Collibra Agent, allows an attacker to write arbitrary files via a crafted ZIP archi",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2026-10621.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-10661",
+      "cwes": [],
+      "title": "A vulnerability has been found in ahujasid blender-mcp up to 7636d13bded82eca58eb93c3f4cd8708dfdfbe8b",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2026-10661.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-10662",
+      "cwes": [],
+      "title": "A vulnerability was found in ahujasid blender-mcp up to 7636d13bded82eca58eb93c3f4cd8708dfdfbe8b",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2026-10662.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-10688",
+      "cwes": [],
+      "title": "A vulnerability was determined in ahujasid blender-mcp up to 7636d13bded82eca58eb93c3f4cd8708dfdfbe8b",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2026-10688.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-10692",
+      "cwes": [],
+      "title": "A weakness has been identified in johnhuang316 code-index-mcp up to 2",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2026-10692.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-10847",
+      "cwes": [],
+      "title": "A local privilege escalation vulnerability exists in Check Point Identity Agent Full for Windows OS",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2026-10847.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-11393",
+      "cwes": [],
+      "title": "Improper neutralization of triple-quote characters during Python code generation in AgentCore CLI before v0",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2026-11393.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-11529",
+      "cwes": [],
+      "title": "A vulnerability was determined in designcomputer mysql-mcp-server up to 0",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2026-11529.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-11717",
+      "cwes": [],
+      "title": "An authentication bypass vulnerability exists in the generic opaque token validation path (validateOpaqueToken) of googl",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "critical",
+      "file": "euvd/CVE-2026-11717.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-11718",
+      "cwes": [],
+      "title": "An authentication bypass vulnerability exists in the generic opaque token validation path (validateOpaqueToken) of googl",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "critical",
+      "file": "euvd/CVE-2026-11718.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-11719",
+      "cwes": [],
+      "title": "An authenticated authorization bypass vulnerability exists in MCP Toolbox for Databases due to missing scope enforcement",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2026-11719.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-11720",
+      "cwes": [],
+      "title": "A path traversal vulnerability exists in the HTTP tool URL builder of googleapis/mcp-toolbox",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "critical",
+      "file": "euvd/CVE-2026-11720.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-13318",
+      "cwes": [],
+      "title": "A server-side request forgery (SSRF) flaw was found in KubeVirt's virt-api port-forward handler",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2026-13318.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-13448",
+      "cwes": [],
+      "title": "IBM Langflow OSS 1",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2026-13448.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-1400",
+      "cwes": [],
+      "title": "The AI Engine – The Chatbot and AI Framework for WordPress plugin for WordPress is vulnerable to arbitrary file uploads ",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2026-1400.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-14501",
+      "cwes": [],
+      "title": "IBM Db2 Genius Hub 1",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2026-14501.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-14628",
+      "cwes": [],
+      "title": "A vulnerability was detected in NousResearch hermes-agent up to 2026",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2026-14628.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-14699",
+      "cwes": [],
+      "title": "A weakness has been identified in zcaceres markdownify-mcp up to 1",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2026-14699.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-14702",
+      "cwes": [],
+      "title": "A flaw has been found in zcaceres markdownify-mcp up to 1",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "low",
+      "file": "euvd/CVE-2026-14702.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-14783",
+      "cwes": [],
+      "title": "A vulnerability was determined in NousResearch hermes-agent 2026",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2026-14783.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-15265",
+      "cwes": [],
+      "title": "A path traversal vulnerability in Tenable Agent 11",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "critical",
+      "file": "euvd/CVE-2026-15265.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-15330",
+      "cwes": [],
+      "title": "A vulnerability was determined in zhayujie CowAgent up to 2",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2026-15330.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-15331",
+      "cwes": [],
+      "title": "A vulnerability was identified in zhayujie CowAgent up to 2",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2026-15331.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-15495",
+      "cwes": [],
+      "title": "A vulnerability has been found in SonicCloudOrg sonic-agent up to 2",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2026-15495.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-15496",
+      "cwes": [],
+      "title": "A vulnerability was found in SonicCloudOrg sonic-agent up to 2",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2026-15496.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-15522",
+      "cwes": [],
+      "title": "A security flaw has been discovered in tugcantopaloglu godot-mcp 2",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2026-15522.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-15524",
+      "cwes": [],
+      "title": "A security vulnerability has been detected in alioshr memory-bank-mcp up to 0",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2026-15524.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-15526",
+      "cwes": [],
+      "title": "A flaw has been found in augmnt augments-mcp-server 7",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2026-15526.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-15528",
+      "cwes": [],
+      "title": "A vulnerability was found in lamaalrajih kicad-mcp up to 3",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2026-15528.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-15628",
+      "cwes": [],
+      "title": "A security flaw has been discovered in zhayujie chatgpt-on-wechat CowAgent up to 2",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2026-15628.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-15668",
+      "cwes": [],
+      "title": "A vulnerability has been found in louisho5 picobot up to 0",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2026-15668.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-15669",
+      "cwes": [],
+      "title": "A vulnerability was found in louisho5 picobot up to 0",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2026-15669.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-16194",
+      "cwes": [],
+      "title": "A vulnerability was determined in zhayujie CowAgent up to 2",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2026-16194.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-16481",
+      "cwes": [],
+      "title": "A Server-Side Request Forgery (SSRF) and credential exfiltration vulnerability exists in the cloud-healthcare-fhir-fetch",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2026-16481.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-17458",
+      "cwes": [],
+      "title": "A vulnerability was found in mf-yang openclaw-cn up to 0",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2026-17458.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-1977",
+      "cwes": [],
+      "title": "A security vulnerability has been detected in isaacwasserman mcp-vegalite-server up to 16aefed598b8cd897b78e99b907f6e298",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2026-1977.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-2008",
+      "cwes": [],
+      "title": "A vulnerability was detected in abhiphile fermat-mcp up to 47f11def1cd37e45dd060f30cdce346cbdbd6f0a",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2026-2008.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-20265",
+      "cwes": [],
+      "title": "In Splunk AI Toolkit versions below 5",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2026-20265.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-2130",
+      "cwes": [],
+      "title": "A vulnerability was determined in BurtTheCoder mcp-maigret up to 1",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2026-2130.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-2131",
+      "cwes": [],
+      "title": "A vulnerability was identified in XixianLiang HarmonyOS-mcp-server 0",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2026-2131.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-2178",
+      "cwes": [],
+      "title": "A vulnerability was found in r-huijts xcode-mcp-server up to f3419f00117aa9949e326f78cc940166c88f18cb",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2026-2178.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-21869",
+      "cwes": [],
+      "title": "llama",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2026-21869.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-22551",
+      "cwes": [],
+      "title": "In Eclipse Theia versions prior to 1",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2026-22551.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-2256",
+      "cwes": [],
+      "title": "A command injection vulnerability in ModelScope's ms-agent versions v1",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2026-2256.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-22708",
+      "cwes": [],
+      "title": "Cursor is a code editor built for programming with AI",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2026-22708.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-22778",
+      "cwes": [],
+      "title": "vLLM is an inference and serving engine for large language models (LLMs)",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "critical",
+      "file": "euvd/CVE-2026-22778.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-22785",
+      "cwes": [],
+      "title": "orval generates type-safe JS clients (TypeScript) from any valid OpenAPI v3 or Swagger v2 specification",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "critical",
+      "file": "euvd/CVE-2026-22785.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-22792",
+      "cwes": [],
+      "title": "5ire is a cross-platform desktop artificial intelligence assistant and model context protocol client",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "critical",
+      "file": "euvd/CVE-2026-22792.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-22793",
+      "cwes": [],
+      "title": "5ire is a cross-platform desktop artificial intelligence assistant and model context protocol client",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "critical",
+      "file": "euvd/CVE-2026-22793.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-22807",
+      "cwes": [],
+      "title": "vLLM is an inference and serving engine for large language models (LLMs)",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2026-22807.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-23523",
+      "cwes": [],
+      "title": "Dive is an open-source MCP Host Desktop Application that enables integration with function-calling LLMs",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "critical",
+      "file": "euvd/CVE-2026-23523.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-24142",
+      "cwes": [],
+      "title": "NVIDIA TRT-LLM for any platform contains a deserialization vulnerability   and unsafe serialized handle",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2026-24142.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-24163",
+      "cwes": [],
+      "title": "NVIDIA TRT-LLM for any platform contains a vulnerability in RPC testing, where an attacker could  cause an unsafe deseri",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2026-24163.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-24220",
+      "cwes": [],
+      "title": "NVIDIA TensorRT-LLM for any platform contains a vulnerability in visual gen server, where an attacker could cause an uns",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2026-24220.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-24222",
+      "cwes": [],
+      "title": "NVIDIA NeMoClaw contains a vulnerability in the sandbox environment initialization component, where a remote attacker co",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2026-24222.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-24226",
+      "cwes": [],
+      "title": "NVIDIA TensorRT-LLM for Linux contains a vulnerability where an attacker could cause improper control of code generation",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2026-24226.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-24233",
+      "cwes": [],
+      "title": "NVIDIA TensorRT-LLM for Linux contains a vulnerability in the restricted unpickler used for model weight deserialization",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2026-24233.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-24234",
+      "cwes": [],
+      "title": "NVIDIA TensorRT-LLM for Linux contains a vulnerability in the multimodal media fetching functions, where a network-acces",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2026-24234.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-24259",
+      "cwes": [],
+      "title": "NVIDIA TensorRT-LLM for Linux contains a vulnerability where an attacker could cause missing authentication for a critic",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2026-24259.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-24478",
+      "cwes": [],
+      "title": "AnythingLLM is an application that turns pieces of content into context that any LLM can use as references during chatti",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2026-24478.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-24516",
+      "cwes": [],
+      "title": "A command injection vulnerability exists in DigitalOcean Droplet Agent through 1",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2026-24516.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-24779",
+      "cwes": [],
+      "title": "vLLM is an inference and serving engine for large language models (LLMs)",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2026-24779.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-24881",
+      "cwes": [],
+      "title": "In GnuPG before 2",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2026-24881.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-25546",
+      "cwes": [],
+      "title": "Godot MCP is a Model Context Protocol (MCP) server for interacting with the Godot game engine",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2026-25546.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-2555",
+      "cwes": [],
+      "title": "A weakness has been identified in JeecgBoot 3",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "low",
+      "file": "euvd/CVE-2026-2555.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-25650",
+      "cwes": [],
+      "title": "MCP Salesforce Connector is a Model Context Protocol (MCP) server implementation for Salesforce integration",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2026-25650.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-25904",
+      "cwes": [],
+      "title": "The Pydantic-AI MCP Run Python tool configures the Deno sandbox with an overly permissive configuration that allows the ",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2026-25904.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-25905",
+      "cwes": [],
+      "title": "The Python code being run by 'runPython' or 'runPythonAsync' is not isolated from the rest of the JS code, allowing any ",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2026-25905.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-26001",
+      "cwes": [],
+      "title": "The GLPI Inventory Plugin handles network discovery, inventory, software deployment, and data collection for GLPI agents",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2026-26001.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-26015",
+      "cwes": [],
+      "title": "DocsGPT is a GPT-powered chat for documentation",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "critical",
+      "file": "euvd/CVE-2026-26015.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-26029",
+      "cwes": [],
+      "title": "sf-mcp-server is an implementation of Salesforce MCP server for Claude for Desktop",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2026-26029.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-26057",
+      "cwes": [],
+      "title": "Skill Scanner is a security scanner for AI Agent Skills that detects prompt injection, data exfiltration, and malicious ",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2026-26057.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-26268",
+      "cwes": [],
+      "title": "Cursor is a code editor built for programming with AI",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2026-26268.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-27113",
+      "cwes": [],
+      "title": "Liquid Prompt is an adaptive prompt for Bash and Zsh",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2026-27113.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-27203",
+      "cwes": [],
+      "title": "eBay API MCP Server is an open source local MCP server providing AI assistants with comprehensive access to eBay's Sell ",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2026-27203.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-2740",
+      "cwes": [],
+      "title": "Zohocorp ManageEngine ADSelfService Plus version before 6525, DataSecurity Plus before 6264 and RecoveryManager Plus bef",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2026-2740.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-27735",
+      "cwes": [],
+      "title": "Model Context Protocol Servers is a collection of reference implementations for the model context protocol (MCP)",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2026-27735.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-27794",
+      "cwes": [],
+      "title": "LangGraph Checkpoint defines the base interface for LangGraph checkpointers",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2026-27794.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-27896",
+      "cwes": [],
+      "title": "The Go MCP SDK used Go's standard encoding/json",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2026-27896.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-27952",
+      "cwes": [],
+      "title": "Agenta is an open-source LLMOps platform",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2026-27952.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-27961",
+      "cwes": [],
+      "title": "Agenta is an open-source LLMOps platform",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2026-27961.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-28463",
+      "cwes": [],
+      "title": "OpenClaw versions prior to 2026",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2026-28463.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-28797",
+      "cwes": [],
+      "title": "RAGFlow is an open-source RAG (Retrieval-Augmented Generation) engine",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2026-28797.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-29870",
+      "cwes": [],
+      "title": "A directory traversal vulnerability in the agentic-context-engine project versions up to 0",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2026-29870.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-29871",
+      "cwes": [],
+      "title": "A path traversal vulnerability exists in the awesome-llm-apps project in commit e46690f99c3f08be80a9877fab52acacf7ab8251",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2026-29871.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-30273",
+      "cwes": [],
+      "title": "pandas-ai v3",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2026-30273.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-30711",
+      "cwes": [],
+      "title": "Devome GRR v4",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2026-30711.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-31854",
+      "cwes": [],
+      "title": "Cursor is a code editor built for programming with AI",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2026-31854.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-32013",
+      "cwes": [],
+      "title": "OpenClaw versions prior to 2026",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2026-32013.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-32192",
+      "cwes": [],
+      "title": "Deserialization of untrusted data in Azure Monitor Agent allows an authorized attacker to elevate privileges locally",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2026-32192.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-32947",
+      "cwes": [],
+      "title": "Harden-Runner is a CI/CD security agent that works like an EDR for GitHub Actions runners",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2026-32947.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-32999",
+      "cwes": [],
+      "title": "Insufficient character filtering in backup agent signing module on Comet Backup server allows authenticated tenant admin",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "critical",
+      "file": "euvd/CVE-2026-32999.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-33075",
+      "cwes": [],
+      "title": "FastGPT is an AI Agent building platform",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "critical",
+      "file": "euvd/CVE-2026-33075.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-33081",
+      "cwes": [],
+      "title": "PinchTab is a standalone HTTP server that gives AI agents direct control over a Chrome browser",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2026-33081.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-33233",
+      "cwes": [],
+      "title": "AutoGPT is a workflow automation platform for creating, deploying, and managing continuous artificial intelligence agent",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2026-33233.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-33234",
+      "cwes": [],
+      "title": "AutoGPT is a workflow automation platform for creating, deploying, and managing continuous artificial intelligence agent",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2026-33234.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-33475",
+      "cwes": [],
+      "title": "Langflow is a tool for building and deploying AI-powered agents and workflows",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "critical",
+      "file": "euvd/CVE-2026-33475.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-33619",
+      "cwes": [],
+      "title": "PinchTab is a standalone HTTP server that gives AI agents direct control over a Chrome browser",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2026-33619.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-33623",
+      "cwes": [],
+      "title": "PinchTab is a standalone HTTP server that gives AI agents direct control over a Chrome browser",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2026-33623.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-33655",
+      "cwes": [],
+      "title": "New API is a large language mode (LLM) gateway and artificial intelligence (AI) asset management system",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2026-33655.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-33694",
+      "cwes": [],
+      "title": "This vulnerability allows an attacker to create a junction, enabling the deletion of arbitrary files with SYSTEM privile",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2026-33694.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-33701",
+      "cwes": [],
+      "title": "OpenTelemetry Java Instrumentation provides OpenTelemetry auto-instrumentation and instrumentation libraries for Java",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "critical",
+      "file": "euvd/CVE-2026-33701.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-33718",
+      "cwes": [],
+      "title": "OpenHands is software for AI-driven development",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2026-33718.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-33728",
+      "cwes": [],
+      "title": "dd-trace-java is a Datadog APM client for Java",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "critical",
+      "file": "euvd/CVE-2026-33728.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-34172",
+      "cwes": [],
+      "title": "Giskard is an open-source Python library for testing and evaluating agentic systems",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2026-34172.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-3456",
+      "cwes": [],
+      "title": "The GeekyBot — Generate AI Content Without Prompt, Chatbot and Lead Generation plugin for WordPress is vulnerable to SQL",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2026-3456.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-34724",
+      "cwes": [],
+      "title": "Zammad is a web based open source helpdesk/customer support system",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2026-34724.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-3484",
+      "cwes": [],
+      "title": "A vulnerability was detected in PhialsBasement nmap-mcp-server up to bee6d23547d57ae02460022f7c78ac0893092e38",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2026-3484.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-3486",
+      "cwes": [],
+      "title": "A vulnerability has been found in itsourcecode College Management System 1",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2026-3486.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-35020",
+      "cwes": [],
+      "title": "This CVE ID has been rejected by the its CVE Numbering Authority (CNA)",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2026-35020.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-35570",
+      "cwes": [],
+      "title": "OpenClaude is an open-source coding-agent command line interface for cloud and local model providers",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2026-35570.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-35615",
+      "cwes": [],
+      "title": "PraisonAI is a multi-agent teams system",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "critical",
+      "file": "euvd/CVE-2026-35615.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-35632",
+      "cwes": [],
+      "title": "OpenClaw through 2026",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2026-35632.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-36044",
+      "cwes": [],
+      "title": "@pensar/apex <= 0",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2026-36044.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-3680",
+      "cwes": [],
+      "title": "A security flaw has been discovered in RyuzakiShinji biome-mcp-server up to 1",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2026-3680.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-39006",
+      "cwes": [],
+      "title": "An issue in SNMP4J-Agent 3",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "low",
+      "file": "euvd/CVE-2026-39006.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-39305",
+      "cwes": [],
+      "title": "PraisonAI is a multi-agent teams system",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "critical",
+      "file": "euvd/CVE-2026-39305.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-39306",
+      "cwes": [],
+      "title": "PraisonAI is a multi-agent teams system",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2026-39306.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-39308",
+      "cwes": [],
+      "title": "PraisonAI is a multi-agent teams system",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2026-39308.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-39359",
+      "cwes": [],
+      "title": "Wazuh is a free and open source platform used for threat prevention, detection, and response",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2026-39359.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-40083",
+      "cwes": [],
+      "title": "Cacti is an open source performance and fault management framework",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2026-40083.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-40100",
+      "cwes": [],
+      "title": "FastGPT is an AI Agent building platform",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2026-40100.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-40114",
+      "cwes": [],
+      "title": "PraisonAI is a multi-agent teams system",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2026-40114.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-40148",
+      "cwes": [],
+      "title": "PraisonAI is a multi-agent teams system",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2026-40148.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-40158",
+      "cwes": [],
+      "title": "PraisonAI is a multi-agent teams system",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2026-40158.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-40288",
+      "cwes": [],
+      "title": "PraisonAI is a multi-agent teams system",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "critical",
+      "file": "euvd/CVE-2026-40288.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-40351",
+      "cwes": [],
+      "title": "FastGPT is an AI Agent building platform",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "critical",
+      "file": "euvd/CVE-2026-40351.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-40352",
+      "cwes": [],
+      "title": "FastGPT is an AI Agent building platform",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2026-40352.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-40516",
+      "cwes": [],
+      "title": "OpenHarness before commit bd4df81 contains a server-side request forgery vulnerability in the web_fetch and web_search t",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2026-40516.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-40518",
+      "cwes": [],
+      "title": "ByteDance DeerFlow before commit 2176b2b contains a path traversal and arbitrary file write vulnerability in bootstrap-m",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2026-40518.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-41065",
+      "cwes": [],
+      "title": "Tautulli is a Python based monitoring and tracking tool for Plex Media Server",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2026-41065.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-41378",
+      "cwes": [],
+      "title": "OpenClaw before 2026",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2026-41378.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-41679",
+      "cwes": [],
+      "title": "Paperclip is a Node",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "critical",
+      "file": "euvd/CVE-2026-41679.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-4192",
+      "cwes": [],
+      "title": "A vulnerability has been found in AvinashBole quip-mcp-server 1",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2026-4192.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-4199",
+      "cwes": [],
+      "title": "A vulnerability was identified in bazinga012 mcp_code_executor up to 0",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2026-4199.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-42048",
+      "cwes": [],
+      "title": "Langflow is a tool for building and deploying AI-powered agents and workflows",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "critical",
+      "file": "euvd/CVE-2026-42048.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-42075",
+      "cwes": [],
+      "title": "Evolver is a GEP-powered self-evolving engine for AI agents",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2026-42075.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-42076",
+      "cwes": [],
+      "title": "Evolver is a GEP-powered self-evolving engine for AI agents",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "critical",
+      "file": "euvd/CVE-2026-42076.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-42261",
+      "cwes": [],
+      "title": "PromptHub is an all-in-one AI toolbox for prompt, skill, and agent management",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2026-42261.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-42302",
+      "cwes": [],
+      "title": "FastGPT is an AI Agent building platform",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "critical",
+      "file": "euvd/CVE-2026-42302.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-42339",
+      "cwes": [],
+      "title": "New API is a large language mode (LLM) gateway and artificial intelligence (AI) asset management system",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2026-42339.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-42434",
+      "cwes": [],
+      "title": "OpenClaw versions 2026",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2026-42434.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-4269",
+      "cwes": [],
+      "title": "A missing S3 ownership verification in the Bedrock AgentCore Starter Toolkit before version v0",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2026-4269.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-42853",
+      "cwes": [],
+      "title": "ApostropheCMS is an open-source Node",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2026-42853.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-42867",
+      "cwes": [],
+      "title": "Langflow is a tool for building and deploying AI-powered agents and workflows",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2026-42867.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-4307",
+      "cwes": [],
+      "title": "A security flaw has been discovered in frdel/agent0ai agent-zero 0",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2026-4307.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-4308",
+      "cwes": [],
+      "title": "A weakness has been identified in frdel/agent0ai agent-zero 0",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2026-4308.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-43534",
+      "cwes": [],
+      "title": "OpenClaw before 2026",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "critical",
+      "file": "euvd/CVE-2026-43534.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-43899",
+      "cwes": [],
+      "title": "DeepChat is an open-source artificial intelligence agent platform that unifies models, tools, and agents",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "critical",
+      "file": "euvd/CVE-2026-43899.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-43938",
+      "cwes": [],
+      "title": "YetAnotherForum",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2026-43938.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-43993",
+      "cwes": [],
+      "title": "JunoClaw is an agentic AI platform built on Juno Network",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2026-43993.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-44285",
+      "cwes": [],
+      "title": "FastGPT is an AI Agent building platform",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2026-44285.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-44286",
+      "cwes": [],
+      "title": "FastGPT is an AI Agent building platform",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "low",
+      "file": "euvd/CVE-2026-44286.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-44335",
+      "cwes": [],
+      "title": "PraisonAI is a multi-agent teams system",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2026-44335.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-44688",
+      "cwes": [],
+      "title": "In Eclipse Theia versions prior to 1",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2026-44688.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-44712",
+      "cwes": [],
+      "title": "pam_usb provides hardware authentication for Linux using ordinary removable media",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2026-44712.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-44716",
+      "cwes": [],
+      "title": "Pipecat is an open-source Python framework for building real-time voice and multimodal conversational agents",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2026-44716.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-4496",
+      "cwes": [],
+      "title": "A vulnerability was found in sigmade Git-MCP-Server up to 785aa159f262a02d5791a5d8a8e13c507ac42880",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2026-4496.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-4530",
+      "cwes": [],
+      "title": "A security flaw has been discovered in apconw Aix-DB up to 1",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2026-4530.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-45373",
+      "cwes": [],
+      "title": "CodeWhale is a DeepSeek + MiMo coding agent in terminal",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2026-45373.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-46364",
+      "cwes": [],
+      "title": "phpMyFAQ before 4",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "critical",
+      "file": "euvd/CVE-2026-46364.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-46548",
+      "cwes": [],
+      "title": "NocoDB is software for building databases as spreadsheets",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2026-46548.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-46580",
+      "cwes": [],
+      "title": "In Eclipse Theia versions prior to 1",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2026-46580.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-47118",
+      "cwes": [],
+      "title": "Agent Zero before version 1",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2026-47118.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-47128",
+      "cwes": [],
+      "title": "nono is software that allows users to run AI agents in a zero-latency sandbox",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2026-47128.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-47250",
+      "cwes": [
+        "CWE-88"
+      ],
+      "title": "MCP Server Kubernetes: kubectl-generic flag injection enables Kubernetes bearer token exfiltration",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "ghsa/GHSA-6mx4-4h42-r8vh.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-47367",
+      "cwes": [],
+      "title": "A malicious actor with access to the network and low privileges could exploit an Improper Input Validation vulnerability",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "critical",
+      "file": "euvd/CVE-2026-47367.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-47470",
+      "cwes": [
+        "CWE-20"
+      ],
+      "title": "NVIDIA TensorRT-LLM for any platform contains a vulnerability in the gRPC server chat API endpoint, where an attacker co",
+      "proposedTactic": "ATD-TA2",
+      "category": "prompt-injection",
+      "severity": "medium",
+      "file": "euvd/CVE-2026-47470.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-47471",
+      "cwes": [],
+      "title": "NVIDIA TensorRT-LLM for any platform contains a vulnerability in tensor deserialization, where an attacker could cause a",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2026-47471.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-47472",
+      "cwes": [],
+      "title": "NVIDIA TensorRT-LLM contains a vulnerability in its inter-process communication layer where an attacker with local same-",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2026-47472.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-47828",
+      "cwes": [],
+      "title": "During bosh create-env and bosh delete-env, the CLI uploads compiled CPI packages and rendered job templates to the new ",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2026-47828.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-4810",
+      "cwes": [],
+      "title": "A Code Injection and Missing Authentication vulnerability in Google Agent Development Kit (ADK) versions 1",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "critical",
+      "file": "euvd/CVE-2026-4810.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-48124",
+      "cwes": [],
+      "title": "Cursor is a code editor built for programming with AI",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2026-48124.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-4837",
+      "cwes": [],
+      "title": "An eval() injection vulnerability in the Rapid7 Insight Agent beaconing logic for Linux versions could theoretically all",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2026-4837.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-48731",
+      "cwes": [],
+      "title": "Warp is an agentic development environment",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2026-48731.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-48732",
+      "cwes": [],
+      "title": "Warp is an agentic development environment",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2026-48732.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-48774",
+      "cwes": [],
+      "title": "ProxySQL is a proxy for MySQL and its forks, as well as PostgreSQL",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2026-48774.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-48775",
+      "cwes": [],
+      "title": "LangGraph SQLite Checkpoint is an implementation of LangGraph CheckpointSaver that uses SQLite DB (both sync and async, ",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2026-48775.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-48787",
+      "cwes": [],
+      "title": "gin-vue-admin is an AI-assisted basic development platform",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2026-48787.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-48814",
+      "cwes": [],
+      "title": "Network-AI is a TypeScript/Node",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "critical",
+      "file": "euvd/CVE-2026-48814.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-48989",
+      "cwes": [],
+      "title": "Windows-MCP is an open-source project that integrates AI agents with Windows",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2026-48989.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-49095",
+      "cwes": [
+        "CWE-20"
+      ],
+      "title": "Improper Input Validation (CWE-20) in the Kibana Fleet agent policy management feature can lead to privilege escalation",
+      "proposedTactic": "ATD-TA2",
+      "category": "prompt-injection",
+      "severity": "high",
+      "file": "euvd/CVE-2026-49095.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-49257",
+      "cwes": [],
+      "title": "mcp-pinot is a Python-based Model Context Protocol (MCP) server for interacting with Apache Pinot",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "critical",
+      "file": "euvd/CVE-2026-49257.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-49291",
+      "cwes": [],
+      "title": "mcp-memory-service is a semantic memory layer for AI applications",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2026-49291.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-49357",
+      "cwes": [],
+      "title": "Line Desktop MCP is a project that, while unaffiliated with the official line-bot-mcp-server, allows users to directly o",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2026-49357.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-5023",
+      "cwes": [],
+      "title": "A vulnerability has been found in DeDeveloper23 codebase-mcp up to 3ec749d237dd8eabbeef48657cf917275792fde6",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2026-5023.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-50548",
+      "cwes": [],
+      "title": "Cursor is a code editor built for programming with AI",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "critical",
+      "file": "euvd/CVE-2026-50548.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-50757",
+      "cwes": [],
+      "title": "Directory Traversal vulnerability in DayuanJiang next-ai-draw-io 0",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "low",
+      "file": "euvd/CVE-2026-50757.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-5125",
+      "cwes": [],
+      "title": "A vulnerability was detected in raine consult-llm-mcp up to 2",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2026-5125.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-5131",
+      "cwes": [],
+      "title": "GREENmod uses named pipes for communication between plugins, the web portal, and the system service, but the access cont",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2026-5131.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-5269",
+      "cwes": [],
+      "title": "In Ciena's Navigator Network Control Suite (NCS) and Manage Control Plan (MCP), there are hidden system accounts used fo",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "low",
+      "file": "euvd/CVE-2026-5269.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-5270",
+      "cwes": [],
+      "title": "An authentication bypass vulnerability exists in certain releases of Ciena Navigator Network Control Suite (NCS), Manage",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "low",
+      "file": "euvd/CVE-2026-5270.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-5346",
+      "cwes": [],
+      "title": "A vulnerability was determined in huimeicloud hm_editor up to 2",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2026-5346.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-53476",
+      "cwes": [],
+      "title": "A flaw was found in assisted-migration-agent",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "critical",
+      "file": "euvd/CVE-2026-53476.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-53808",
+      "cwes": [],
+      "title": "OpenClaw before 2026",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2026-53808.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-53814",
+      "cwes": [
+        "CWE-266"
+      ],
+      "title": "OpenClaw before 2026.5.20 contains a privilege escalation vulnerability where hook-triggered agent runs incorr",
+      "proposedTactic": "ATD-TA2",
+      "category": "prompt-injection",
+      "severity": "high",
+      "file": "nvd/CVE-2026-53814.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-5429",
+      "cwes": [],
+      "title": "Unsanitized input during web page generation in the Kiro Agent webview in Kiro IDE before version 0",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2026-5429.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-54319",
+      "cwes": [],
+      "title": "Daytona is a secure and elastic infrastructure runtime for AI-generated code execution and agent workflows",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2026-54319.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-54320",
+      "cwes": [],
+      "title": "Daytona is a secure and elastic infrastructure runtime for AI-generated code execution and agent workflows",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2026-54320.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-54321",
+      "cwes": [],
+      "title": "Daytona is a secure and elastic infrastructure runtime for AI-generated code execution and agent workflows",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2026-54321.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-54322",
+      "cwes": [],
+      "title": "Daytona is a secure and elastic infrastructure runtime for AI-generated code execution and agent workflows",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2026-54322.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-54323",
+      "cwes": [],
+      "title": "Daytona is a secure and elastic infrastructure runtime for AI-generated code execution and agent workflows",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2026-54323.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-54324",
+      "cwes": [],
+      "title": "Daytona is a secure and elastic infrastructure runtime for AI-generated code execution and agent workflows",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2026-54324.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-54699",
+      "cwes": [],
+      "title": "Warp is an agentic development environment",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2026-54699.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-5528",
+      "cwes": [],
+      "title": "A security vulnerability has been detected in MoussaabBadla code-screenshot-mcp up to 0",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2026-5528.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-55412",
+      "cwes": [],
+      "title": "ToolJet is the open-source foundation am AI-native platform for building and deploying internal tools, workflows and AI ",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2026-55412.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-55413",
+      "cwes": [],
+      "title": "ToolJet is the open-source foundation am AI-native platform for building and deploying internal tools, workflows and AI ",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "critical",
+      "file": "euvd/CVE-2026-55413.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-5587",
+      "cwes": [],
+      "title": "A vulnerability was identified in wbbeyourself MAC-SQL up to 31a9df5e0d520be4769be57a4b9022e5e34a14f4",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2026-5587.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-56076",
+      "cwes": [],
+      "title": "PraisonAI before 1",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2026-56076.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-56077",
+      "cwes": [],
+      "title": "PraisonAI before 1",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2026-56077.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-56078",
+      "cwes": [],
+      "title": "PraisonAI before 1",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2026-56078.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-56151",
+      "cwes": [
+        "CWE-20"
+      ],
+      "title": "Improper Input Validation (CWE-20) in Kibana can lead to a denial of service via Input Data Manipulation (CAPEC-153)",
+      "proposedTactic": "ATD-TA2",
+      "category": "prompt-injection",
+      "severity": "medium",
+      "file": "euvd/CVE-2026-56151.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-5621",
+      "cwes": [],
+      "title": "A vulnerability was found in ChrisChinchilla Vale-MCP up to 0",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2026-5621.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-56261",
+      "cwes": [],
+      "title": "Crawl4AI before 0",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "critical",
+      "file": "euvd/CVE-2026-56261.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-56266",
+      "cwes": [],
+      "title": "Crawl4AI before 0",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "critical",
+      "file": "euvd/CVE-2026-56266.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-5627",
+      "cwes": [],
+      "title": "A path traversal vulnerability exists in mintplex-labs/anything-llm versions up to and including 1",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "critical",
+      "file": "euvd/CVE-2026-5627.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-56663",
+      "cwes": [],
+      "title": "AutoGPT is a workflow automation platform for creating, deploying, and managing continuous artificial intelligence agent",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2026-56663.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-56692",
+      "cwes": [],
+      "title": "NanoClaw before 2",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2026-56692.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-56696",
+      "cwes": [],
+      "title": "OpenHarness /issue and /pr_comments slash commands lack remote_invocable=False protection, allowing remote channel sende",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2026-56696.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-57301",
+      "cwes": [],
+      "title": "Jenkins OWASP ZAP Plugin 1",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2026-57301.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-58170",
+      "cwes": [],
+      "title": "Vibe-Trading before 0",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2026-58170.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-58499",
+      "cwes": [],
+      "title": "EverOS is a memory runtime for agents",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2026-58499.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-59800",
+      "cwes": [],
+      "title": "9Router before 0",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "critical",
+      "file": "euvd/CVE-2026-59800.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-5998",
+      "cwes": [],
+      "title": "A flaw has been found in zhayujie chatgpt-on-wechat CowAgent up to 2",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2026-5998.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-6011",
+      "cwes": [],
+      "title": "A weakness has been identified in OpenClaw up to 2026",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2026-6011.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-61426",
+      "cwes": [],
+      "title": "PraisonAI before 1",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2026-61426.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-61613",
+      "cwes": [],
+      "title": "Cursor is a code editor built for programming with AI",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2026-61613.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-63077",
+      "cwes": [],
+      "title": "In JetBrains TeamCity before 2026",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "critical",
+      "file": "euvd/CVE-2026-63077.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-6348",
+      "cwes": [],
+      "title": "WinMatrix agent developed by Simopro Technology has a Missing Authentication vulnerability, allowing authenticated local",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "critical",
+      "file": "euvd/CVE-2026-6348.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-6389",
+      "cwes": [],
+      "title": "IBM Turbonomic prometurbo agent 8",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2026-6389.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-6442",
+      "cwes": [],
+      "title": "Improper validation of bash commands in Snowflake Cortex Code CLI versions prior to 1",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2026-6442.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-64651",
+      "cwes": [],
+      "title": "The `@ai-sdk/harness-opencode` tool connects HarnessAgent to OpenCode through a sandboxed bridge",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2026-64651.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-6516",
+      "cwes": [],
+      "title": "Zohocorp ManageEngine ADAudit Plus versions before 8606 are affected by Unauthenticated Remote code execution due to the",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "critical",
+      "file": "euvd/CVE-2026-6516.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-65695",
+      "cwes": [],
+      "title": "Office-Word-MCP-Server through 1",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2026-65695.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-65698",
+      "cwes": [],
+      "title": "Void through 1",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2026-65698.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-66138",
+      "cwes": [],
+      "title": "In OpenStack Ironic Python Agent through 11",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2026-66138.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-6663",
+      "cwes": [],
+      "title": "The GWD Connect plugin for WordPress is vulnerable to missing authorization to limited code execution in all versions up",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2026-6663.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-6942",
+      "cwes": [],
+      "title": "radare2-mcp version 1",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "critical",
+      "file": "euvd/CVE-2026-6942.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-6980",
+      "cwes": [],
+      "title": "A vulnerability has been found in Divyanshu-hash GitPilot-MCP up to 9ed9f153ba4158a2ad230ee4871b25130da29ffd",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2026-6980.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-7038",
+      "cwes": [],
+      "title": "A weakness has been identified in tufantunc ssh-mcp up to 1",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2026-7038.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-7039",
+      "cwes": [],
+      "title": "A security vulnerability has been detected in tufantunc ssh-mcp up to 1",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2026-7039.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-7064",
+      "cwes": [],
+      "title": "A flaw has been found in AgentDeskAI browser-tools-mcp up to 1",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2026-7064.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-7066",
+      "cwes": [],
+      "title": "A vulnerability was found in choieastsea simple-openstack-mcp up to 767b2f4a8154cca344344b9725537a58399e6036",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2026-7066.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-7157",
+      "cwes": [],
+      "title": "A flaw has been found in disler aider-mcp-server up to b2516fa466d0d851932da92ee6d0e66946db9efc",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2026-7157.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-7205",
+      "cwes": [],
+      "title": "A vulnerability was identified in duartium papers-mcp-server 9ceb3812a6458ba7922ca24a7406f8807bc55598",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2026-7205.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-7216",
+      "cwes": [],
+      "title": "A weakness has been identified in donchelo processing-claude-mcp-bridge up to e017b20a4b592a45531a6392f494007f04e661bd",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2026-7216.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-7217",
+      "cwes": [],
+      "title": "A security vulnerability has been detected in Deepractice PromptX up to 2",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2026-7217.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-7220",
+      "cwes": [],
+      "title": "A vulnerability has been found in jackwrichards FastlyMCP up to 6f3d0b0e654fc51076badc7fa16c03c461f95620",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2026-7220.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-7235",
+      "cwes": [],
+      "title": "A security vulnerability has been detected in ErlichLiu claude-agent-sdk-master up to b185aa7ff0d864581257008077b4010fca",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2026-7235.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-7237",
+      "cwes": [],
+      "title": "A vulnerability was detected in AgiFlow scaffold-mcp up to 1",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2026-7237.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-7271",
+      "cwes": [],
+      "title": "A vulnerability was detected in DV0x creative-ad-agent up to 751b9e5146604dc65049bd0f62dcbdad6212f8a3",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2026-7271.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-7314",
+      "cwes": [],
+      "title": "A vulnerability was detected in eiceblue spire-doc-mcp-server 1",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2026-7314.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-7315",
+      "cwes": [],
+      "title": "A flaw has been found in eiceblue spire-pdf-mcp-server 0",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2026-7315.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-7316",
+      "cwes": [],
+      "title": "A vulnerability has been found in eiliyaabedini aider-mcp up to 667b914301aada695aab0e46d1fb3a7d5e32c8af",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2026-7316.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-7319",
+      "cwes": [],
+      "title": "A flaw has been found in elinsky execution-system-mcp 0",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2026-7319.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-7386",
+      "cwes": [],
+      "title": "A flaw has been found in fatbobman mail-mcp-bridge up to 1",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2026-7386.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-7396",
+      "cwes": [],
+      "title": "A vulnerability was identified in NousResearch hermes-agent 0",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2026-7396.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-7400",
+      "cwes": [],
+      "title": "A security vulnerability has been detected in geekgod382 filesystem-mcp-server 1",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2026-7400.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-7403",
+      "cwes": [],
+      "title": "A security flaw has been discovered in geldata gel-mcp 0",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2026-7403.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-7404",
+      "cwes": [],
+      "title": "A weakness has been identified in getsimpletool mcpo-simple-server up to 0",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2026-7404.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-7466",
+      "cwes": [],
+      "title": "AgentFlow contains an arbitrary code execution vulnerability that allows attackers to execute local Python pipeline file",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2026-7466.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-7588",
+      "cwes": [],
+      "title": "A vulnerability was found in ggerve coding-standards-mcp",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2026-7588.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-7589",
+      "cwes": [],
+      "title": "A vulnerability was determined in ghantakiran splunk-mcp-integration up to 0b86b09d5e5adf0433acd43c975951224613a1a6",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2026-7589.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-7627",
+      "cwes": [],
+      "title": "A security vulnerability has been detected in 8nite metatrader-4-mcp 1",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2026-7627.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-7644",
+      "cwes": [],
+      "title": "A vulnerability has been found in ChatGPTNextWeb NextChat up to 2",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2026-7644.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-7785",
+      "cwes": [],
+      "title": "A security flaw has been discovered in A-G-U-P-T-A wireshark-mcp edaf604416fbc94a201b4043092d4a1b09a12275/400c3da70074f2",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2026-7785.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-7810",
+      "cwes": [],
+      "title": "A flaw has been found in UsamaK98 python-notebook-mcp up to a05a232815809a7e425b5fa7be26e0d4369894c2",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2026-7810.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-8116",
+      "cwes": [],
+      "title": "A weakness has been identified in huangjunsen0406 xiaozhi-mcphub up to 1",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2026-8116.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-8797",
+      "cwes": [],
+      "title": "An access control deficiency vulnerability exists in ExpressUpdate Agent for Windows",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "euvd/CVE-2026-8797.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-9073",
+      "cwes": [],
+      "title": "A flaw was found in foreman-mcp-server",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2026-9073.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-9351",
+      "cwes": [],
+      "title": "A security flaw has been discovered in NousResearch hermes-agent up to 2026",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2026-9351.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-9367",
+      "cwes": [],
+      "title": "A vulnerability was determined in NousResearch hermes-agent up to 5157f5427f19488b31c6fdebbacd15d798ce7f63",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2026-9367.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-9468",
+      "cwes": [],
+      "title": "A security flaw has been discovered in dazeb cline-mcp-memory-bank up to 55c81b9cf6c16700983c84dc4cdea3cafa19a75f",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2026-9468.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-9473",
+      "cwes": [],
+      "title": "A vulnerability has been found in c-rick jimeng-mcp 1",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2026-9473.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-9565",
+      "cwes": [],
+      "title": "A vulnerability was determined in haojing8312 WorkClaw up to 0",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "euvd/CVE-2026-9565.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-45805",
+      "cwes": [
+        "CWE-749"
+      ],
+      "title": "PenPot MCP REPL server binds to 0.0.0.0 with unauthenticated /execute endpoint — RCE",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "ghsa/GHSA-22qr-rp27-j9wm.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-9353",
+      "cwes": [
+        "CWE-74"
+      ],
+      "title": "hermes-agent has an Injection issue",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "ghsa/GHSA-238w-f66p-w349.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-55615",
+      "cwes": [
+        "CWE-74"
+      ],
+      "title": "Langroid: Neo4jChatAgent executes LLM-generated Cypher without validation (prompt-to-Cypher injection; config-conditiona",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "critical",
+      "file": "ghsa/GHSA-2pq5-3q89-j7cc.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-6209",
+      "cwes": [
+        "CWE-29"
+      ],
+      "title": "LlamaIndex vulnerable to Path Traversal attack through its encode_image function",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "ghsa/GHSA-2rhq-96q8-4vjq.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-54547",
+      "cwes": [
+        "CWE-287"
+      ],
+      "title": "meta-ads-mcp: X-Pipeboard-Token Header Auth Bypass Reuses Operator Meta Token",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "ghsa/GHSA-2v2f-mvfg-ph56.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-10223",
+      "cwes": [
+        "CWE-74"
+      ],
+      "title": "hermes-agent has an Injection issue",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "low",
+      "file": "ghsa/GHSA-33qv-c5qm-799v.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-53366",
+      "cwes": [
+        "CWE-248"
+      ],
+      "title": "MCP Python SDK vulnerability in the FastMCP Server causes validation error, leading to DoS",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "ghsa/GHSA-3qhf-m339-9g5v.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2024-2952",
+      "cwes": [
+        "CWE-76"
+      ],
+      "title": "LiteLLM has Server-Side Template Injection vulnerability in /completions endpoint",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "critical",
+      "file": "ghsa/GHSA-46cm-pfwv-cgf8.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-7206",
+      "cwes": [
+        "CWE-74"
+      ],
+      "title": "sqlite-mcp has an Injection issue",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "ghsa/GHSA-4j28-22qp-rjcf.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-5327",
+      "cwes": [
+        "CWE-74"
+      ],
+      "title": "fast-filesystem-mcp is vulnerable to command injection through handleGetDiskUsage function",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "low",
+      "file": "ghsa/GHSA-5226-3rvg-hp4x.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2023-36188",
+      "cwes": [
+        "CWE-74"
+      ],
+      "title": "langchain vulnerable to arbitrary code execution",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "critical",
+      "file": "ghsa/GHSA-57fc-8q82-gfp3.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2023-34541",
+      "cwes": [],
+      "title": "Langchain vulnerable to arbitrary code execution",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "critical",
+      "file": "ghsa/GHSA-6643-h7h5-x9wh.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-35002",
+      "cwes": [
+        "CWE-95"
+      ],
+      "title": "Agno is vulnerable to Eval Injection",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "critical",
+      "file": "ghsa/GHSA-77rh-m34w-rv36.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-0621",
+      "cwes": [
+        "CWE-1333"
+      ],
+      "title": "Anthropic's MCP TypeScript SDK has a ReDoS vulnerability",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "ghsa/GHSA-8r9q-7v3j-jr4g.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-42073",
+      "cwes": [
+        "CWE-352",
+        "CWE-400"
+      ],
+      "title": "OpenClaude MCP OAuth Callback: State Check Bypass via error Param Leads to DoS",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "ghsa/GHSA-c73c-x77g-854r.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-6603",
+      "cwes": [
+        "CWE-74"
+      ],
+      "title": "AgentScope Vulnerable to Remote Code Injection",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "ghsa/GHSA-cr24-fv3h-8cjm.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-41268",
+      "cwes": [
+        "CWE-20"
+      ],
+      "title": "Flowise: Parameter Override Bypass Remote Command Execution",
+      "proposedTactic": "ATD-TA2",
+      "category": "prompt-injection",
+      "severity": "high",
+      "file": "ghsa/GHSA-cvrr-qhgw-2mm6.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2024-6961",
+      "cwes": [
+        "CWE-611"
+      ],
+      "title": "Guardrails AI vulnerable to Improper Restriction of XML External Entity Reference",
+      "proposedTactic": "ATD-TA2",
+      "category": "context-exfiltration",
+      "severity": "high",
+      "file": "ghsa/GHSA-f8hx-f4xw-c646.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2023-44467",
+      "cwes": [],
+      "title": "langchain_experimental vulnerable to arbitrary code execution via PALChain in the python exec method",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "critical",
+      "file": "ghsa/GHSA-gjjr-63x4-v8cq.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-44339",
+      "cwes": [
+        "CWE-470"
+      ],
+      "title": "PraisonAI has unsafe tool resolution in `ToolExecutionMixin.execute_tool`: undeclared `__main__` callables execute",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "ghsa/GHSA-gmjg-hv98-qggq.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2024-41950",
+      "cwes": [
+        "CWE-1336"
+      ],
+      "title": "Insecure Jinja2 templates rendered in Haystack Components can lead to RCE",
+      "proposedTactic": "ATD-TA2",
+      "category": "prompt-injection",
+      "severity": "high",
+      "file": "ghsa/GHSA-hx9v-6r9f-w677.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-46701",
+      "cwes": [
+        "CWE-346"
+      ],
+      "title": "Network-AI: Unauthenticated Cross-Origin MCP Tool Invocation via Empty Default Secret",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "ghsa/GHSA-j3vx-cx2r-pvg8.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-53365",
+      "cwes": [
+        "CWE-248"
+      ],
+      "title": "MCP Python SDK has Unhandled Exception in Streamable HTTP Transport, Leading to Denial of Service",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "ghsa/GHSA-j975-95f5-7wqh.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-44970",
+      "cwes": [
+        "CWE-201"
+      ],
+      "title": "dbt MCP Server Transmits All MCP Tool Arguments Including Raw SQL and --vars Credentials to dbt Labs Telemetry by Defaul",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "low",
+      "file": "ghsa/GHSA-jj54-r8gm-2fcf.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-31040",
+      "cwes": [
+        "CWE-20"
+      ],
+      "title": "stata-mcp has insufficient validation of user-supplied Stata do-file content that can lead to command execution",
+      "proposedTactic": "ATD-TA2",
+      "category": "prompt-injection",
+      "severity": "high",
+      "file": "ghsa/GHSA-jpcj-7wfg-mqxv.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-46341",
+      "cwes": [
+        "CWE-20",
+        "CWE-183"
+      ],
+      "title": "Apify Model Context Protocol (MCP) server: Domain Allowlist Bypass in fetch-apify-docs via String Prefix Matching",
+      "proposedTactic": "ATD-TA2",
+      "category": "prompt-injection",
+      "severity": "medium",
+      "file": "ghsa/GHSA-jwp7-wg77-3w9v.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-10222",
+      "cwes": [
+        "CWE-74"
+      ],
+      "title": "hermes-agent has an Injection issue",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "low",
+      "file": "ghsa/GHSA-mv8x-fg99-32mf.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2024-46946",
+      "cwes": [
+        "CWE-95"
+      ],
+      "title": "LangChain Experimental Eval Injection vulnerability",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "critical",
+      "file": "ghsa/GHSA-p2qj-r53j-h3xj.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-9366",
+      "cwes": [
+        "CWE-74"
+      ],
+      "title": "hermes-agent has an Injection issue",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "ghsa/GHSA-pgp4-xr4j-h5cg.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2023-39659",
+      "cwes": [
+        "CWE-74"
+      ],
+      "title": "LangChain vulnerable to arbitrary code execution",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "critical",
+      "file": "ghsa/GHSA-prgp-w7vf-ch62.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-48985",
+      "cwes": [
+        "CWE-20",
+        "CWE-682"
+      ],
+      "title": "Vercel’s AI SDK's filetype whitelists can be bypassed when uploading files",
+      "proposedTactic": "ATD-TA2",
+      "category": "prompt-injection",
+      "severity": "low",
+      "file": "ghsa/GHSA-rwvc-j5jr-mgvh.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2024-27444",
+      "cwes": [
+        "CWE-749"
+      ],
+      "title": "LangChain Experimental vulnerable to arbitrary code execution",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "critical",
+      "file": "ghsa/GHSA-v8vj-cv27-hjv8.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2024-45858",
+      "cwes": [
+        "CWE-95"
+      ],
+      "title": "Guardrails has an arbitrary code execution vulnerability",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "ghsa/GHSA-w392-75q8-vr67.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-69253",
+      "cwes": [
+        "CWE-95"
+      ],
+      "title": "Flowise Sandbox Escape to RCE",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "critical",
+      "file": "ghsa/GHSA-wg86-r78f-74mp.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2024-38459",
+      "cwes": [
+        "CWE-276"
+      ],
+      "title": "langchain_experimental Code Execution via Python REPL access",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "ghsa/GHSA-wmvm-9vqv-5qpp.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-69263",
+      "cwes": [
+        "CWE-184"
+      ],
+      "title": "Flowise: CVE-2025-8943 Patch Bypass: npm_config_yes bypasses MCP environment variable blocklist (Unauthenticated RCE)",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "ghsa/GHSA-xc48-889x-5qmw.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-44968",
+      "cwes": [
+        "CWE-88"
+      ],
+      "title": "dbt MCP Server has an Argument Injection in dbt CLI Tool Wrappers via node_selection and resource_type Parameters",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "ghsa/GHSA-xpww-f6pm-cfhq.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-10221",
+      "cwes": [
+        "CWE-74"
+      ],
+      "title": "hermes-agent has an Injection issue",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "ghsa/GHSA-xq8w-9jvx-gm3v.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-42203",
+      "cwes": [
+        "CWE-1336"
+      ],
+      "title": "LiteLLM: Server-Side Template Injection in /prompts/test endpoint",
+      "proposedTactic": "ATD-TA2",
+      "category": "prompt-injection",
+      "severity": "high",
+      "file": "ghsa/GHSA-xqmj-j6mv-4862.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2024-0550",
+      "cwes": [
+        "CWE-23"
+      ],
+      "title": "AnythingLLM Profile Picture Path Traversal",
+      "proposedTactic": "ATD-TA2",
+      "category": "context-exfiltration",
+      "severity": "high",
+      "file": "huntr/CVE-2024-0550.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-0284",
+      "cwes": [
+        "CWE-74"
+      ],
+      "title": "Palo Alto NetworksのPAN-OSにおけるインジェクションに関する脆弱性",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "critical",
+      "file": "jvn/CVE-2026-0284.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-14380",
+      "cwes": [
+        "CWE-95"
+      ],
+      "title": "The Perl FoundationのDBIにおけるEval インジェクションに関する脆弱性",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "jvn/CVE-2026-14380.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-17991",
+      "cwes": [
+        "CWE-20"
+      ],
+      "title": "GoogleのGoogle Chromeにおける入力確認に関する脆弱性",
+      "proposedTactic": "ATD-TA2",
+      "category": "prompt-injection",
+      "severity": "critical",
+      "file": "jvn/CVE-2026-17991.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-45065",
+      "cwes": [
+        "CWE-185",
+        "CWE-601"
+      ],
+      "title": "Sensio LabsのSymfonyにおける複数の脆弱性",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "medium",
+      "file": "jvn/CVE-2026-45065.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-49042",
+      "cwes": [
+        "CWE-20"
+      ],
+      "title": "Apache Software FoundationのApache Camelにおける入力確認に関する脆弱性",
+      "proposedTactic": "ATD-TA2",
+      "category": "prompt-injection",
+      "severity": "high",
+      "file": "jvn/CVE-2026-49042.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-49214",
+      "cwes": [
+        "CWE-113",
+        "CWE-20",
+        "CWE-93"
+      ],
+      "title": "guzzlephpのpsr-7における複数の脆弱性",
+      "proposedTactic": "ATD-TA2",
+      "category": "prompt-injection",
+      "severity": "medium",
+      "file": "jvn/CVE-2026-49214.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-49875",
+      "cwes": [
+        "CWE-611"
+      ],
+      "title": "Apache Software FoundationのApache CXFにおけるXML 外部エンティティの脆弱性",
+      "proposedTactic": "ATD-TA2",
+      "category": "context-exfiltration",
+      "severity": "critical",
+      "file": "jvn/CVE-2026-49875.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-50632",
+      "cwes": [
+        "CWE-20"
+      ],
+      "title": "Apache Software FoundationのApache CXFにおける入力確認に関する脆弱性",
+      "proposedTactic": "ATD-TA2",
+      "category": "prompt-injection",
+      "severity": "high",
+      "file": "jvn/CVE-2026-50632.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-50633",
+      "cwes": [
+        "CWE-20"
+      ],
+      "title": "Apache Software FoundationのApache CXFにおける入力確認に関する脆弱性",
+      "proposedTactic": "ATD-TA2",
+      "category": "prompt-injection",
+      "severity": "high",
+      "file": "jvn/CVE-2026-50633.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-55973",
+      "cwes": [
+        "CWE-20"
+      ],
+      "title": "NLnet Labsのunboundにおける入力確認に関する脆弱性",
+      "proposedTactic": "ATD-TA2",
+      "category": "prompt-injection",
+      "severity": "high",
+      "file": "jvn/CVE-2026-55973.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-58213",
+      "cwes": [
+        "CWE-74"
+      ],
+      "title": "Linux Foundationのnats-serverにおけるインジェクションに関する脆弱性",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "jvn/CVE-2026-58213.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-63734",
+      "cwes": [
+        "CWE-20"
+      ],
+      "title": "SurrealDBにおける入力確認に関する脆弱性",
+      "proposedTactic": "ATD-TA2",
+      "category": "prompt-injection",
+      "severity": "medium",
+      "file": "jvn/CVE-2026-63734.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-33833",
+      "cwes": [
+        "CWE-20",
+        "CWE-74"
+      ],
+      "title": "Azure Machine Learning Notebook Spoofing Vulnerability",
+      "proposedTactic": "ATD-TA2",
+      "category": "prompt-injection",
+      "severity": "high",
+      "file": "msrc/CVE-2026-33833.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-41100",
+      "cwes": [
+        "CWE-20"
+      ],
+      "title": "Microsoft 365 Copilot for Android Spoofing Vulnerability",
+      "proposedTactic": "ATD-TA2",
+      "category": "prompt-injection",
+      "severity": "high",
+      "file": "msrc/CVE-2026-41100.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-41614",
+      "cwes": [
+        "CWE-20"
+      ],
+      "title": "M365 Copilot for Desktop Spoofing Vulnerability",
+      "proposedTactic": "ATD-TA2",
+      "category": "prompt-injection",
+      "severity": "high",
+      "file": "msrc/CVE-2026-41614.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2024-37032",
+      "cwes": [],
+      "title": "Ollama - Remote Code Execution",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "critical",
+      "file": "nuclei/CVE-2024-37032.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-26319",
+      "cwes": [
+        "CWE-434"
+      ],
+      "title": "FlowiseAI Flowise <= 2.2.6 - Arbitrary File Upload",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "nuclei/CVE-2025-26319.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-71324",
+      "cwes": [
+        "CWE-73"
+      ],
+      "title": "Flowise - Path Traversal",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "nuclei/CVE-2025-71324.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-71334",
+      "cwes": [
+        "CWE-73"
+      ],
+      "title": "Flowise - Path Traversal",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "critical",
+      "file": "nuclei/CVE-2025-71334.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-10750",
+      "cwes": [],
+      "title": "The Royal MCP WordPress plugin before 1.4.26 does not perform capability checks on the majority of its MCP too",
+      "proposedTactic": "ATD-TA2",
+      "category": "prompt-injection",
+      "severity": "high",
+      "file": "nvd/CVE-2026-10750.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-11371",
+      "cwes": [],
+      "title": "The BetterDocs WordPress plugin before 4.5.5 does not sanitise an AI-generated documentation summary before st",
+      "proposedTactic": "ATD-TA2",
+      "category": "prompt-injection",
+      "severity": "medium",
+      "file": "nvd/CVE-2026-11371.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-11624",
+      "cwes": [
+        "CWE-346"
+      ],
+      "title": "The Model Context Protocol has a security warning advising servers to validate the \"Origin\" header on all inco",
+      "proposedTactic": "ATD-TA2",
+      "category": "prompt-injection",
+      "severity": "medium",
+      "file": "nvd/CVE-2026-11624.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-12112",
+      "cwes": [
+        "CWE-287"
+      ],
+      "title": "A flaw was found in the foreman-mcp-server.",
+      "proposedTactic": "ATD-TA4",
+      "category": "privilege-escalation",
+      "severity": "high",
+      "file": "nvd/CVE-2026-12112.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-12773",
+      "cwes": [
+        "CWE-287",
+        "CWE-303"
+      ],
+      "title": "A weakness has been identified in BerriAI litellm up to 1.59.8.",
+      "proposedTactic": "ATD-TA4",
+      "category": "privilege-escalation",
+      "severity": "high",
+      "file": "nvd/CVE-2026-12773.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-13341",
+      "cwes": [
+        "CWE-20"
+      ],
+      "title": "A vulnerability exists in the Kong Konnect Model Context Protocol (MCP) server prior to version 1.0.0, which c",
+      "proposedTactic": "ATD-TA2",
+      "category": "prompt-injection",
+      "severity": "high",
+      "file": "nvd/CVE-2026-13341.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-13489",
+      "cwes": [
+        "CWE-662"
+      ],
+      "title": "A weakness has been identified in 78 xiaozhi-esp32 up to 2.2.6.",
+      "proposedTactic": "ATD-TA2",
+      "category": "prompt-injection",
+      "severity": "low",
+      "file": "nvd/CVE-2026-13489.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-13524",
+      "cwes": [
+        "CWE-266",
+        "CWE-285"
+      ],
+      "title": "A security vulnerability has been detected in CherryHQ cherry-studio up to 1.9.6.",
+      "proposedTactic": "ATD-TA2",
+      "category": "prompt-injection",
+      "severity": "medium",
+      "file": "nvd/CVE-2026-13524.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-14539",
+      "cwes": [
+        "CWE-770"
+      ],
+      "title": "An allocation of resources without limits vulnerability in the HTTP handler component of Google mcp-toolbox ve",
+      "proposedTactic": "ATD-TA2",
+      "category": "prompt-injection",
+      "severity": "medium",
+      "file": "nvd/CVE-2026-14539.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-14541",
+      "cwes": [
+        "CWE-287"
+      ],
+      "title": "An authentication bypass and audience confusion vulnerability exists in the Google OAuth provider component of",
+      "proposedTactic": "ATD-TA4",
+      "category": "privilege-escalation",
+      "severity": "medium",
+      "file": "nvd/CVE-2026-14541.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-15415",
+      "cwes": [
+        "CWE-23"
+      ],
+      "title": "AWS HealthOmics is a HIPAA-eligible service that fully manages the compute, storage, and workflow engine infra",
+      "proposedTactic": "ATD-TA2",
+      "category": "prompt-injection",
+      "severity": "medium",
+      "file": "nvd/CVE-2026-15415.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-15583",
+      "cwes": [],
+      "title": "A confused-deputy flaw in Grafana MCP Server allows an unauthenticated remote attacker to exfiltrate the serve",
+      "proposedTactic": "ATD-TA2",
+      "category": "prompt-injection",
+      "severity": "high",
+      "file": "nvd/CVE-2026-15583.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-15976",
+      "cwes": [],
+      "title": "SGLang contains a RCE vulnerability when attempting to load model weights from a HuggingFace repository, speci",
+      "proposedTactic": "ATD-TA2",
+      "category": "prompt-injection",
+      "severity": "medium",
+      "file": "nvd/CVE-2026-15976.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-15988",
+      "cwes": [
+        "CWE-352"
+      ],
+      "title": "The AI Engine – The Chatbot, AI Framework & MCP for WordPress plugin for WordPress is vulnerable to Cross-Site",
+      "proposedTactic": "ATD-TA3",
+      "category": "agent-manipulation",
+      "severity": "high",
+      "file": "nvd/CVE-2026-15988.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-16496",
+      "cwes": [
+        "CWE-384"
+      ],
+      "title": "The terraform-mcp-server before version 1.1.0 is vulnerable to an authorization bypass in the streamable-HTTP ",
+      "proposedTactic": "ATD-TA2",
+      "category": "prompt-injection",
+      "severity": "high",
+      "file": "nvd/CVE-2026-16496.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-16584",
+      "cwes": [
+        "CWE-455"
+      ],
+      "title": "Improper handling of an initialization failure in AWS API MCP Server from 0.2.13 through 1.3.46 might allow an",
+      "proposedTactic": "ATD-TA2",
+      "category": "prompt-injection",
+      "severity": "high",
+      "file": "nvd/CVE-2026-16584.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-17433",
+      "cwes": [
+        "CWE-266",
+        "CWE-285"
+      ],
+      "title": "A vulnerability was detected in nanocoai NanoClaw up to 2.0.64.",
+      "proposedTactic": "ATD-TA2",
+      "category": "prompt-injection",
+      "severity": "medium",
+      "file": "nvd/CVE-2026-17433.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-17626",
+      "cwes": [
+        "CWE-266"
+      ],
+      "title": "IBM Langflow OSS 1.0.0 through 1.10.3 Langflow could allow an authenticated attacker to read, modify, or expos",
+      "proposedTactic": "ATD-TA2",
+      "category": "prompt-injection",
+      "severity": "high",
+      "file": "nvd/CVE-2026-17626.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-18655",
+      "cwes": [
+        "CWE-923"
+      ],
+      "title": "Improper restriction of intended endpoints in the RabbitMQ broker connection tools of the Amazon MQ MCP Server",
+      "proposedTactic": "ATD-TA2",
+      "category": "prompt-injection",
+      "severity": "medium",
+      "file": "nvd/CVE-2026-18655.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-18733",
+      "cwes": [],
+      "title": "A prompt injection vulnerability in the shell tool in Amazon Strands Agents Tools before 0.8.0 might allow rem",
+      "proposedTactic": "ATD-TA2",
+      "category": "prompt-injection",
+      "severity": "high",
+      "file": "nvd/CVE-2026-18733.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-22561",
+      "cwes": [
+        "CWE-427"
+      ],
+      "title": "Uncontrolled search path elements in Anthropic Claude for Windows installer (Claude Setup.exe) versions prior ",
+      "proposedTactic": "ATD-TA2",
+      "category": "prompt-injection",
+      "severity": "high",
+      "file": "nvd/CVE-2026-22561.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-25750",
+      "cwes": [
+        "CWE-74"
+      ],
+      "title": "Langchain Helm Charts are Helm charts for deploying Langchain applications on Kubernetes.",
+      "proposedTactic": "ATD-TA2",
+      "category": "prompt-injection",
+      "severity": "high",
+      "file": "nvd/CVE-2026-25750.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-27765",
+      "cwes": [
+        "CWE-20"
+      ],
+      "title": "Improper input validation for some vLLM Hardware Plugin for Intel(R) Gaudi(R) software before version 0.16.0 w",
+      "proposedTactic": "ATD-TA2",
+      "category": "prompt-injection",
+      "severity": "medium",
+      "file": "nvd/CVE-2026-27765.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-29791",
+      "cwes": [
+        "CWE-20"
+      ],
+      "title": "Agentgateway is an open source data plane for agentic AI connectivity within or across any agent framework or ",
+      "proposedTactic": "ATD-TA2",
+      "category": "prompt-injection",
+      "severity": "medium",
+      "file": "nvd/CVE-2026-29791.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-30304",
+      "cwes": [
+        "CWE-20"
+      ],
+      "title": "In its design for automatic terminal command execution, AI Code offers two options: Execute safe commands and ",
+      "proposedTactic": "ATD-TA2",
+      "category": "prompt-injection",
+      "severity": "critical",
+      "file": "nvd/CVE-2026-30304.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-30618",
+      "cwes": [],
+      "title": "xszyou Fay 4.3.1 contains a remote code execution vulnerability in its MCP STDIO server management and command",
+      "proposedTactic": "ATD-TA2",
+      "category": "prompt-injection",
+      "severity": "medium",
+      "file": "nvd/CVE-2026-30618.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-30856",
+      "cwes": [
+        "CWE-706"
+      ],
+      "title": "WeKnora is an LLM-powered framework designed for deep document understanding and semantic retrieval.",
+      "proposedTactic": "ATD-TA2",
+      "category": "prompt-injection",
+      "severity": "medium",
+      "file": "nvd/CVE-2026-30856.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-31841",
+      "cwes": [
+        "CWE-433"
+      ],
+      "title": "Hyperterse is a tool-first MCP framework for building AI-ready backend surfaces from declarative config.",
+      "proposedTactic": "ATD-TA2",
+      "category": "prompt-injection",
+      "severity": "medium",
+      "file": "nvd/CVE-2026-31841.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-32247",
+      "cwes": [
+        "CWE-943"
+      ],
+      "title": "Graphiti is a framework for building and querying temporal context graphs for AI agents.",
+      "proposedTactic": "ATD-TA2",
+      "category": "prompt-injection",
+      "severity": "high",
+      "file": "nvd/CVE-2026-32247.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-32632",
+      "cwes": [
+        "CWE-346"
+      ],
+      "title": "Glances is an open-source system cross-platform monitoring tool.",
+      "proposedTactic": "ATD-TA2",
+      "category": "prompt-injection",
+      "severity": "medium",
+      "file": "nvd/CVE-2026-32632.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-33010",
+      "cwes": [
+        "CWE-942"
+      ],
+      "title": "mcp-memory-service is an open-source memory backend for multi-agent systems.",
+      "proposedTactic": "ATD-TA2",
+      "category": "prompt-injection",
+      "severity": "high",
+      "file": "nvd/CVE-2026-33010.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-33252",
+      "cwes": [
+        "CWE-352"
+      ],
+      "title": "The Go MCP SDK used Go's standard encoding/json.",
+      "proposedTactic": "ATD-TA3",
+      "category": "agent-manipulation",
+      "severity": "high",
+      "file": "nvd/CVE-2026-33252.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-33298",
+      "cwes": [
+        "CWE-122",
+        "CWE-190"
+      ],
+      "title": "llama.cpp is an inference of several LLM models in C/C++.",
+      "proposedTactic": "ATD-TA2",
+      "category": "prompt-injection",
+      "severity": "high",
+      "file": "nvd/CVE-2026-33298.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-33980",
+      "cwes": [
+        "CWE-943"
+      ],
+      "title": "Azure Data Explorer MCP Server is a Model Context Protocol (MCP) server that enables AI assistants to execute ",
+      "proposedTactic": "ATD-TA2",
+      "category": "prompt-injection",
+      "severity": "high",
+      "file": "nvd/CVE-2026-33980.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-34159",
+      "cwes": [
+        "CWE-119"
+      ],
+      "title": "llama.cpp is an inference of several LLM models in C/C++.",
+      "proposedTactic": "ATD-TA2",
+      "category": "prompt-injection",
+      "severity": "critical",
+      "file": "nvd/CVE-2026-34159.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-34237",
+      "cwes": [
+        "CWE-942"
+      ],
+      "title": "MCP Java SDK is the official Java SDK for Model Context Protocol servers and clients.",
+      "proposedTactic": "ATD-TA2",
+      "category": "prompt-injection",
+      "severity": "medium",
+      "file": "nvd/CVE-2026-34237.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-34760",
+      "cwes": [
+        "CWE-20"
+      ],
+      "title": "vLLM is an inference and serving engine for large language models (LLMs).",
+      "proposedTactic": "ATD-TA2",
+      "category": "prompt-injection",
+      "severity": "medium",
+      "file": "nvd/CVE-2026-34760.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-35394",
+      "cwes": [
+        "CWE-939"
+      ],
+      "title": "Mobile Next is an MCP server for mobile development and automation.",
+      "proposedTactic": "ATD-TA2",
+      "category": "prompt-injection",
+      "severity": "high",
+      "file": "nvd/CVE-2026-35394.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-35568",
+      "cwes": [
+        "CWE-346"
+      ],
+      "title": "MCP Java SDK is the official Java SDK for Model Context Protocol servers and clients.",
+      "proposedTactic": "ATD-TA2",
+      "category": "prompt-injection",
+      "severity": "medium",
+      "file": "nvd/CVE-2026-35568.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-35577",
+      "cwes": [
+        "CWE-346"
+      ],
+      "title": "Apollo MCP Server is a Model Context Protocol server that exposes GraphQL operations as MCP tools.",
+      "proposedTactic": "ATD-TA2",
+      "category": "prompt-injection",
+      "severity": "medium",
+      "file": "nvd/CVE-2026-35577.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-39313",
+      "cwes": [
+        "CWE-770"
+      ],
+      "title": "mcp-framework is a framework for building Model Context Protocol (MCP) servers.",
+      "proposedTactic": "ATD-TA2",
+      "category": "prompt-injection",
+      "severity": "medium",
+      "file": "nvd/CVE-2026-39313.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-39884",
+      "cwes": [
+        "CWE-88"
+      ],
+      "title": "mcp-server-kubernetes is a Model Context Protocol server for Kubernetes cluster management.",
+      "proposedTactic": "ATD-TA2",
+      "category": "prompt-injection",
+      "severity": "high",
+      "file": "nvd/CVE-2026-39884.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-40087",
+      "cwes": [
+        "CWE-1336"
+      ],
+      "title": "LangChain is a framework for building agents and LLM-powered applications.",
+      "proposedTactic": "ATD-TA2",
+      "category": "prompt-injection",
+      "severity": "medium",
+      "file": "nvd/CVE-2026-40087.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-40608",
+      "cwes": [
+        "CWE-770"
+      ],
+      "title": "Next AI Draw.io is a next.js web application that integrates AI capabilities with draw.io diagrams.",
+      "proposedTactic": "ATD-TA2",
+      "category": "prompt-injection",
+      "severity": "medium",
+      "file": "nvd/CVE-2026-40608.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-41264",
+      "cwes": [
+        "CWE-184"
+      ],
+      "title": "Flowise is a drag & drop user interface to build a customized large language model flow.",
+      "proposedTactic": "ATD-TA2",
+      "category": "prompt-injection",
+      "severity": "critical",
+      "file": "nvd/CVE-2026-41264.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-42079",
+      "cwes": [
+        "CWE-95"
+      ],
+      "title": "PPTAgent is an agentic framework for reflective PowerPoint generation.",
+      "proposedTactic": "ATD-TA2",
+      "category": "prompt-injection",
+      "severity": "high",
+      "file": "nvd/CVE-2026-42079.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-42230",
+      "cwes": [
+        "CWE-601"
+      ],
+      "title": "n8n is an open source workflow automation platform.",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "medium",
+      "file": "nvd/CVE-2026-42230.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-42236",
+      "cwes": [
+        "CWE-770"
+      ],
+      "title": "n8n is an open source workflow automation platform.",
+      "proposedTactic": "ATD-TA2",
+      "category": "prompt-injection",
+      "severity": "high",
+      "file": "nvd/CVE-2026-42236.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-42559",
+      "cwes": [
+        "CWE-346",
+        "CWE-350"
+      ],
+      "title": "RMCP is an official Rust SDK for the Model Context Protocol.",
+      "proposedTactic": "ATD-TA2",
+      "category": "prompt-injection",
+      "severity": "high",
+      "file": "nvd/CVE-2026-42559.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-4270",
+      "cwes": [
+        "CWE-424"
+      ],
+      "title": "Improper Protection of Alternate Path exists in the no-access and workdir feature of the AWS API MCP Server ve",
+      "proposedTactic": "ATD-TA2",
+      "category": "prompt-injection",
+      "severity": "medium",
+      "file": "nvd/CVE-2026-4270.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-4372",
+      "cwes": [
+        "CWE-1066"
+      ],
+      "title": "A critical remote code execution vulnerability exists in all versions of the HuggingFace transformers library ",
+      "proposedTactic": "ATD-TA2",
+      "category": "prompt-injection",
+      "severity": "high",
+      "file": "nvd/CVE-2026-4372.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-43752",
+      "cwes": [
+        "CWE-434"
+      ],
+      "title": "An authenticated administrator may be able to achieve arbitrary code execution on the host system by uploading",
+      "proposedTactic": "ATD-TA2",
+      "category": "prompt-injection",
+      "severity": "medium",
+      "file": "nvd/CVE-2026-43752.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-44118",
+      "cwes": [
+        "CWE-290"
+      ],
+      "title": "OpenClaw before 2026.4.22 derives loopback MCP owner context from spoofable server-issued bearer tokens in req",
+      "proposedTactic": "ATD-TA2",
+      "category": "prompt-injection",
+      "severity": "high",
+      "file": "nvd/CVE-2026-44118.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-44209",
+      "cwes": [
+        "CWE-1336"
+      ],
+      "title": "Banks generates meaningful LLM prompts using a template language that makes sense.",
+      "proposedTactic": "ATD-TA2",
+      "category": "prompt-injection",
+      "severity": "high",
+      "file": "nvd/CVE-2026-44209.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-44246",
+      "cwes": [
+        "CWE-74"
+      ],
+      "title": "nnU-Net is a semantic segmentation framework that automatically adapts its pipeline to a dataset.",
+      "proposedTactic": "ATD-TA2",
+      "category": "prompt-injection",
+      "severity": "high",
+      "file": "nvd/CVE-2026-44246.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-44427",
+      "cwes": [
+        "CWE-601"
+      ],
+      "title": "The MCP Registry provides MCP clients with a list of MCP servers, like an app store for MCP servers.",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "medium",
+      "file": "nvd/CVE-2026-44427.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-44450",
+      "cwes": [
+        "CWE-88"
+      ],
+      "title": "Lumiverse is a full-featured AI chat application.",
+      "proposedTactic": "ATD-TA2",
+      "category": "prompt-injection",
+      "severity": "critical",
+      "file": "nvd/CVE-2026-44450.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-44653",
+      "cwes": [
+        "CWE-201"
+      ],
+      "title": "LibreChat is an enhanced ChatGPT clone that supports multiple AI providers.",
+      "proposedTactic": "ATD-TA2",
+      "category": "prompt-injection",
+      "severity": "medium",
+      "file": "nvd/CVE-2026-44653.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-45312",
+      "cwes": [
+        "CWE-1336"
+      ],
+      "title": "RAGFlow is an open-source RAG (Retrieval-Augmented Generation) engine.",
+      "proposedTactic": "ATD-TA2",
+      "category": "prompt-injection",
+      "severity": "critical",
+      "file": "nvd/CVE-2026-45312.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-45582",
+      "cwes": [
+        "CWE-201"
+      ],
+      "title": "n8n-MCP is an MCP server that provides AI assistants access to n8n node documentation, properties, and operati",
+      "proposedTactic": "ATD-TA2",
+      "category": "prompt-injection",
+      "severity": "medium",
+      "file": "nvd/CVE-2026-45582.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-45781",
+      "cwes": [
+        "CWE-636"
+      ],
+      "title": "The MCP Registry provides MCP clients with a list of MCP servers, like an app store for MCP servers.",
+      "proposedTactic": "ATD-TA2",
+      "category": "prompt-injection",
+      "severity": "low",
+      "file": "nvd/CVE-2026-45781.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-46513",
+      "cwes": [
+        "CWE-256"
+      ],
+      "title": "Frogman provides headless PBX control through MCP and HTTP API.",
+      "proposedTactic": "ATD-TA2",
+      "category": "prompt-injection",
+      "severity": "high",
+      "file": "nvd/CVE-2026-46513.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-47427",
+      "cwes": [
+        "CWE-476"
+      ],
+      "title": "GitHub MCP Server is GitHub's official MCP Server.",
+      "proposedTactic": "ATD-TA2",
+      "category": "prompt-injection",
+      "severity": "high",
+      "file": "nvd/CVE-2026-47427.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-5002",
+      "cwes": [
+        "CWE-74",
+        "CWE-707"
+      ],
+      "title": "A vulnerability has been found in PromtEngineer localGPT up to 4d41c7d1713b16b216d8e062e51a5dd88b20b054.",
+      "proposedTactic": "ATD-TA2",
+      "category": "prompt-injection",
+      "severity": "high",
+      "file": "nvd/CVE-2026-5002.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-50758",
+      "cwes": [],
+      "title": "Cross Site Scripting vulnerability in DayuanJiang next-ai-draw-io 0.4.13 allows a remote attacker to execute a",
+      "proposedTactic": "ATD-TA2",
+      "category": "prompt-injection",
+      "severity": "medium",
+      "file": "nvd/CVE-2026-50758.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-53344",
+      "cwes": [],
+      "title": "In the Linux kernel, the following vulnerability has been resolved: pinctrl: mcp23s08: Initialize mcp->dev and",
+      "proposedTactic": "ATD-TA2",
+      "category": "prompt-injection",
+      "severity": "medium",
+      "file": "nvd/CVE-2026-53344.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-54030",
+      "cwes": [
+        "CWE-346"
+      ],
+      "title": "LibreChat is an enhanced ChatGPT clone that supports multiple AI providers.",
+      "proposedTactic": "ATD-TA2",
+      "category": "prompt-injection",
+      "severity": "high",
+      "file": "nvd/CVE-2026-54030.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-54232",
+      "cwes": [
+        "CWE-427"
+      ],
+      "title": "vLLM is an inference and serving engine for large language models (LLMs).",
+      "proposedTactic": "ATD-TA2",
+      "category": "prompt-injection",
+      "severity": "high",
+      "file": "nvd/CVE-2026-54232.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-54234",
+      "cwes": [
+        "CWE-20",
+        "CWE-1284"
+      ],
+      "title": "vLLM is a high-throughput and memory-efficient inference and serving engine for LLMs.",
+      "proposedTactic": "ATD-TA2",
+      "category": "prompt-injection",
+      "severity": "high",
+      "file": "nvd/CVE-2026-54234.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-56340",
+      "cwes": [
+        "CWE-20",
+        "CWE-787"
+      ],
+      "title": "vLLM versions >= 0.10.2 and < 0.13.0 are missing sparse tensor validation in multimodal embeddings processing.",
+      "proposedTactic": "ATD-TA2",
+      "category": "prompt-injection",
+      "severity": "high",
+      "file": "nvd/CVE-2026-56340.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-58057",
+      "cwes": [
+        "CWE-178"
+      ],
+      "title": "Flowise before 3.1.3 validates Custom MCP stdio environment variables against a denylist using a case-sensitiv",
+      "proposedTactic": "ATD-TA2",
+      "category": "prompt-injection",
+      "severity": "medium",
+      "file": "nvd/CVE-2026-58057.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-58122",
+      "cwes": [
+        "CWE-348"
+      ],
+      "title": "Hermes WebUI before 0.51.307 contains an authentication bypass vulnerability that allows unauthenticated remot",
+      "proposedTactic": "ATD-TA2",
+      "category": "prompt-injection",
+      "severity": "critical",
+      "file": "nvd/CVE-2026-58122.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-58169",
+      "cwes": [
+        "CWE-346"
+      ],
+      "title": "Vibe-Trading before 0.1.10 contains a DNS rebinding authentication bypass vulnerability that allows remote att",
+      "proposedTactic": "ATD-TA2",
+      "category": "prompt-injection",
+      "severity": "high",
+      "file": "nvd/CVE-2026-58169.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-59723",
+      "cwes": [
+        "CWE-346"
+      ],
+      "title": "Cline is an autonomous coding agent as an SDK, IDE extension, or CLI assistant.",
+      "proposedTactic": "ATD-TA2",
+      "category": "prompt-injection",
+      "severity": "high",
+      "file": "nvd/CVE-2026-59723.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-59807",
+      "cwes": [
+        "CWE-73"
+      ],
+      "title": "Composio SDK before 0.2.32-beta.283 contains a path validation bypass vulnerability that allows attackers to r",
+      "proposedTactic": "ATD-TA2",
+      "category": "prompt-injection",
+      "severity": "medium",
+      "file": "nvd/CVE-2026-59807.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-59950",
+      "cwes": [
+        "CWE-346",
+        "CWE-1385"
+      ],
+      "title": "The MCP Python SDK, called mcp on PyPI, is a Python implementation of the Model Context Protocol (MCP).",
+      "proposedTactic": "ATD-TA2",
+      "category": "prompt-injection",
+      "severity": "medium",
+      "file": "nvd/CVE-2026-59950.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-61427",
+      "cwes": [
+        "CWE-20"
+      ],
+      "title": "PraisonAI before 4.6.78 exposes the MCP HTTP-stream transport without authentication by default: the CLI --api",
+      "proposedTactic": "ATD-TA2",
+      "category": "prompt-injection",
+      "severity": "high",
+      "file": "nvd/CVE-2026-61427.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-61459",
+      "cwes": [
+        "CWE-88"
+      ],
+      "title": "MCP Server Kubernetes before 3.9.0 contains an argument injection vulnerability in structured tools (kubectl_g",
+      "proposedTactic": "ATD-TA2",
+      "category": "prompt-injection",
+      "severity": "critical",
+      "file": "nvd/CVE-2026-61459.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-61462",
+      "cwes": [
+        "CWE-73"
+      ],
+      "title": "mcp-gitlab contains a path traversal vulnerability in the job_id parameter of build/index.js that allows attac",
+      "proposedTactic": "ATD-TA2",
+      "category": "prompt-injection",
+      "severity": "high",
+      "file": "nvd/CVE-2026-61462.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-62195",
+      "cwes": [
+        "CWE-732"
+      ],
+      "title": "OpenClaw versions 2026.5.20 before 2026.6.6 contain an authorization bypass vulnerability in the MCP loopback ",
+      "proposedTactic": "ATD-TA4",
+      "category": "privilege-escalation",
+      "severity": "high",
+      "file": "nvd/CVE-2026-62195.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-63118",
+      "cwes": [
+        "CWE-346",
+        "CWE-350"
+      ],
+      "title": "MCP Ruby SDK is the official Ruby SDK for Model Context Protocol servers and clients.",
+      "proposedTactic": "ATD-TA2",
+      "category": "prompt-injection",
+      "severity": "medium",
+      "file": "nvd/CVE-2026-63118.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-63119",
+      "cwes": [
+        "CWE-400",
+        "CWE-770"
+      ],
+      "title": "MCP Ruby SDK is the official Ruby SDK for Model Context Protocol servers and clients.",
+      "proposedTactic": "ATD-TA2",
+      "category": "prompt-injection",
+      "severity": "medium",
+      "file": "nvd/CVE-2026-63119.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-6494",
+      "cwes": [
+        "CWE-117"
+      ],
+      "title": "A flaw was found in the AAP MCP server.",
+      "proposedTactic": "ATD-TA2",
+      "category": "prompt-injection",
+      "severity": "medium",
+      "file": "nvd/CVE-2026-6494.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-6599",
+      "cwes": [
+        "CWE-74",
+        "CWE-707"
+      ],
+      "title": "A vulnerability was detected in langflow-ai langflow up to 1.8.3.",
+      "proposedTactic": "ATD-TA2",
+      "category": "prompt-injection",
+      "severity": "medium",
+      "file": "nvd/CVE-2026-6599.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-66005",
+      "cwes": [
+        "CWE-183",
+        "CWE-942"
+      ],
+      "title": "Jan through 0.8.4, fixed in commit 3e1c1e7, contains a CORS misconfiguration vulnerability in its local API se",
+      "proposedTactic": "ATD-TA2",
+      "category": "prompt-injection",
+      "severity": "medium",
+      "file": "nvd/CVE-2026-66005.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-67336",
+      "cwes": [
+        "CWE-327"
+      ],
+      "title": "better-auth versions before 1.6.11 contain insecure cryptographic defaults in the oidcProvider and mcp plugins",
+      "proposedTactic": "ATD-TA2",
+      "category": "prompt-injection",
+      "severity": "high",
+      "file": "nvd/CVE-2026-67336.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-67430",
+      "cwes": [
+        "CWE-401",
+        "CWE-770"
+      ],
+      "title": "MCP Ruby SDK is the official Ruby SDK for Model Context Protocol servers and clients.",
+      "proposedTactic": "ATD-TA2",
+      "category": "prompt-injection",
+      "severity": "medium",
+      "file": "nvd/CVE-2026-67430.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-67432",
+      "cwes": [
+        "CWE-770"
+      ],
+      "title": "MCP Ruby SDK is the official Ruby SDK for Model Context Protocol servers and clients.",
+      "proposedTactic": "ATD-TA2",
+      "category": "prompt-injection",
+      "severity": "high",
+      "file": "nvd/CVE-2026-67432.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-7482",
+      "cwes": [
+        "CWE-125"
+      ],
+      "title": "Ollama before 0.17.1 contains a heap out-of-bounds read vulnerability in the GGUF model loader.",
+      "proposedTactic": "ATD-TA2",
+      "category": "prompt-injection",
+      "severity": "critical",
+      "file": "nvd/CVE-2026-7482.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-7574",
+      "cwes": [
+        "CWE-353"
+      ],
+      "title": "Anthropic Claude Desktop Cowork VM image handling (confirmed across v1.1348.0 through v1.2278.0, including v1.",
+      "proposedTactic": "ATD-TA2",
+      "category": "prompt-injection",
+      "severity": "high",
+      "file": "nvd/CVE-2026-7574.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-7664",
+      "cwes": [
+        "CWE-287"
+      ],
+      "title": "IBM Langflow OSS 1.0.0 through 1.8.4 could allow unauthenticated attackers to access protected MCP project res",
+      "proposedTactic": "ATD-TA4",
+      "category": "privilege-escalation",
+      "severity": "critical",
+      "file": "nvd/CVE-2026-7664.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-7755",
+      "cwes": [],
+      "title": "IBM Langflow OSS 1.0.0 through 1.10.0 Langflow could allow remote code execution due to incomplete validation ",
+      "proposedTactic": "ATD-TA2",
+      "category": "prompt-injection",
+      "severity": "high",
+      "file": "nvd/CVE-2026-7755.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-9077",
+      "cwes": [
+        "CWE-807"
+      ],
+      "title": "IBM Langflow OSS 1.0.0 through 1.10.3 Langflow allows remote authenticated attackers to bypass localhost-only ",
+      "proposedTactic": "ATD-TA2",
+      "category": "prompt-injection",
+      "severity": "high",
+      "file": "nvd/CVE-2026-9077.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-9739",
+      "cwes": [
+        "CWE-942"
+      ],
+      "title": "Vulnerable to DNS rebinding attacks when using SSE (http://b/499408790).",
+      "proposedTactic": "ATD-TA2",
+      "category": "prompt-injection",
+      "severity": "medium",
+      "file": "nvd/CVE-2026-9739.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-9810",
+      "cwes": [],
+      "title": "The AI Copilot WordPress plugin before 1.5.4 does not bind OAuth access tokens to a WordPress user, and accept",
+      "proposedTactic": "ATD-TA2",
+      "category": "prompt-injection",
+      "severity": "medium",
+      "file": "nvd/CVE-2026-9810.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2023-31036",
+      "cwes": [
+        "CWE-23"
+      ],
+      "title": "NVIDIA Triton Inference Server — CVE-2023-31036",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "nvidia-psirt/CVE-2023-31036.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2024-0087",
+      "cwes": [
+        "CWE-73"
+      ],
+      "title": "NVIDIA Triton Inference Server — CVE-2024-0087",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "critical",
+      "file": "nvidia-psirt/CVE-2024-0087.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2024-0095",
+      "cwes": [
+        "CWE-117"
+      ],
+      "title": "NVIDIA Triton Inference Server — CVE-2024-0095",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "nvidia-psirt/CVE-2024-0095.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-23268",
+      "cwes": [
+        "CWE-20"
+      ],
+      "title": "NVIDIA Triton Inference Server — CVE-2025-23268",
+      "proposedTactic": "ATD-TA2",
+      "category": "prompt-injection",
+      "severity": "high",
+      "file": "nvidia-psirt/CVE-2025-23268.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-23310",
+      "cwes": [
+        "CWE-121"
+      ],
+      "title": "NVIDIA Triton Inference Server — CVE-2025-23310",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "critical",
+      "file": "nvidia-psirt/CVE-2025-23310.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-23311",
+      "cwes": [
+        "CWE-121"
+      ],
+      "title": "NVIDIA Triton Inference Server — CVE-2025-23311",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "critical",
+      "file": "nvidia-psirt/CVE-2025-23311.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-23317",
+      "cwes": [
+        "CWE-122"
+      ],
+      "title": "NVIDIA Triton Inference Server — CVE-2025-23317",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "critical",
+      "file": "nvidia-psirt/CVE-2025-23317.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-23318",
+      "cwes": [
+        "CWE-805"
+      ],
+      "title": "NVIDIA Triton Inference Server — CVE-2025-23318",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "nvidia-psirt/CVE-2025-23318.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-23319",
+      "cwes": [
+        "CWE-805"
+      ],
+      "title": "NVIDIA Triton Inference Server — CVE-2025-23319",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "nvidia-psirt/CVE-2025-23319.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-23336",
+      "cwes": [
+        "CWE-20"
+      ],
+      "title": "NVIDIA Triton Inference Server — CVE-2025-23336",
+      "proposedTactic": "ATD-TA2",
+      "category": "prompt-injection",
+      "severity": "medium",
+      "file": "nvidia-psirt/CVE-2025-23336.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-23360",
+      "cwes": [
+        "CWE-23"
+      ],
+      "title": "NVIDIA NeMo — CVE-2025-23360",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "nvidia-psirt/CVE-2025-23360.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-24207",
+      "cwes": [
+        "CWE-288"
+      ],
+      "title": "NVIDIA Triton Inference Server — CVE-2026-24207",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "critical",
+      "file": "nvidia-psirt/CVE-2026-24207.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-24213",
+      "cwes": [
+        "CWE-125"
+      ],
+      "title": "NVIDIA Triton Inference Server — CVE-2026-24213",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "nvidia-psirt/CVE-2026-24213.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-24214",
+      "cwes": [
+        "CWE-190"
+      ],
+      "title": "NVIDIA Triton Inference Server — CVE-2026-24214",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "nvidia-psirt/CVE-2026-24214.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-24217",
+      "cwes": [
+        "CWE-29"
+      ],
+      "title": "NVIDIA BioNeMo Framework — CVE-2026-24217",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "high",
+      "file": "nvidia-psirt/CVE-2026-24217.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-47481",
+      "cwes": [
+        "CWE-288"
+      ],
+      "title": "NVIDIA Triton Inference Server — CVE-2026-47481",
+      "proposedTactic": "ATD-TA8",
+      "category": "model-abuse",
+      "severity": "medium",
+      "file": "nvidia-psirt/CVE-2026-47481.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2005-4001",
+      "cwes": [],
+      "title": "Multiple SQL injection vulnerabilities in phpYellowTM Pro Edition and Lite Edition 5.33 allow remote attackers to execut",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2005-4001.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2007-0038",
+      "cwes": [
+        "CWE-119"
+      ],
+      "title": "Stack-based buffer overflow in the animated cursor code in Microsoft Windows 2000 SP4 through Vista allows remote attack",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2007-0038.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2007-1765",
+      "cwes": [],
+      "title": "Unspecified vulnerability in Microsoft Windows 2000 SP4 through Vista allows remote attackers to execute arbitrary code ",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2007-1765.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2007-1867",
+      "cwes": [],
+      "title": "Buffer overflow in IrfanView 3.99 allows remote attackers to execute arbitrary code via a crafted animated cursor (ANI) ",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2007-1867.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2007-2109",
+      "cwes": [],
+      "title": "Multiple unspecified vulnerabilities in Oracle Database 10.2.0.3 have unknown impact and remote authenticated attack vec",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "medium",
+      "file": "owasp-asi/CVE-2007-2109.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2010-1685",
+      "cwes": [
+        "CWE-119"
+      ],
+      "title": "Stack-based buffer overflow in CursorArts ZipWrangler 1.20 allows user-assisted remote attackers to execute arbitrary co",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2010-1685.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2011-2120",
+      "cwes": [
+        "CWE-189"
+      ],
+      "title": "Integer overflow in the CursorAsset x32 component in Adobe Shockwave Player before 11.6.0.626 allows attackers to execut",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2011-2120.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2012-4399",
+      "cwes": [
+        "CWE-611"
+      ],
+      "title": "CakePHPallows remote attackers to read arbitrary files via XML data containing external entity references",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2012-4399.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2013-0131",
+      "cwes": [
+        "CWE-119"
+      ],
+      "title": "Buffer overflow in the NVIDIA GPU driver before 304.88, 310.x before 310.44, and 313.x before 313.30 for the X Window Sy",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2013-0131.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2013-4318",
+      "cwes": [
+        "CWE-74"
+      ],
+      "title": "Features file injection vulnerability",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "medium",
+      "file": "owasp-asi/CVE-2013-4318.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2014-0225",
+      "cwes": [
+        "CWE-611"
+      ],
+      "title": "Improper Restriction of XML External Entity Reference in Spring Framework",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2014-0225.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2014-1539",
+      "cwes": [
+        "CWE-20"
+      ],
+      "title": "Mozilla Firefox before 30.0 and Thunderbird through 24.6 on OS X do not ensure visibility of the cursor after interactio",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "medium",
+      "file": "owasp-asi/CVE-2014-1539.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2014-3529",
+      "cwes": [
+        "CWE-20",
+        "CWE-611"
+      ],
+      "title": "Improper Restriction of XML External Entity Reference in Apache POI",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "medium",
+      "file": "owasp-asi/CVE-2014-3529.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2015-6497",
+      "cwes": [
+        "CWE-20"
+      ],
+      "title": "Magento arbitrary PHP code execution via the productData parameter",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2015-6497.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2015-8031",
+      "cwes": [
+        "CWE-611"
+      ],
+      "title": "Hudson XML API susceptible to External Entity Injection Vunerability prior to v3.3.2",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "critical",
+      "file": "owasp-asi/CVE-2015-8031.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2015-8549",
+      "cwes": [
+        "CWE-611"
+      ],
+      "title": "PyAMF vulnerable to XML external entity (XXE)",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2015-8549.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2016-4972",
+      "cwes": [
+        "CWE-20"
+      ],
+      "title": "OpenStack Murano Code Execution",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "critical",
+      "file": "owasp-asi/CVE-2016-4972.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2016-5002",
+      "cwes": [
+        "CWE-611"
+      ],
+      "title": "Apache XML-RPC XXE Vulnerability",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2016-5002.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2016-5851",
+      "cwes": [
+        "CWE-611"
+      ],
+      "title": "Improper Restriction of XML External Entity Reference in python-docx",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2016-5851.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2016-6798",
+      "cwes": [
+        "CWE-611"
+      ],
+      "title": "XML External Entity Reference in Apache Sling",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "critical",
+      "file": "owasp-asi/CVE-2016-6798.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2016-9795",
+      "cwes": [
+        "CWE-20"
+      ],
+      "title": "The casrvc program in CA Common Services, as used in CA Client Automation 12.8, 12.9, and 14.0; CA SystemEDGE 5.8.2 and ",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2016-9795.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2017-12620",
+      "cwes": [
+        "CWE-611"
+      ],
+      "title": "Improper Restriction of XML External Entity Reference in Apache OpenNLP",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "critical",
+      "file": "owasp-asi/CVE-2017-12620.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2017-12621",
+      "cwes": [
+        "CWE-611"
+      ],
+      "title": "Improper Restriction of XML External Entity Reference in Jelly",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "critical",
+      "file": "owasp-asi/CVE-2017-12621.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2017-15280",
+      "cwes": [
+        "CWE-611"
+      ],
+      "title": "Umbraco CMS XXE Vulnerability",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "medium",
+      "file": "owasp-asi/CVE-2017-15280.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2017-15691",
+      "cwes": [
+        "CWE-611"
+      ],
+      "title": "Improper Restriction of XML External Entity Reference in Apache uimaj",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "medium",
+      "file": "owasp-asi/CVE-2017-15691.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2017-18197",
+      "cwes": [
+        "CWE-611"
+      ],
+      "title": "mxGraph vulnerable to XXE attacks",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "critical",
+      "file": "owasp-asi/CVE-2017-18197.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2017-5662",
+      "cwes": [
+        "CWE-611"
+      ],
+      "title": "Improper Restriction of XML External Entity Reference in Apache Batik",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2017-5662.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2017-7664",
+      "cwes": [
+        "CWE-611"
+      ],
+      "title": "Apache OpenMeetings does not correctly validate uploaded XML documents",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "critical",
+      "file": "owasp-asi/CVE-2017-7664.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2018-1000054",
+      "cwes": [
+        "CWE-611"
+      ],
+      "title": "Improper Restriction of XML External Entity Reference in Jenkins JUnit Plugin",
+      "proposedTactic": "ATD-TA4",
+      "category": "privilege-escalation",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2018-1000054.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2018-11758",
+      "cwes": [
+        "CWE-611"
+      ],
+      "title": "XML External Entity Reference in Apache Cayenne",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2018-11758.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2018-14065",
+      "cwes": [
+        "CWE-611"
+      ],
+      "title": "PHPOffice Common Improper Restriction of XML External Entity Reference",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "critical",
+      "file": "owasp-asi/CVE-2018-14065.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2018-3749",
+      "cwes": [
+        "CWE-20"
+      ],
+      "title": "Improper Input Validation in Deap",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "critical",
+      "file": "owasp-asi/CVE-2018-3749.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2018-6765",
+      "cwes": [
+        "CWE-427"
+      ],
+      "title": "Swisscom MySwisscomAssistant 2.17.1.1065 contains a vulnerability that could allow an unauthenticated, remote attacker t",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2018-6765.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2018-6968",
+      "cwes": [],
+      "title": "The VMware AirWatch Agent for Android prior to 8.2 and AirWatch Agent for Windows Mobile prior to 6.5.2 contain a remote",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "critical",
+      "file": "owasp-asi/CVE-2018-6968.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2018-7577",
+      "cwes": [
+        "CWE-20"
+      ],
+      "title": "Memcpy parameter overlap in Google Snappy library 1.1.4, as used in Google TensorFlow before 1.7.1, could result in a cr",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2018-7577.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2018-8825",
+      "cwes": [
+        "CWE-119"
+      ],
+      "title": "Google TensorFlow 1.7 and below is affected by: Buffer Overflow.",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2018-8825.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2019-1002",
+      "cwes": [
+        "CWE-787"
+      ],
+      "title": "ChakraCore RCE via Out-of-bounds write",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2019-1002.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2019-1024",
+      "cwes": [
+        "CWE-787"
+      ],
+      "title": "Chakra Scripting Engine RCE via Out-of-bounds write",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2019-1024.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2019-10327",
+      "cwes": [
+        "CWE-611"
+      ],
+      "title": "XML External Entity processing vulnerability in Pipeline Maven Integration Jenkins Plugin",
+      "proposedTactic": "ATD-TA4",
+      "category": "privilege-escalation",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2019-10327.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2019-10793",
+      "cwes": [
+        "CWE-74"
+      ],
+      "title": "Prototype Pollution in dot-object",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "medium",
+      "file": "owasp-asi/CVE-2019-10793.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2019-10794",
+      "cwes": [
+        "CWE-74"
+      ],
+      "title": "component-flatten vulnerable to Prototype Pollution",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "medium",
+      "file": "owasp-asi/CVE-2019-10794.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2019-10795",
+      "cwes": [
+        "CWE-74"
+      ],
+      "title": "Prototype Pollution in undefsafe",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "medium",
+      "file": "owasp-asi/CVE-2019-10795.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2019-15160",
+      "cwes": [
+        "CWE-611",
+        "CWE-776"
+      ],
+      "title": "Inline DTD allows XML bomb attack",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2019-15160.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2019-15690",
+      "cwes": [
+        "CWE-122"
+      ],
+      "title": "LibVNCServer 0.9.12 release and earlier contains heap buffer overflow vulnerability within the HandleCursorShape() funct",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2019-15690.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2019-17560",
+      "cwes": [
+        "CWE-20",
+        "CWE-295",
+        "CWE-347"
+      ],
+      "title": "Improper Certificate Validation in Apache Netbeans",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "critical",
+      "file": "owasp-asi/CVE-2019-17560.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2019-17626",
+      "cwes": [
+        "CWE-91"
+      ],
+      "title": "XML Injection in ReportLab",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "critical",
+      "file": "owasp-asi/CVE-2019-17626.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2019-19450",
+      "cwes": [
+        "CWE-91"
+      ],
+      "title": "ReportLab vulnerable to remote code execution via paraparser",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "critical",
+      "file": "owasp-asi/CVE-2019-19450.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2019-25155",
+      "cwes": [
+        "CWE-601"
+      ],
+      "title": "DOMPurify Open Redirect vulnerability",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "medium",
+      "file": "owasp-asi/CVE-2019-25155.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2019-5312",
+      "cwes": [
+        "CWE-611"
+      ],
+      "title": "XML External Entity Reference in weixin-java-tools",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "critical",
+      "file": "owasp-asi/CVE-2019-5312.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2019-7722",
+      "cwes": [
+        "CWE-611"
+      ],
+      "title": "Improper Restriction of XML External Entity Reference in PMD",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2019-7722.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2020-10959",
+      "cwes": [
+        "CWE-601"
+      ],
+      "title": "MediaWiki Open Redirect vulnerability",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "medium",
+      "file": "owasp-asi/CVE-2020-10959.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2020-10960",
+      "cwes": [
+        "CWE-116",
+        "CWE-74"
+      ],
+      "title": "MediaWiki makeCollapsible allows applying event handler to any CSS selector",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "medium",
+      "file": "owasp-asi/CVE-2020-10960.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2020-10991",
+      "cwes": [
+        "CWE-611"
+      ],
+      "title": "Withdrawn Advisory: Improper Restriction of XML External Entity Reference in Mulesoft APIkit",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "critical",
+      "file": "owasp-asi/CVE-2020-10991.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2020-11053",
+      "cwes": [
+        "CWE-601"
+      ],
+      "title": "Open Redirect in OAuth2 Proxy",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2020-11053.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2020-1147",
+      "cwes": [],
+      "title": ".NET Framework, SharePoint Server, and Visual Studio Remote Code Execution Vulnerability",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2020-1147.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2020-12283",
+      "cwes": [
+        "CWE-601"
+      ],
+      "title": "Open redirect vulnerability in Sourcegraph",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "medium",
+      "file": "owasp-asi/CVE-2020-12283.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2020-13692",
+      "cwes": [
+        "CWE-611"
+      ],
+      "title": "Improper Restriction of XML External Entity Reference",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2020-13692.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2020-13936",
+      "cwes": [
+        "CWE-20"
+      ],
+      "title": "Sandbox Bypass in Apache Velocity Engine",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2020-13936.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2020-13940",
+      "cwes": [
+        "CWE-611"
+      ],
+      "title": "Improper Restriction of XML External Entity Reference in Apache NiFi",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "medium",
+      "file": "owasp-asi/CVE-2020-13940.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2020-15190",
+      "cwes": [
+        "CWE-119",
+        "CWE-122",
+        "CWE-125",
+        "CWE-134",
+        "CWE-197",
+        "CWE-20",
+        "CWE-252",
+        "CWE-476",
+        "CWE-617",
+        "CWE-754",
+        "CWE-770",
+        "CWE-787",
+        "CWE-908"
+      ],
+      "title": "In Tensorflow before versions 1.15.4, 2.0.3, 2.1.2, 2.2.1 and 2.3.1, the `tf.raw_ops.Switch` operation takes as input a ",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "critical",
+      "file": "owasp-asi/CVE-2020-15190.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2020-16977",
+      "cwes": [],
+      "title": "<p>A remote code execution vulnerability exists in Visual Studio Code when the Python extension loads a Jupyter notebook",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2020-16977.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2020-17376",
+      "cwes": [
+        "CWE-611"
+      ],
+      "title": "OpenStack Nova Live migration fails to update persistent domain XML",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2020-17376.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2020-2108",
+      "cwes": [
+        "CWE-611"
+      ],
+      "title": "XXE vulnerability in Jenkins WebSphere Deployer Plugin",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2020-2108.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2020-2284",
+      "cwes": [
+        "CWE-611"
+      ],
+      "title": "XXE vulnerability in Jenkins Liquibase Runner Plugin",
+      "proposedTactic": "ATD-TA4",
+      "category": "privilege-escalation",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2020-2284.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2020-2298",
+      "cwes": [
+        "CWE-611"
+      ],
+      "title": "XXE vulnerability in Jenkins Nerrvana Plugin",
+      "proposedTactic": "ATD-TA4",
+      "category": "privilege-escalation",
+      "severity": "medium",
+      "file": "owasp-asi/CVE-2020-2298.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2020-2324",
+      "cwes": [
+        "CWE-611"
+      ],
+      "title": "XXE vulnerability in Jenkins CVS Plugin",
+      "proposedTactic": "ATD-TA4",
+      "category": "privilege-escalation",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2020-2324.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2020-24922",
+      "cwes": [
+        "CWE-352"
+      ],
+      "title": "xuxueli xxl-job Cross-Site Request Forgery Vulnerability",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2020-24922.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2020-25614",
+      "cwes": [
+        "CWE-119",
+        "CWE-20"
+      ],
+      "title": "xmlquery lacks check for whether LoadURL response is in XML format, causing denial of service",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2020-25614.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2020-25750",
+      "cwes": [
+        "CWE-611"
+      ],
+      "title": "DotPlant2 Improper Restriction of XML External Entity Reference",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2020-25750.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2020-26266",
+      "cwes": [
+        "CWE-908"
+      ],
+      "title": "In affected versions of TensorFlow under certain cases a saved model can trigger use of uninitialized values during code",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "medium",
+      "file": "owasp-asi/CVE-2020-26266.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2020-26270",
+      "cwes": [
+        "CWE-20"
+      ],
+      "title": "In affected versions of TensorFlow running an LSTM/GRU model where the LSTM/GRU layer receives an input with zero-length",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "medium",
+      "file": "owasp-asi/CVE-2020-26270.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2020-26708",
+      "cwes": [
+        "CWE-611"
+      ],
+      "title": "requests-xml XML External Entity Injection vulnerability",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2020-26708.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2020-26709",
+      "cwes": [
+        "CWE-611"
+      ],
+      "title": "py-xml XML External Entity Injection vulnerability",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2020-26709.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2020-26710",
+      "cwes": [
+        "CWE-611"
+      ],
+      "title": "easy-parse XML External Entity Injection vulnerability",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2020-26710.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2020-5215",
+      "cwes": [
+        "CWE-20",
+        "CWE-754"
+      ],
+      "title": "In TensorFlow before 1.15.2 and 2.0.1, converting a string (from Python) to a tf.float16 value results in a segmentation",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "medium",
+      "file": "owasp-asi/CVE-2020-5215.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2020-9495",
+      "cwes": [
+        "CWE-74"
+      ],
+      "title": "Injection in Apache Archiva",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "medium",
+      "file": "owasp-asi/CVE-2020-9495.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2021-21639",
+      "cwes": [
+        "CWE-20"
+      ],
+      "title": "Lack of type validation in agent related REST API in Jenkins",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "medium",
+      "file": "owasp-asi/CVE-2021-21639.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2021-21642",
+      "cwes": [
+        "CWE-611"
+      ],
+      "title": "XML External Entity Reference vulnerability in Jenkins Config File Provider Plugin",
+      "proposedTactic": "ATD-TA4",
+      "category": "privilege-escalation",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2021-21642.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2021-21656",
+      "cwes": [
+        "CWE-611"
+      ],
+      "title": "XML external entity (XXE) attacks in Jenkins Xcode integration Plugin",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2021-21656.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2021-21657",
+      "cwes": [
+        "CWE-611"
+      ],
+      "title": "XXE vulnerability in Jenkins URLTrigger Plugin",
+      "proposedTactic": "ATD-TA4",
+      "category": "privilege-escalation",
+      "severity": "critical",
+      "file": "owasp-asi/CVE-2021-21657.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2021-21669",
+      "cwes": [
+        "CWE-611"
+      ],
+      "title": "XXE vulnerability in Jenkins Generic Webhook Trigger Plugin",
+      "proposedTactic": "ATD-TA4",
+      "category": "privilege-escalation",
+      "severity": "critical",
+      "file": "owasp-asi/CVE-2021-21669.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2021-23463",
+      "cwes": [
+        "CWE-611"
+      ],
+      "title": "Improper Restriction of XML External Entity Reference in com.h2database:h2.",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2021-23463.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2021-23771",
+      "cwes": [
+        "CWE-1321"
+      ],
+      "title": "Sandbox escape in notevil and argencoders-notevil",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "medium",
+      "file": "owasp-asi/CVE-2021-23771.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2021-23792",
+      "cwes": [
+        "CWE-611"
+      ],
+      "title": "External Entity Reference in TwelveMonkeys ImageIO",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "critical",
+      "file": "owasp-asi/CVE-2021-23792.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2021-23901",
+      "cwes": [
+        "CWE-611"
+      ],
+      "title": "XML external entity (XXE) injection in Apache Nutch",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "critical",
+      "file": "owasp-asi/CVE-2021-23901.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2021-25915",
+      "cwes": [
+        "CWE-1321"
+      ],
+      "title": "Changeset vulnerable to prototype pollution",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "critical",
+      "file": "owasp-asi/CVE-2021-25915.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2021-26251",
+      "cwes": [
+        "CWE-20"
+      ],
+      "title": "Improper input validation in the Intel(R) Distribution of OpenVINO(TM) Toolkit may allow an authenticated user to potent",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "medium",
+      "file": "owasp-asi/CVE-2021-26251.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2021-27817",
+      "cwes": [
+        "CWE-434"
+      ],
+      "title": "ShopXO RCE Vulnerability",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "critical",
+      "file": "owasp-asi/CVE-2021-27817.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2021-29136",
+      "cwes": [
+        "CWE-20"
+      ],
+      "title": "Improper input validation in umoci",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "medium",
+      "file": "owasp-asi/CVE-2021-29136.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2021-3902",
+      "cwes": [
+        "CWE-611"
+      ],
+      "title": "Improper Restriction of XML External Entity Reference in dompdf/dompdf",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "critical",
+      "file": "owasp-asi/CVE-2021-3902.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2021-41042",
+      "cwes": [
+        "CWE-611"
+      ],
+      "title": "XML External Entity Reference in Eclipse Lyo",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "medium",
+      "file": "owasp-asi/CVE-2021-41042.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2021-41411",
+      "cwes": [
+        "CWE-611"
+      ],
+      "title": "XML External Entity Reference in drools",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "critical",
+      "file": "owasp-asi/CVE-2021-41411.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2021-43090",
+      "cwes": [
+        "CWE-611"
+      ],
+      "title": "Improper Restriction of XML External Entity Reference in soa-model",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "critical",
+      "file": "owasp-asi/CVE-2021-43090.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2021-46849",
+      "cwes": [
+        "CWE-611"
+      ],
+      "title": "Duplicate Advisory: Improper Restriction of XML External Entity Reference in pikepdf",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "critical",
+      "file": "owasp-asi/CVE-2021-46849.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2021-47621",
+      "cwes": [
+        "CWE-611"
+      ],
+      "title": "ClassGraph XML External Entity Reference",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "medium",
+      "file": "owasp-asi/CVE-2021-47621.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2022-0219",
+      "cwes": [
+        "CWE-611"
+      ],
+      "title": "Improper Restriction of XML External Entity Reference in skylot/jadx",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "medium",
+      "file": "owasp-asi/CVE-2022-0219.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2022-0239",
+      "cwes": [
+        "CWE-611"
+      ],
+      "title": "corenlp is vulnerable to Improper Restriction of XML External Entity Reference",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "critical",
+      "file": "owasp-asi/CVE-2022-0239.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2022-0265",
+      "cwes": [
+        "CWE-611"
+      ],
+      "title": "XML External Entity Reference in Hazelcast",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "critical",
+      "file": "owasp-asi/CVE-2022-0265.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2022-0272",
+      "cwes": [
+        "CWE-611"
+      ],
+      "title": "XML External Entity Reference in detekt",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2022-0272.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2022-1243",
+      "cwes": [
+        "CWE-20"
+      ],
+      "title": "Incorrect protocol extraction via \r, \n and \t characters",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2022-1243.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2022-21144",
+      "cwes": [
+        "CWE-20"
+      ],
+      "title": "Denial of service vulnerability exists in libxmljs",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2022-21144.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2022-21705",
+      "cwes": [
+        "CWE-74"
+      ],
+      "title": "Authenticated remote code execution in October CMS",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2022-21705.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2022-23529",
+      "cwes": [
+        "CWE-20"
+      ],
+      "title": "jsonwebtoken has insecure input validation in jwt.verify function",
+      "proposedTactic": "ATD-TA4",
+      "category": "privilege-escalation",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2022-23529.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2022-23616",
+      "cwes": [
+        "CWE-74"
+      ],
+      "title": "Remote code execution in xwiki-platform",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2022-23616.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2022-23623",
+      "cwes": [
+        "CWE-1321",
+        "CWE-20"
+      ],
+      "title": "Validation bypass in frourio",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2022-23623.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2022-23624",
+      "cwes": [
+        "CWE-1321",
+        "CWE-20"
+      ],
+      "title": "Validation bypass in frourio-express",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2022-23624.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2022-23640",
+      "cwes": [
+        "CWE-611",
+        "CWE-776"
+      ],
+      "title": "Improper Restriction of XML External Entity Reference in com.monitorjbl:xlsx-streamer",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "critical",
+      "file": "owasp-asi/CVE-2022-23640.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2022-2385",
+      "cwes": [
+        "CWE-20"
+      ],
+      "title": "aws-iam-authenticator allow-listed IAM identity may be able to modify their username, escalate privileges before v0.5.9",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2022-2385.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2022-24093",
+      "cwes": [
+        "CWE-20"
+      ],
+      "title": "Magento Open Source affected by Improper Input Validation",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "medium",
+      "file": "owasp-asi/CVE-2022-24093.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2022-24898",
+      "cwes": [
+        "CWE-611"
+      ],
+      "title": "Arbitrary file access through XML parsing in org.xwiki.commons:xwiki-commons-xml",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "medium",
+      "file": "owasp-asi/CVE-2022-24898.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2022-25312",
+      "cwes": [
+        "CWE-611"
+      ],
+      "title": "Improper Restriction of XML External Entity Reference in Any23",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "critical",
+      "file": "owasp-asi/CVE-2022-25312.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2022-26477",
+      "cwes": [
+        "CWE-400"
+      ],
+      "title": "SystemDS CPU exhaustion vulnerability",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2022-26477.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2022-26661",
+      "cwes": [
+        "CWE-611",
+        "CWE-776"
+      ],
+      "title": "XML Entity Expansion in trytond and proteus",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2022-26661.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2022-28890",
+      "cwes": [
+        "CWE-611"
+      ],
+      "title": "XML External Entity Reference in apache jena",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "critical",
+      "file": "owasp-asi/CVE-2022-28890.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2022-29181",
+      "cwes": [
+        "CWE-241",
+        "CWE-843"
+      ],
+      "title": "Nokogiri Improperly Handles Unexpected Data Type",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2022-29181.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2022-31471",
+      "cwes": [
+        "CWE-611",
+        "CWE-776"
+      ],
+      "title": "untangle vulnerable to XML Entity Expansion",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2022-31471.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2022-3150",
+      "cwes": [],
+      "title": "The WP Custom Cursors WordPress plugin before 3.2 does not properly sanitise and escape a parameter before using it in a",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2022-3150.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2022-31777",
+      "cwes": [
+        "CWE-74"
+      ],
+      "title": "Apache Spark vulnerable to Log Injection",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "medium",
+      "file": "owasp-asi/CVE-2022-31777.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2022-3294",
+      "cwes": [
+        "CWE-20"
+      ],
+      "title": "Kubernetes vulnerable to validation bypass",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2022-3294.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2022-34558",
+      "cwes": [],
+      "title": "WMAgent arbitrary code execution via a crafted dbs-client package",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "critical",
+      "file": "owasp-asi/CVE-2022-34558.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2022-36085",
+      "cwes": [
+        "CWE-20"
+      ],
+      "title": "OPA Compiler: Bypass of WithUnsafeBuiltins using \"with\" keyword to mock functions",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2022-36085.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2022-37189",
+      "cwes": [
+        "CWE-611"
+      ],
+      "title": "MEI2Volpiano is vulnerable to XML External Entity (XXE), leading to a Denial of Service (DoS)",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2022-37189.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2022-39135",
+      "cwes": [
+        "CWE-611"
+      ],
+      "title": "Apache Calcite before 1.32.0 vulnerable to potential XML External Entity (XXE) attack",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "critical",
+      "file": "owasp-asi/CVE-2022-39135.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2022-39353",
+      "cwes": [
+        "CWE-1288",
+        "CWE-20"
+      ],
+      "title": "xmldom allows multiple root nodes in a DOM",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "critical",
+      "file": "owasp-asi/CVE-2022-39353.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2022-40145",
+      "cwes": [
+        "CWE-20",
+        "CWE-611",
+        "CWE-74",
+        "CWE-91"
+      ],
+      "title": "Apache Ivy External Entity Reference vulnerability",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "critical",
+      "file": "owasp-asi/CVE-2022-40145.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2022-40705",
+      "cwes": [
+        "CWE-611"
+      ],
+      "title": "Apache SOAP's RPCRouterServlet allows reading of arbitrary files over HTTP",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2022-40705.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2022-4135",
+      "cwes": [
+        "CWE-787"
+      ],
+      "title": "Heap buffer overflow in GPU",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "critical",
+      "file": "owasp-asi/CVE-2022-4135.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2022-41928",
+      "cwes": [
+        "CWE-95"
+      ],
+      "title": "Improper Neutralization of Directives in Dynamically Evaluated Code ('Eval Injection') in AttachmentSelector.xml",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "critical",
+      "file": "owasp-asi/CVE-2022-41928.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2022-42009",
+      "cwes": [
+        "CWE-917"
+      ],
+      "title": "Apache Ambari Expression Language Injection vulnerability",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2022-42009.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2022-43689",
+      "cwes": [
+        "CWE-611"
+      ],
+      "title": "Concrete CMS vulnerable to XML External Entity",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "medium",
+      "file": "owasp-asi/CVE-2022-43689.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2022-43720",
+      "cwes": [
+        "CWE-74"
+      ],
+      "title": "Apache Superset vulnerable to Injection",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "medium",
+      "file": "owasp-asi/CVE-2022-43720.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2022-45801",
+      "cwes": [
+        "CWE-74"
+      ],
+      "title": "Apache StreamPark LDAP Injection vulnerability",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "medium",
+      "file": "owasp-asi/CVE-2022-45801.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2022-46365",
+      "cwes": [
+        "CWE-20"
+      ],
+      "title": "Apache StreamPark Improper Input Validation vulnerability",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "critical",
+      "file": "owasp-asi/CVE-2022-46365.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2022-47500",
+      "cwes": [
+        "CWE-601"
+      ],
+      "title": "Apache Helix UI vulnerable to Open Redirect",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "medium",
+      "file": "owasp-asi/CVE-2022-47500.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2022-47636",
+      "cwes": [
+        "CWE-427"
+      ],
+      "title": "A DLL hijacking vulnerability has been discovered in OutSystems Service Studio 11 11.53.30 build 61739.",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2022-47636.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2022-48622",
+      "cwes": [
+        "CWE-787"
+      ],
+      "title": "In GNOME GdkPixbuf (aka gdk-pixbuf) through 2.42.10, the ANI (Windows animated cursor) decoder encounters heap memory co",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2022-48622.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2023-0493",
+      "cwes": [
+        "CWE-74",
+        "CWE-76"
+      ],
+      "title": "Withdrawn Advisory: HTML injections in BTCPayServer",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2023-0493.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2023-22465",
+      "cwes": [
+        "CWE-20"
+      ],
+      "title": "Http4s improperly parses User-Agent and Server headers",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2023-22465.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2023-22621",
+      "cwes": [
+        "CWE-74"
+      ],
+      "title": "Strapi plugins vulnerable to Server-Side Template Injection and Remote Code Execution in the Users-Permissions Plugin",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "critical",
+      "file": "owasp-asi/CVE-2023-22621.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2023-23926",
+      "cwes": [
+        "CWE-611"
+      ],
+      "title": "XML External Entity (XXE) vulnerability in apoc.import.graphml",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "medium",
+      "file": "owasp-asi/CVE-2023-23926.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2023-24187",
+      "cwes": [
+        "CWE-611"
+      ],
+      "title": "XML External Entity Reference in ureport",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2023-24187.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2023-24429",
+      "cwes": [
+        "CWE-256",
+        "CWE-312",
+        "CWE-611",
+        "CWE-776"
+      ],
+      "title": "XML external entity vulnerability on agents in Jenkins MSTest Plugin",
+      "proposedTactic": "ATD-TA4",
+      "category": "privilege-escalation",
+      "severity": "critical",
+      "file": "owasp-asi/CVE-2023-24429.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2023-24936",
+      "cwes": [],
+      "title": ".NET Elevation of Privilege Vulnerability",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2023-24936.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2023-26043",
+      "cwes": [
+        "CWE-611"
+      ],
+      "title": "GeoServer style upload functionality vulnerable to XML External Entity (XXE) injection",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2023-26043.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2023-2629",
+      "cwes": [
+        "CWE-1236"
+      ],
+      "title": "Embedding untrusted input inside CSV files leads to Formula Injection/CSV Injection",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2023-2629.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2023-27476",
+      "cwes": [
+        "CWE-611"
+      ],
+      "title": "OWSLib vulnerable to XML External Entity (XXE) Injection",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2023-27476.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2023-27480",
+      "cwes": [
+        "CWE-611"
+      ],
+      "title": "XWiki Platform vulnerable to data leak via Improper Restriction of XML External Entity Reference",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2023-27480.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2023-28113",
+      "cwes": [
+        "CWE-20",
+        "CWE-347"
+      ],
+      "title": "russh may use insecure Diffie-Hellman keys",
+      "proposedTactic": "ATD-TA4",
+      "category": "privilege-escalation",
+      "severity": "medium",
+      "file": "owasp-asi/CVE-2023-28113.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2023-28118",
+      "cwes": [
+        "CWE-776"
+      ],
+      "title": "kaml has potential denial of service while parsing input with anchors and aliases",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2023-28118.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2023-28680",
+      "cwes": [
+        "CWE-611"
+      ],
+      "title": "Jenkins AbsInt a³ Plugin XML External Entity Reference vulnerability",
+      "proposedTactic": "ATD-TA4",
+      "category": "privilege-escalation",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2023-28680.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2023-29199",
+      "cwes": [
+        "CWE-913"
+      ],
+      "title": "vm2 Sandbox Escape vulnerability",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "critical",
+      "file": "owasp-asi/CVE-2023-29199.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2023-29213",
+      "cwes": [
+        "CWE-352",
+        "CWE-74",
+        "CWE-95"
+      ],
+      "title": "org.xwiki.platform:xwiki-platform-logging-ui Eval Injection vulnerability",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "critical",
+      "file": "owasp-asi/CVE-2023-29213.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2023-29337",
+      "cwes": [
+        "CWE-367"
+      ],
+      "title": "NuGet Client Remote Code Execution Vulnerability",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2023-29337.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2023-29510",
+      "cwes": [
+        "CWE-74"
+      ],
+      "title": "Code injection via unescaped translations in xwiki-platform",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "critical",
+      "file": "owasp-asi/CVE-2023-29510.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2023-29523",
+      "cwes": [
+        "CWE-74"
+      ],
+      "title": "XWiki Platform vulnerable to code injection in display method used in user profiles",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "critical",
+      "file": "owasp-asi/CVE-2023-29523.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2023-29525",
+      "cwes": [
+        "CWE-74"
+      ],
+      "title": "XWiki Platform vulnerable to privilege escalation from view right on XWiki.Notifications.Code.LegacyNotificationAdminist",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "critical",
+      "file": "owasp-asi/CVE-2023-29525.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2023-2984",
+      "cwes": [
+        "CWE-29"
+      ],
+      "title": "Pimcore vulnerable to Pre-Auth Path Traversal in pimcore_log parameter",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "medium",
+      "file": "owasp-asi/CVE-2023-2984.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2023-33126",
+      "cwes": [],
+      "title": "Microsoft Security Advisory CVE-2023-33126: .NET Remote Code Execution Vulnerability",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2023-33126.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2023-33127",
+      "cwes": [
+        "CWE-1220"
+      ],
+      "title": "Microsoft Security Advisory CVE-2023-33127: .NET Remote Code Execution Vulnerability",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2023-33127.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2023-34239",
+      "cwes": [
+        "CWE-20"
+      ],
+      "title": "Gradio — Vulnerability (CVE-2023-34239)",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2023-34239.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2023-34411",
+      "cwes": [
+        "CWE-611",
+        "CWE-617"
+      ],
+      "title": "xml-rs vulnerable to denial of service via invalid token in XML document",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2023-34411.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2023-34457",
+      "cwes": [
+        "CWE-20"
+      ],
+      "title": "MechanicalSoup vulnerable to malicious web server reading arbitrary files on client using file input inside HTML form",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2023-34457.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2023-35797",
+      "cwes": [
+        "CWE-20"
+      ],
+      "title": "Apache Airflow Hive Provider Beeline remote code execution with Principal",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "critical",
+      "file": "owasp-asi/CVE-2023-35797.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2023-36049",
+      "cwes": [
+        "CWE-20"
+      ],
+      "title": "Microsoft Security Advisory CVE-2023-36049: .NET Elevation of Privilege Vulnerability",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2023-36049.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2023-36237",
+      "cwes": [
+        "CWE-352"
+      ],
+      "title": "Bagisto Cross-Site Request Forgery vulnerability",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2023-36237.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2023-36470",
+      "cwes": [
+        "CWE-74"
+      ],
+      "title": "XWiki Platform vulnerable to Code Injection in icon themes",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "critical",
+      "file": "owasp-asi/CVE-2023-36470.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2023-36792",
+      "cwes": [],
+      "title": "Microsoft Security Advisory CVE-2023-36792: .NET Remote Code Execution Vulnerability",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2023-36792.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2023-36793",
+      "cwes": [],
+      "title": "Microsoft Security Advisory CVE-2023-36793: .NET Remote Code Execution Vulnerability",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2023-36793.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2023-36794",
+      "cwes": [],
+      "title": "Microsoft Security Advisory CVE-2023-36794: .NET Remote Code Execution Vulnerability",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2023-36794.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2023-36796",
+      "cwes": [],
+      "title": "Microsoft Security Advisory CVE-2023-36796: .NET Remote Code Execution Vulnerability",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2023-36796.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2023-37271",
+      "cwes": [
+        "CWE-913"
+      ],
+      "title": "RestrictedPython vulnerable to arbitrary code execution via stack frame sandbox escape",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2023-37271.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2023-37277",
+      "cwes": [
+        "CWE-352"
+      ],
+      "title": "XWiki Platform vulnerable to cross-site request forgery (CSRF) via the REST API",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "critical",
+      "file": "owasp-asi/CVE-2023-37277.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2023-40035",
+      "cwes": [
+        "CWE-74"
+      ],
+      "title": "Craft CMS vulnerable to Remote Code Execution via validatePath bypass",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2023-40035.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2023-40177",
+      "cwes": [
+        "CWE-95"
+      ],
+      "title": "XWiki Platform privilege escalation (PR) from account through AWM content fields",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "critical",
+      "file": "owasp-asi/CVE-2023-40177.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2023-41034",
+      "cwes": [
+        "CWE-611"
+      ],
+      "title": "DDFFileParser is vulnerable to XXE Attacks",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "medium",
+      "file": "owasp-asi/CVE-2023-41034.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2023-41885",
+      "cwes": [
+        "CWE-203",
+        "CWE-204"
+      ],
+      "title": "Piccolo's current `BaseUser.login` implementation is vulnerable to time based user enumeration",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "medium",
+      "file": "owasp-asi/CVE-2023-41885.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2023-4218",
+      "cwes": [
+        "CWE-611"
+      ],
+      "title": "Eclipse IDE XXE in eclipse.platform",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "medium",
+      "file": "owasp-asi/CVE-2023-4218.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2023-4241",
+      "cwes": [
+        "CWE-20"
+      ],
+      "title": "lol-html panics on certain HTML inputs",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2023-4241.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2023-42503",
+      "cwes": [
+        "CWE-20",
+        "CWE-400"
+      ],
+      "title": "Apache Commons Compress denial of service vulnerability",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "medium",
+      "file": "owasp-asi/CVE-2023-42503.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2023-45139",
+      "cwes": [
+        "CWE-611"
+      ],
+      "title": "fonttools XML External Entity Injection (XXE) Vulnerability",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2023-45139.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2023-45193",
+      "cwes": [
+        "CWE-20"
+      ],
+      "title": "IBM Db2 for Linux, UNIX and Windows (includes Db2 Connect Server) 11.5 federated server is vulnerable to a denial of ser",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "medium",
+      "file": "owasp-asi/CVE-2023-45193.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2023-45303",
+      "cwes": [
+        "CWE-74"
+      ],
+      "title": "ThingsBoard Server-Side Template Injection",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2023-45303.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2023-45811",
+      "cwes": [
+        "CWE-1321"
+      ],
+      "title": "Synchrony deobfuscator prototype pollution vulnerability leading to arbitrary code execution",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2023-45811.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2023-46245",
+      "cwes": [
+        "CWE-1336"
+      ],
+      "title": "Kimai (Authenticated) SSTI to RCE by Uploading a Malicious Twig File",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2023-46245.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2023-48223",
+      "cwes": [
+        "CWE-20",
+        "CWE-327"
+      ],
+      "title": "fast-jwt: Incomplete fix for CVE-2023-48223: JWT Algorithm Confusion via Whitespace-Prefixed RSA Public Key",
+      "proposedTactic": "ATD-TA4",
+      "category": "privilege-escalation",
+      "severity": "critical",
+      "file": "owasp-asi/CVE-2023-48223.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2023-48362",
+      "cwes": [
+        "CWE-611"
+      ],
+      "title": "XML External Entity Reference (XXE) in the XML Format Plugin in Apache Drill",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2023-48362.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2023-49081",
+      "cwes": [
+        "CWE-20"
+      ],
+      "title": "Improper validation in meraki",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2023-49081.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2023-49082",
+      "cwes": [
+        "CWE-20"
+      ],
+      "title": "aiohttp's ClientSession is vulnerable to CRLF injection via method",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "medium",
+      "file": "owasp-asi/CVE-2023-49082.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2023-49733",
+      "cwes": [
+        "CWE-611"
+      ],
+      "title": "Apache Cocoon Improper Restriction of XML External Entity Reference vulnerability",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "critical",
+      "file": "owasp-asi/CVE-2023-49733.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2023-50380",
+      "cwes": [
+        "CWE-611"
+      ],
+      "title": "Apache Ambari XML External Entity injection",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "medium",
+      "file": "owasp-asi/CVE-2023-50380.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2023-50709",
+      "cwes": [
+        "CWE-20"
+      ],
+      "title": "Cube API denial of service attack",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "medium",
+      "file": "owasp-asi/CVE-2023-50709.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2023-51444",
+      "cwes": [
+        "CWE-20",
+        "CWE-434"
+      ],
+      "title": "Arbitrary file upload vulnerability in GeoServer's REST Coverage Store API",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2023-51444.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2023-53929",
+      "cwes": [
+        "CWE-1236"
+      ],
+      "title": "phpMyFAQ contains a CSV injection vulnerability",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "medium",
+      "file": "owasp-asi/CVE-2023-53929.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2023-6147",
+      "cwes": [
+        "CWE-611"
+      ],
+      "title": "Qualys Jenkins Plugin for WAS XML External Entity vulnerability",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "medium",
+      "file": "owasp-asi/CVE-2023-6147.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2023-6836",
+      "cwes": [
+        "CWE-611"
+      ],
+      "title": "WSO2 products vulnerable to XML External Entity attack",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "medium",
+      "file": "owasp-asi/CVE-2023-6836.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2024-0793",
+      "cwes": [
+        "CWE-20",
+        "CWE-476"
+      ],
+      "title": "Kubernetes Nil pointer dereference in KCM after v1 HPA patch request",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2024-0793.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2024-10846",
+      "cwes": [
+        "CWE-20",
+        "CWE-400"
+      ],
+      "title": "Excessive Platform Resource Consumption within a Loop when unmarshalling Compose file having recursive loop",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "medium",
+      "file": "owasp-asi/CVE-2024-10846.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2024-11044",
+      "cwes": [
+        "CWE-601"
+      ],
+      "title": "An open redirect vulnerability in automatic1111/stable-diffusion-webui version 1.10.0 allows a remote unauthenticated at",
+      "proposedTactic": "ATD-TA4",
+      "category": "privilege-escalation",
+      "severity": "medium",
+      "file": "owasp-asi/CVE-2024-11044.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2024-11404",
+      "cwes": [
+        "CWE-20",
+        "CWE-434",
+        "CWE-80"
+      ],
+      "title": "Django Filer Unrestricted Upload of File with Dangerous Type",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "medium",
+      "file": "owasp-asi/CVE-2024-11404.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2024-12236",
+      "cwes": [
+        "CWE-755"
+      ],
+      "title": "A security issue exists in Vertex Gemini API for customers using VPC-SC.",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "medium",
+      "file": "owasp-asi/CVE-2024-12236.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2024-12401",
+      "cwes": [
+        "CWE-20"
+      ],
+      "title": "Duplicate Advisory: cert-manager ha a potential slowdown / DoS when parsing specially crafted PEM inputs",
+      "proposedTactic": "ATD-TA4",
+      "category": "privilege-escalation",
+      "severity": "medium",
+      "file": "owasp-asi/CVE-2024-12401.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2024-21575",
+      "cwes": [
+        "CWE-35"
+      ],
+      "title": "ComfyUI-Impact-Pack is vulnerable to Path Traversal.",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2024-21575.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2024-21641",
+      "cwes": [
+        "CWE-601"
+      ],
+      "title": "Flarum's logout Route allows open redirects",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "medium",
+      "file": "owasp-asi/CVE-2024-21641.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2024-21802",
+      "cwes": [
+        "CWE-122",
+        "CWE-787"
+      ],
+      "title": "A heap-based buffer overflow vulnerability exists in the GGUF library info-&gt;ne functionality of llama.cpp Commit 18c2",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2024-21802.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2024-21825",
+      "cwes": [
+        "CWE-190",
+        "CWE-787"
+      ],
+      "title": "A heap-based buffer overflow vulnerability exists in the GGUF library GGUF_TYPE_ARRAY/GGUF_TYPE_STRING parsing functiona",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2024-21825.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2024-21836",
+      "cwes": [
+        "CWE-190",
+        "CWE-787"
+      ],
+      "title": "A heap-based buffer overflow vulnerability exists in the GGUF library header.n_tensors functionality of llama.cpp Commit",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2024-21836.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2024-22259",
+      "cwes": [
+        "CWE-601"
+      ],
+      "title": "Spring Framework URL Parsing with Host Validation Vulnerability",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2024-22259.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2024-22262",
+      "cwes": [
+        "CWE-601"
+      ],
+      "title": "Spring Framework URL Parsing with Host Validation",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2024-22262.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2024-23496",
+      "cwes": [
+        "CWE-190",
+        "CWE-787"
+      ],
+      "title": "A heap-based buffer overflow vulnerability exists in the GGUF library gguf_fread_str functionality of llama.cpp Commit 1",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2024-23496.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2024-23605",
+      "cwes": [
+        "CWE-190",
+        "CWE-787"
+      ],
+      "title": "A heap-based buffer overflow vulnerability exists in the GGUF library header.n_kv functionality of llama.cpp Commit 18c2",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2024-23605.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2024-23634",
+      "cwes": [
+        "CWE-20",
+        "CWE-73"
+      ],
+      "title": "GeoServer Arbitrary file renaming vulnerability in REST Coverage/Data Store API",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "medium",
+      "file": "owasp-asi/CVE-2024-23634.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2024-23730",
+      "cwes": [],
+      "title": "The OpenAPI and ChatGPT plugin loaders in LlamaHub (aka llama-hub) before 0.0.67 allow attackers to execute arbitrary co",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "critical",
+      "file": "owasp-asi/CVE-2024-23730.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2024-23841",
+      "cwes": [
+        "CWE-80"
+      ],
+      "title": "@apollo/experimental-nextjs-app-support Cross-site Scripting vulnerability",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2024-23841.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2024-26482",
+      "cwes": [
+        "CWE-80"
+      ],
+      "title": "Withdrawn Advisory: Kirby CMS HTML injection vulnerability",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2024-26482.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2024-27564",
+      "cwes": [],
+      "title": "Chinese ChatGPT-clone (pictureproxy.php) SSRF exploited in the wild",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "medium",
+      "file": "owasp-asi/CVE-2024-27564.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2024-27931",
+      "cwes": [
+        "CWE-20"
+      ],
+      "title": "Insufficient permission checking in `Deno.makeTemp*` APIs",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "medium",
+      "file": "owasp-asi/CVE-2024-27931.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2024-28103",
+      "cwes": [
+        "CWE-20"
+      ],
+      "title": "Missing security headers in Action Pack on non-HTML responses",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "medium",
+      "file": "owasp-asi/CVE-2024-28103.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2024-28105",
+      "cwes": [
+        "CWE-434"
+      ],
+      "title": "phpMyFAQ's File Upload Bypass at Category Image Leads to RCE",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2024-28105.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2024-29018",
+      "cwes": [
+        "CWE-669"
+      ],
+      "title": "Moby — Data Exfiltration (CVE-2024-29018)",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "medium",
+      "file": "owasp-asi/CVE-2024-29018.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2024-30045",
+      "cwes": [
+        "CWE-122"
+      ],
+      "title": "Microsoft Security Advisory CVE-2024-30045 | .NET Remote code Execution Vulnerability",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "medium",
+      "file": "owasp-asi/CVE-2024-30045.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2024-30105",
+      "cwes": [
+        "CWE-400"
+      ],
+      "title": "Microsoft Security Advisory CVE-2024-30105 | .NET Denial of Service Vulnerability",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2024-30105.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2024-31985",
+      "cwes": [
+        "CWE-352",
+        "CWE-95"
+      ],
+      "title": "XWiki Platform CSRF remote code execution through scheduler job's document reference",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "critical",
+      "file": "owasp-asi/CVE-2024-31985.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2024-31988",
+      "cwes": [
+        "CWE-352"
+      ],
+      "title": "XWiki Platform CSRF remote code execution through the realtime HTML Converter API",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "critical",
+      "file": "owasp-asi/CVE-2024-31988.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2024-32048",
+      "cwes": [
+        "CWE-20"
+      ],
+      "title": "Improper input validation in the Intel(R) Distribution of OpenVINO(TM) Model Server software before version 2024.0 may a",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "medium",
+      "file": "owasp-asi/CVE-2024-32048.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2024-32880",
+      "cwes": [
+        "CWE-434"
+      ],
+      "title": "pyLoad allows upload to arbitrary folder lead to RCE",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "critical",
+      "file": "owasp-asi/CVE-2024-32880.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2024-34345",
+      "cwes": [
+        "CWE-611"
+      ],
+      "title": "@cyclonedx/cyclonedx-library Improper Restriction of XML External Entity Reference vulnerability",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2024-34345.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2024-34391",
+      "cwes": [
+        "CWE-843"
+      ],
+      "title": "libxmljs vulnerable to type confusion when parsing specially crafted XML",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "critical",
+      "file": "owasp-asi/CVE-2024-34391.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2024-34393",
+      "cwes": [
+        "CWE-843"
+      ],
+      "title": "libxmljs2 type confusion vulnerability when parsing specially crafted XML",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "critical",
+      "file": "owasp-asi/CVE-2024-34393.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2024-34394",
+      "cwes": [
+        "CWE-843"
+      ],
+      "title": "libxmljs2 vulnerable to type confusion when parsing specially crafted XML",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "critical",
+      "file": "owasp-asi/CVE-2024-34394.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2024-35264",
+      "cwes": [
+        "CWE-416"
+      ],
+      "title": "Microsoft Security Advisory CVE-2024-35264 | .NET Remote Code Execution Vulnerability",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "critical",
+      "file": "owasp-asi/CVE-2024-35264.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2024-3584",
+      "cwes": [
+        "CWE-20"
+      ],
+      "title": "qdrant/qdrant version 1.9.0-dev is vulnerable to path traversal due to improper input validation in the `/collections/{n",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2024-3584.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2024-36827",
+      "cwes": [
+        "CWE-611",
+        "CWE-776"
+      ],
+      "title": "ebookmeta XML External Entity vulnerability",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2024-36827.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2024-38095",
+      "cwes": [
+        "CWE-20"
+      ],
+      "title": "Microsoft Security Advisory CVE-2024-38095 | .NET Denial of Service Vulnerability",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2024-38095.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2024-38374",
+      "cwes": [
+        "CWE-611"
+      ],
+      "title": "Improper Restriction of XML External Entity Reference in org.cyclonedx:cyclonedx-core-java",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2024-38374.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2024-38529",
+      "cwes": [
+        "CWE-434"
+      ],
+      "title": "Admidio Vulnerable to RCE via Arbitrary File Upload in Message Attachment",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "critical",
+      "file": "owasp-asi/CVE-2024-38529.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2024-41122",
+      "cwes": [
+        "CWE-74"
+      ],
+      "title": "Woodpecker's custom environment variables allow to alter execution flow of plugins",
+      "proposedTactic": "ATD-TA4",
+      "category": "privilege-escalation",
+      "severity": "medium",
+      "file": "owasp-asi/CVE-2024-41122.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2024-41597",
+      "cwes": [
+        "CWE-352"
+      ],
+      "title": "ProcessWire Cross Site Request Forgery vulnerability",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "low",
+      "file": "owasp-asi/CVE-2024-41597.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2024-4254",
+      "cwes": [
+        "CWE-214"
+      ],
+      "title": "The 'deploy-website.yml' workflow in the gradio-app/gradio repository, specifically in the 'main' branch, is vulnerable ",
+      "proposedTactic": "ATD-TA4",
+      "category": "privilege-escalation",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2024-4254.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2024-42835",
+      "cwes": [],
+      "title": "langflow v1.0.12 was discovered to contain a remote code execution (RCE) vulnerability via the PythonCodeTool component.",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "critical",
+      "file": "owasp-asi/CVE-2024-42835.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2024-4330",
+      "cwes": [
+        "CWE-23"
+      ],
+      "title": "path traversal vulnerability was identified in the parisneo/lollms-webui",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "medium",
+      "file": "owasp-asi/CVE-2024-4330.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2024-43484",
+      "cwes": [
+        "CWE-407"
+      ],
+      "title": "Microsoft Security Advisory CVE-2024-43484 | .NET Denial of Service Vulnerability",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2024-43484.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2024-43485",
+      "cwes": [
+        "CWE-407"
+      ],
+      "title": "Microsoft Security Advisory CVE-2024-43485 | .NET Denial of Service Vulnerability",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2024-43485.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2024-45048",
+      "cwes": [
+        "CWE-1395",
+        "CWE-611"
+      ],
+      "title": "Kimai has an XXE Leading to Local File Read",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2024-45048.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2024-45187",
+      "cwes": [
+        "CWE-266",
+        "CWE-613"
+      ],
+      "title": "Mage AI incorrectly gives privileges to users with deleted accounts",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "medium",
+      "file": "owasp-asi/CVE-2024-45187.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2024-45293",
+      "cwes": [
+        "CWE-611"
+      ],
+      "title": "XXE in PHPSpreadsheet's XLSX reader",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2024-45293.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2024-45294",
+      "cwes": [
+        "CWE-611"
+      ],
+      "title": "XXE vulnerability in XSLT parsing in `org.hl7.fhir.publisher`",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2024-45294.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2024-45302",
+      "cwes": [
+        "CWE-113",
+        "CWE-74",
+        "CWE-93"
+      ],
+      "title": "CRLF Injection in RestSharp's `RestRequest.AddHeader` method",
+      "proposedTactic": "ATD-TA4",
+      "category": "privilege-escalation",
+      "severity": "medium",
+      "file": "owasp-asi/CVE-2024-45302.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2024-45599",
+      "cwes": [
+        "CWE-277"
+      ],
+      "title": "Cursor — Rce (CVE-2024-45599)",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "low",
+      "file": "owasp-asi/CVE-2024-45599.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2024-46985",
+      "cwes": [
+        "CWE-611"
+      ],
+      "title": "DataEase has an XML External Entity Reference vulnerability",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2024-46985.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2024-46997",
+      "cwes": [
+        "CWE-74"
+      ],
+      "title": "DataEase's H2 datasource has a remote command execution risk",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "critical",
+      "file": "owasp-asi/CVE-2024-46997.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2024-4897",
+      "cwes": [
+        "CWE-76"
+      ],
+      "title": "parisneo/lollms-webui, in its latest version, is vulnerable to remote code execution due to an insecure dependency on ll",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2024-4897.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2024-50050",
+      "cwes": [],
+      "title": "ShadowMQ — critical RCE in Meta/NVIDIA/vLLM inference servers via pickle deserialization",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "critical",
+      "file": "owasp-asi/CVE-2024-50050.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2024-51132",
+      "cwes": [
+        "CWE-601",
+        "CWE-611"
+      ],
+      "title": "HAPI FHIR XML External Entity (XXE) vulnerability",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2024-51132.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2024-52596",
+      "cwes": [
+        "CWE-611"
+      ],
+      "title": "SimpleSAMLphp vulnerable to XXE in parsing SAML messages",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2024-52596.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2024-52806",
+      "cwes": [
+        "CWE-611"
+      ],
+      "title": "SimpleSAMLphp SAML2 has an XXE in parsing SAML messages",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "medium",
+      "file": "owasp-asi/CVE-2024-52806.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2024-5443",
+      "cwes": [
+        "CWE-29"
+      ],
+      "title": "Remote Code Execution via path traversal bypass in lollms",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "critical",
+      "file": "owasp-asi/CVE-2024-5443.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2024-55887",
+      "cwes": [
+        "CWE-611"
+      ],
+      "title": "Ucum-java has an XXE vulnerability in XML parsing",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2024-55887.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2024-6139",
+      "cwes": [
+        "CWE-29"
+      ],
+      "title": "lollms vulnerable to dot-dot-slash path traversal in XTTS server",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2024-6139.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2024-6985",
+      "cwes": [
+        "CWE-23"
+      ],
+      "title": "Lord of Large Language Models (LoLLMs) path traversal vulnerability in the api open_personality_folder endpoint",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "medium",
+      "file": "owasp-asi/CVE-2024-6985.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2024-7033",
+      "cwes": [
+        "CWE-29"
+      ],
+      "title": "Open WebUI Allows Arbitrary File Write via the `download_model` Endpoint",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "medium",
+      "file": "owasp-asi/CVE-2024-7033.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2024-7806",
+      "cwes": [
+        "CWE-352"
+      ],
+      "title": "Open WebUI Cross-Site Request Forgery (CSRF) Vulnerability",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2024-7806.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2024-9329",
+      "cwes": [
+        "CWE-233",
+        "CWE-601"
+      ],
+      "title": "Eclipse Glassfish improperly handles http parameters",
+      "proposedTactic": "ATD-TA4",
+      "category": "privilege-escalation",
+      "severity": "medium",
+      "file": "owasp-asi/CVE-2024-9329.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-1040",
+      "cwes": [
+        "CWE-1336"
+      ],
+      "title": "AutoGPT versions 0.3.4 and earlier are vulnerable to a Server-Side Template Injection (SSTI) that could lead to Remote C",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2025-1040.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-10713",
+      "cwes": [
+        "CWE-611"
+      ],
+      "title": "WSO2 Carbon Mediation vulnerable to XML External Entity (XXE) attacks",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "medium",
+      "file": "owasp-asi/CVE-2025-10713.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-12487",
+      "cwes": [
+        "CWE-807"
+      ],
+      "title": "oobabooga text-generation-webui trust_remote_code Reliance on Untrusted Inputs Remote Code Execution Vulnerability.",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "critical",
+      "file": "owasp-asi/CVE-2025-12487.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-21171",
+      "cwes": [
+        "CWE-122"
+      ],
+      "title": "Microsoft Security Advisory CVE-2025-21171 | .NET Remote Code Execution Vulnerability",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2025-21171.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-21172",
+      "cwes": [
+        "CWE-122"
+      ],
+      "title": "Microsoft Security Advisory CVE-2025-21172 | .NET and Visual Studio Remote Code Execution Vulnerability",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2025-21172.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-21176",
+      "cwes": [
+        "CWE-126"
+      ],
+      "title": "Microsoft Security Advisory CVE-2025-21176 | .NET and Visual Studio Remote Code Execution Vulnerability",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2025-21176.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-24359",
+      "cwes": [
+        "CWE-134",
+        "CWE-367",
+        "CWE-749"
+      ],
+      "title": "ASTEVAL Allows Maliciously Crafted Format Strings to Lead to Sandbox Escape",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2025-24359.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-25014",
+      "cwes": [
+        "CWE-1321"
+      ],
+      "title": "A Prototype pollution vulnerability in Kibana leads to arbitrary code execution via crafted HTTP requests to machine lea",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "critical",
+      "file": "owasp-asi/CVE-2025-25014.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-27411",
+      "cwes": [
+        "CWE-434"
+      ],
+      "title": "REDAXO allows Arbitrary File Upload in the mediapool page",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "medium",
+      "file": "owasp-asi/CVE-2025-27411.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-2905",
+      "cwes": [
+        "CWE-611"
+      ],
+      "title": "WSO2 API Manager XML External Entity (XXE) vulnerability",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "critical",
+      "file": "owasp-asi/CVE-2025-2905.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-30402",
+      "cwes": [
+        "CWE-122"
+      ],
+      "title": "ExecuTorch vulnerable to Heap-based Buffer Overflow attack",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2025-30402.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-30404",
+      "cwes": [
+        "CWE-190"
+      ],
+      "title": "ExecuTorch integer overflow vulnerability",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "critical",
+      "file": "owasp-asi/CVE-2025-30404.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-31475",
+      "cwes": [
+        "CWE-1321"
+      ],
+      "title": "tarteaucitron.js allows prototype pollution via custom text injection",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "medium",
+      "file": "owasp-asi/CVE-2025-31475.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-31487",
+      "cwes": [
+        "CWE-611"
+      ],
+      "title": "The XWiki JIRA extension allows data leak through an XXE attack by using a fake JIRA server",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2025-31487.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-31672",
+      "cwes": [
+        "CWE-20"
+      ],
+      "title": "Apache POI OOXML Vulnerable to Improper Input Validation in OOXML File Parsing",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "medium",
+      "file": "owasp-asi/CVE-2025-31672.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-32970",
+      "cwes": [
+        "CWE-601"
+      ],
+      "title": "org.xwiki.platform:xwiki-platform-wysiwyg-api Open Redirect vulnerability",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "medium",
+      "file": "owasp-asi/CVE-2025-32970.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-3466",
+      "cwes": [
+        "CWE-1100"
+      ],
+      "title": "langgenius/dify versions 1.1.0 to 1.1.2 are vulnerable to unsanitized input in the code node, allowing execution of arbi",
+      "proposedTactic": "ATD-TA4",
+      "category": "privilege-escalation",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2025-3466.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-36730",
+      "cwes": [],
+      "title": "Windsurf Data Exfiltration & SpAIware (Multiple Vectors)",
+      "proposedTactic": "ATD-TA2",
+      "category": "prompt-injection",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2025-36730.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-49131",
+      "cwes": [
+        "CWE-732"
+      ],
+      "title": "FastGPT — Rce (CVE-2025-49131)",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "medium",
+      "file": "owasp-asi/CVE-2025-49131.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-49592",
+      "cwes": [
+        "CWE-601"
+      ],
+      "title": "n8n — Info Disclosure (CVE-2025-49592)",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "medium",
+      "file": "owasp-asi/CVE-2025-49592.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-52888",
+      "cwes": [
+        "CWE-611"
+      ],
+      "title": "Allure Report allows Improper XXE Restriction via DocumentBuilderFactory",
+      "proposedTactic": "ATD-TA4",
+      "category": "privilege-escalation",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2025-52888.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-53621",
+      "cwes": [
+        "CWE-611"
+      ],
+      "title": "DSpace open source software — Vulnerability (CVE-2025-53621)",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "medium",
+      "file": "owasp-asi/CVE-2025-53621.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-53770",
+      "cwes": [],
+      "title": "ToolShell RCE via SharePoint",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "medium",
+      "file": "owasp-asi/CVE-2025-53770.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-54287",
+      "cwes": [
+        "CWE-1336"
+      ],
+      "title": "Canonical LXD Arbitrary File Read via Template Injection in Snapshot Patterns",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2025-54287.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-54949",
+      "cwes": [
+        "CWE-122"
+      ],
+      "title": "ExecuTorch heap buffer overflow vulnerability",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "critical",
+      "file": "owasp-asi/CVE-2025-54949.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-54950",
+      "cwes": [
+        "CWE-125"
+      ],
+      "title": "ExecuTorch out-of-bounds access vulnerability",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "critical",
+      "file": "owasp-asi/CVE-2025-54950.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-54951",
+      "cwes": [
+        "CWE-122"
+      ],
+      "title": "ExecuTorch vulnerable to Heap-based Buffer Overflow",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "critical",
+      "file": "owasp-asi/CVE-2025-54951.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-54988",
+      "cwes": [
+        "CWE-611"
+      ],
+      "title": "Apache Tika XXE Vulnerability via Crafted XFA File Inside a PDF",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "critical",
+      "file": "owasp-asi/CVE-2025-54988.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-55013",
+      "cwes": [
+        "CWE-23"
+      ],
+      "title": "Assemblyline 4 service client vulnerable to Arbitrary Write through path traversal in Client code",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "medium",
+      "file": "owasp-asi/CVE-2025-55013.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-55178",
+      "cwes": [],
+      "title": "Llama Stack prior to version v0.2.20 accepted unverified parameters in the resolve_ast_by_type function which could pote",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "medium",
+      "file": "owasp-asi/CVE-2025-55178.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-55182",
+      "cwes": [],
+      "title": "React2Shell Impacting Dify and AI Platforms (CVE-2025-55182)",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "critical",
+      "file": "owasp-asi/CVE-2025-55182.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-58067",
+      "cwes": [
+        "CWE-601"
+      ],
+      "title": "Google Sign-In for Rails allowed redirect to protocol-relative URI",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "medium",
+      "file": "owasp-asi/CVE-2025-58067.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-61685",
+      "cwes": [
+        "CWE-548"
+      ],
+      "title": "Mastra — Path Traversal (CVE-2025-61685)",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "medium",
+      "file": "owasp-asi/CVE-2025-61685.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-6237",
+      "cwes": [
+        "CWE-73"
+      ],
+      "title": "A vulnerability in invokeai version v6.0.0a1 and below allows attackers to perform path traversal and arbitrary file del",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "critical",
+      "file": "owasp-asi/CVE-2025-6237.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-62379",
+      "cwes": [
+        "CWE-601"
+      ],
+      "title": "reflex-dev/reflex has an Open Redirect vulnerability",
+      "proposedTactic": "ATD-TA4",
+      "category": "privilege-escalation",
+      "severity": "low",
+      "file": "owasp-asi/CVE-2025-62379.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-64518",
+      "cwes": [
+        "CWE-611"
+      ],
+      "title": "CycloneDX Core (Java): BOM validation is vulnerable to XML External Entity injection",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2025-64518.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-65482",
+      "cwes": [
+        "CWE-611"
+      ],
+      "title": "XDocReport affected by an XML External Entity (XXE) vulnerability",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "critical",
+      "file": "owasp-asi/CVE-2025-65482.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-66034",
+      "cwes": [
+        "CWE-91"
+      ],
+      "title": "fontTools is Vulnerable to Arbitrary File Write and XML injection in fontTools.varLib",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "medium",
+      "file": "owasp-asi/CVE-2025-66034.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-66371",
+      "cwes": [
+        "CWE-611"
+      ],
+      "title": "Peppol-py is vulnerable to XXE attacks due to Saxon configuration",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "medium",
+      "file": "owasp-asi/CVE-2025-66371.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-66451",
+      "cwes": [
+        "CWE-20",
+        "CWE-915"
+      ],
+      "title": "LibreChat — Vulnerability (CVE-2025-66451)",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "medium",
+      "file": "owasp-asi/CVE-2025-66451.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-66786",
+      "cwes": [
+        "CWE-20"
+      ],
+      "title": "OpenAirInterface CN5G AMF<=v2.0.1 There is a logical error when processing JSON format requests.",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2025-66786.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-66959",
+      "cwes": [
+        "CWE-20",
+        "CWE-400"
+      ],
+      "title": "An issue in ollama v.0.12.10 allows a remote attacker to cause a denial of service via the GGUF decoder",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2025-66959.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-67502",
+      "cwes": [
+        "CWE-601"
+      ],
+      "title": "Open Redirect Vulnerability in Taguette",
+      "proposedTactic": "ATD-TA4",
+      "category": "privilege-escalation",
+      "severity": "medium",
+      "file": "owasp-asi/CVE-2025-67502.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-68280",
+      "cwes": [
+        "CWE-611"
+      ],
+      "title": "Apache SIS has Improper Restriction of XML External Entity Reference vulnerability",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "medium",
+      "file": "owasp-asi/CVE-2025-68280.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-68463",
+      "cwes": [
+        "CWE-611"
+      ],
+      "title": "Biopython is vulnerable to doctype XML external entity (XXE) injection through Bio.Entrez",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "medium",
+      "file": "owasp-asi/CVE-2025-68463.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-68493",
+      "cwes": [
+        "CWE-112",
+        "CWE-611"
+      ],
+      "title": "Apache Struts 2 is Missing XML Validation",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2025-68493.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-9556",
+      "cwes": [],
+      "title": "Langchaingo supports the use of jinja2 syntax when parsing prompts, which is in turn parsed using the gonja library v1.5",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "critical",
+      "file": "owasp-asi/CVE-2025-9556.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-0769",
+      "cwes": [
+        "CWE-95"
+      ],
+      "title": "Langflow eval_custom_component_code Eval Injection Remote Code Execution Vulnerability.",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "critical",
+      "file": "owasp-asi/CVE-2026-0769.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-0830",
+      "cwes": [],
+      "title": "Kiro IDE Command Injection (CVE-2026-0830)",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "medium",
+      "file": "owasp-asi/CVE-2026-0830.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-12143",
+      "cwes": [
+        "CWE-93"
+      ],
+      "title": "form-data: CRLF injection in form-data via unescaped multipart field names and filenames",
+      "proposedTactic": "ATD-TA4",
+      "category": "privilege-escalation",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2026-12143.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-1470",
+      "cwes": [
+        "CWE-95"
+      ],
+      "title": "n8n contains a critical Remote Code Execution (RCE) vulnerability in its workflow Expression evaluation system.",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "critical",
+      "file": "owasp-asi/CVE-2026-1470.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-1868",
+      "cwes": [
+        "CWE-1336"
+      ],
+      "title": "GitLab has remediated a vulnerability in the Duo Workflow Service component of GitLab AI Gateway affecting all versions ",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "critical",
+      "file": "owasp-asi/CVE-2026-1868.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-21452",
+      "cwes": [
+        "CWE-400",
+        "CWE-789"
+      ],
+      "title": "MessagePack for Java Vulnerable to Remote DoS via Malicious EXT Payload Allocation",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2026-21452.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-21858",
+      "cwes": [
+        "CWE-20"
+      ],
+      "title": "n8n Unauthenticated RCE \"Ni8mare\" (CVE-2026-21858)",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "critical",
+      "file": "owasp-asi/CVE-2026-21858.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-22032",
+      "cwes": [
+        "CWE-601"
+      ],
+      "title": "Directus has open redirect in SAML",
+      "proposedTactic": "ATD-TA4",
+      "category": "privilege-escalation",
+      "severity": "medium",
+      "file": "owasp-asi/CVE-2026-22032.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-22186",
+      "cwes": [
+        "CWE-611"
+      ],
+      "title": "Bio-Formats has an XML External Entity (XXE) vulnerability",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "medium",
+      "file": "owasp-asi/CVE-2026-22186.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-22218",
+      "cwes": [],
+      "title": "ChainLeak -- Chainlit AI Framework Vulnerabilities (CVE-2026-22218 & CVE-2026-22219)",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "medium",
+      "file": "owasp-asi/CVE-2026-22218.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-22244",
+      "cwes": [
+        "CWE-1336"
+      ],
+      "title": "OpenMetadata's Server-Side Template Injection (SSTI) in FreeMarker email templates leads to RCE",
+      "proposedTactic": "ATD-TA4",
+      "category": "privilege-escalation",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2026-22244.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-22444",
+      "cwes": [
+        "CWE-20"
+      ],
+      "title": "Apache Solr: Insufficient file-access checking in standalone core-creation requests",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2026-22444.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-22699",
+      "cwes": [
+        "CWE-20"
+      ],
+      "title": "SM2-PKE has Unchecked AffinePoint Decoding (unwrap) in decrypt()",
+      "proposedTactic": "ATD-TA4",
+      "category": "privilege-escalation",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2026-22699.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-22700",
+      "cwes": [
+        "CWE-20"
+      ],
+      "title": "RustCrypto Has Insufficient Length Validation in decrypt() in SM2-PKE",
+      "proposedTactic": "ATD-TA4",
+      "category": "privilege-escalation",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2026-22700.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-23626",
+      "cwes": [
+        "CWE-1336"
+      ],
+      "title": "Kimai has an Authenticated Server-Side Template Injection (SSTI)",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "medium",
+      "file": "owasp-asi/CVE-2026-23626.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-23795",
+      "cwes": [
+        "CWE-611"
+      ],
+      "title": "Apache Syncope: Console XXE on Keymaster parameters",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "medium",
+      "file": "owasp-asi/CVE-2026-23795.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-24051",
+      "cwes": [
+        "CWE-426"
+      ],
+      "title": "OpenTelemetry Go SDK Vulnerable to Arbitrary Code Execution via PATH Hijacking",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2026-24051.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-24052",
+      "cwes": [
+        "CWE-601"
+      ],
+      "title": "Claude Code — Data Exfiltration (CVE-2026-24052)",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2026-24052.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-25128",
+      "cwes": [
+        "CWE-20",
+        "CWE-248"
+      ],
+      "title": "fast-xml-parser has RangeError DoS Numeric Entities Bug",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2026-25128.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-2587",
+      "cwes": [
+        "CWE-917"
+      ],
+      "title": "GlassFish's gadget handler is vulnerable to RCE",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "critical",
+      "file": "owasp-asi/CVE-2026-2587.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-26003",
+      "cwes": [
+        "CWE-601"
+      ],
+      "title": "FastGPT — Vulnerability (CVE-2026-26003)",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "medium",
+      "file": "owasp-asi/CVE-2026-26003.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-26020",
+      "cwes": [
+        "CWE-285"
+      ],
+      "title": "AutoGPT — Rce (CVE-2026-26020)",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2026-26020.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-26144",
+      "cwes": [],
+      "title": "Microsoft Excel XSS Weaponizes Copilot Agent (CVE-2026-26144)",
+      "proposedTactic": "ATD-TA2",
+      "category": "prompt-injection",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2026-26144.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-26171",
+      "cwes": [
+        "CWE-400",
+        "CWE-611"
+      ],
+      "title": "Microsoft Security Advisory CVE-2026-26171 – .NET Denial of Service Vulnerability",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2026-26171.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-27891",
+      "cwes": [
+        "CWE-20",
+        "CWE-434"
+      ],
+      "title": "FacturaScripts Vulnerable to Remote Code Execution (RCE) via Zip Slip in Plugin Upload Mechanism",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2026-27891.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-27982",
+      "cwes": [
+        "CWE-601"
+      ],
+      "title": "django-allauth has an open redirect vulnerability",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "medium",
+      "file": "owasp-asi/CVE-2026-27982.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-28681",
+      "cwes": [
+        "CWE-601",
+        "CWE-640"
+      ],
+      "title": "IRRd: web UI host header injection allows password reset poisoning via attacker-controlled email links",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2026-28681.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-29186",
+      "cwes": [
+        "CWE-434",
+        "CWE-74"
+      ],
+      "title": "TechDocs Mkdocs Configuration Key Enables Arbitrary Code Execution",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2026-29186.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-29778",
+      "cwes": [
+        "CWE-23"
+      ],
+      "title": "pyLoad has an Arbitrary File Write via Path Traversal in edit_package()",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2026-29778.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-30077",
+      "cwes": [
+        "CWE-20"
+      ],
+      "title": "OpenAirInterface V2.2.0 AMF crashes when it receives an NGAP message with invalid procedure code or invalid PDU-type.",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2026-30077.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-32008",
+      "cwes": [
+        "CWE-610"
+      ],
+      "title": "OpenClaw versions prior to 2026.2.21 contain an improper URL scheme validation vulnerability in the assertBrowserNavigat",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "medium",
+      "file": "owasp-asi/CVE-2026-32008.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-33574",
+      "cwes": [
+        "CWE-367"
+      ],
+      "title": "OpenClaw before 2026.3.8 contains a path traversal vulnerability in the skills download installer that validates the too",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "medium",
+      "file": "owasp-asi/CVE-2026-33574.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-33646",
+      "cwes": [],
+      "title": "Mise Vulnerable to Arbitrary Code Execution via Tera Templates in .tool-versions Files (Trust Bypass)",
+      "proposedTactic": "ATD-TA4",
+      "category": "privilege-escalation",
+      "severity": "critical",
+      "file": "owasp-asi/CVE-2026-33646.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-33647",
+      "cwes": [
+        "CWE-434"
+      ],
+      "title": "AVideo Vulnerable to Remote Code Execution via MIME/Extension Mismatch in ImageGallery File Upload",
+      "proposedTactic": "ATD-TA4",
+      "category": "privilege-escalation",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2026-33647.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-33672",
+      "cwes": [
+        "CWE-1321"
+      ],
+      "title": "Picomatch: Method Injection in POSIX Character Classes causes incorrect Glob Matching",
+      "proposedTactic": "ATD-TA4",
+      "category": "privilege-escalation",
+      "severity": "medium",
+      "file": "owasp-asi/CVE-2026-33672.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-33696",
+      "cwes": [
+        "CWE-1321"
+      ],
+      "title": "n8n — Rce (CVE-2026-33696)",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2026-33696.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-3408",
+      "cwes": [
+        "CWE-404",
+        "CWE-476",
+        "CWE-787"
+      ],
+      "title": "Open Babel has a NULL pointer dereference in CDXML OBAtom::GetExplicitValence",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "low",
+      "file": "owasp-asi/CVE-2026-3408.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-34178",
+      "cwes": [
+        "CWE-20"
+      ],
+      "title": "LXD: Importing a crafted backup leads to project restriction bypass",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "critical",
+      "file": "owasp-asi/CVE-2026-34178.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-34240",
+      "cwes": [
+        "CWE-347"
+      ],
+      "title": "jose vulnerable to untrusted JWK header key acceptance during signature verification",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2026-34240.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-34383",
+      "cwes": [
+        "CWE-20",
+        "CWE-352"
+      ],
+      "title": "Admidio has CSRF and Form Validation Bypass in Inventory Item Save via `imported` Parameter",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "medium",
+      "file": "owasp-asi/CVE-2026-34383.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-34762",
+      "cwes": [
+        "CWE-20"
+      ],
+      "title": "Ella Core Has Audit Log Falsification via Path/Body IMSI Mismatch in UpdateSubscriber",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "low",
+      "file": "owasp-asi/CVE-2026-34762.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-34767",
+      "cwes": [
+        "CWE-113",
+        "CWE-74"
+      ],
+      "title": "Electron: HTTP Response Header Injection in custom protocol handlers and webRequest",
+      "proposedTactic": "ATD-TA4",
+      "category": "privilege-escalation",
+      "severity": "medium",
+      "file": "owasp-asi/CVE-2026-34767.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-35433",
+      "cwes": [
+        "CWE-122",
+        "CWE-20"
+      ],
+      "title": "Microsoft Security Advisory CVE-2026-35433 – .NET Elevation of Privilege Vulnerability",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2026-35433.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-35515",
+      "cwes": [
+        "CWE-74"
+      ],
+      "title": "@nestjs/core Improperly Neutralizes Special Elements in Output Used by a Downstream Component ('Injection')",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "medium",
+      "file": "owasp-asi/CVE-2026-35515.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-39376",
+      "cwes": [
+        "CWE-400",
+        "CWE-674"
+      ],
+      "title": "FastFeedParser has an infinite redirect loop DoS via meta-refresh chain",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2026-39376.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-39987",
+      "cwes": [],
+      "title": "Marimo Pre-Auth RCE (CVE-2026-39987)",
+      "proposedTactic": "ATD-TA4",
+      "category": "privilege-escalation",
+      "severity": "critical",
+      "file": "owasp-asi/CVE-2026-39987.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-40319",
+      "cwes": [
+        "CWE-1333",
+        "CWE-1336"
+      ],
+      "title": "Giskard has Unsandboxed Jinja2 Template Rendering in ConformityCheck",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "medium",
+      "file": "owasp-asi/CVE-2026-40319.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-40488",
+      "cwes": [
+        "CWE-434"
+      ],
+      "title": "OpenMage LTS: Customer File Upload Extension Blocklist Bypass → Remote Code Execution",
+      "proposedTactic": "ATD-TA4",
+      "category": "privilege-escalation",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2026-40488.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-40682",
+      "cwes": [
+        "CWE-611"
+      ],
+      "title": "Apache OpenNLP DictionaryEntryPersistor Vulnerable to XML External Entity (XXE) via Unsanitized Dictionary Parsing",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "critical",
+      "file": "owasp-asi/CVE-2026-40682.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-40882",
+      "cwes": [
+        "CWE-611"
+      ],
+      "title": "OpenRemote has XXE in Velbus Asset Import",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2026-40882.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-41044",
+      "cwes": [
+        "CWE-20"
+      ],
+      "title": "Apache ActiveMQ Vulnerable to Code Injection",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2026-41044.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-41066",
+      "cwes": [
+        "CWE-611"
+      ],
+      "title": "lxml: Default configuration of iterparse() and ETCompatXMLParser() allows XXE to local files",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2026-41066.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-41228",
+      "cwes": [
+        "CWE-98"
+      ],
+      "title": "Froxlor has Local File Inclusion via path traversal in API `def_language` parameter leads to Remote Code Execution",
+      "proposedTactic": "ATD-TA4",
+      "category": "privilege-escalation",
+      "severity": "critical",
+      "file": "owasp-asi/CVE-2026-41228.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-41327",
+      "cwes": [
+        "CWE-943"
+      ],
+      "title": "Dgraph: Pre-Auth Full Database Exfiltration via DQL Injection in Upsert Condition Field",
+      "proposedTactic": "ATD-TA4",
+      "category": "privilege-escalation",
+      "severity": "critical",
+      "file": "owasp-asi/CVE-2026-41327.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-41328",
+      "cwes": [
+        "CWE-943"
+      ],
+      "title": "Dgraph: Pre-Auth Full Database Exfiltration via DQL Injection in NQuad Lang Field",
+      "proposedTactic": "ATD-TA4",
+      "category": "privilege-escalation",
+      "severity": "critical",
+      "file": "owasp-asi/CVE-2026-41328.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-41384",
+      "cwes": [
+        "CWE-15"
+      ],
+      "title": "OpenClaw before 2026.3.24 contains an environment variable injection vulnerability in the CLI backend runner that allows",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2026-41384.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-41895",
+      "cwes": [
+        "CWE-611"
+      ],
+      "title": "changedetection.io project has an XXE vulnerability",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2026-41895.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-42033",
+      "cwes": [
+        "CWE-1321"
+      ],
+      "title": "Axios: Prototype Pollution Gadgets - Response Tampering, Data Exfiltration, and Request Hijacking",
+      "proposedTactic": "ATD-TA4",
+      "category": "privilege-escalation",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2026-42033.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-42085",
+      "cwes": [
+        "CWE-23"
+      ],
+      "title": "OpenC3 COSMOS allows arbitrary writes to plugins directory via path-traversed config filenames",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "medium",
+      "file": "owasp-asi/CVE-2026-42085.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-42207",
+      "cwes": [
+        "CWE-601"
+      ],
+      "title": "Magento LTS Vulnerable to Open Redirect via Unvalidated `uenc` Parameter in `stockAction()`",
+      "proposedTactic": "ATD-TA4",
+      "category": "privilege-escalation",
+      "severity": "medium",
+      "file": "owasp-asi/CVE-2026-42207.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-42231",
+      "cwes": [
+        "CWE-1321"
+      ],
+      "title": "n8n — Rce (CVE-2026-42231)",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2026-42231.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-42232",
+      "cwes": [
+        "CWE-1321"
+      ],
+      "title": "n8n — Rce (CVE-2026-44791)",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "critical",
+      "file": "owasp-asi/CVE-2026-42232.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-42586",
+      "cwes": [
+        "CWE-93"
+      ],
+      "title": "Netty Redis Codec Encoder has a CRLF Injection Issue",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "medium",
+      "file": "owasp-asi/CVE-2026-42586.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-43533",
+      "cwes": [
+        "CWE-23"
+      ],
+      "title": "OpenClaw before 2026.4.10 contains an arbitrary file read vulnerability in QQBot media tags that allows attackers to ref",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2026-43533.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-43566",
+      "cwes": [
+        "CWE-184"
+      ],
+      "title": "OpenClaw versions 2026.4.7 before 2026.4.14 contain a privilege escalation vulnerability where heartbeat owner downgrade",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "critical",
+      "file": "owasp-asi/CVE-2026-43566.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-43582",
+      "cwes": [
+        "CWE-367"
+      ],
+      "title": "OpenClaw before 2026.4.10 contains a server-side request forgery vulnerability in browser navigation policy that allows ",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "medium",
+      "file": "owasp-asi/CVE-2026-43582.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-44020",
+      "cwes": [
+        "CWE-776"
+      ],
+      "title": "Docling: Unsafe XML Entity Expansion in USPTO Patent Backend",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2026-44020.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-44182",
+      "cwes": [
+        "CWE-74"
+      ],
+      "title": "Jupyter Enterprise Gateway: Kubernetes Manifest Injection in Jinja2 Template Rendering",
+      "proposedTactic": "ATD-TA4",
+      "category": "privilege-escalation",
+      "severity": "critical",
+      "file": "owasp-asi/CVE-2026-44182.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-44455",
+      "cwes": [
+        "CWE-74"
+      ],
+      "title": "hono/jsx has Unvalidated JSX Tag Names that May Allow HTML Injection",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "medium",
+      "file": "owasp-asi/CVE-2026-44455.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-44458",
+      "cwes": [
+        "CWE-116",
+        "CWE-74"
+      ],
+      "title": "Hono has CSS Declaration Injection via Style Object Values in JSX SSR",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "medium",
+      "file": "owasp-asi/CVE-2026-44458.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-44618",
+      "cwes": [
+        "CWE-611"
+      ],
+      "title": "Apache CXF's WS-Transfer module has an insecure XML parser configuration",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "medium",
+      "file": "owasp-asi/CVE-2026-44618.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-44789",
+      "cwes": [
+        "CWE-1321"
+      ],
+      "title": "n8n — Rce (CVE-2026-44789)",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "critical",
+      "file": "owasp-asi/CVE-2026-44789.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-44939",
+      "cwes": [
+        "CWE-95"
+      ],
+      "title": "Rancher vulnerable to command injection through unsanitized YAML parameter",
+      "proposedTactic": "ATD-TA4",
+      "category": "privilege-escalation",
+      "severity": "critical",
+      "file": "owasp-asi/CVE-2026-44939.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-44966",
+      "cwes": [
+        "CWE-1321"
+      ],
+      "title": "Velocity.js has a Prototype Pollution vulnerability through #set path assignment",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2026-44966.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-45004",
+      "cwes": [
+        "CWE-427"
+      ],
+      "title": "OpenClaw before 2026.4.23 contains an arbitrary code execution vulnerability in the bundled plugin setup resolver that l",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2026-45004.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-45071",
+      "cwes": [
+        "CWE-611"
+      ],
+      "title": "Symfony has XXE (Local File Disclosure) in DomCrawler::addXmlContent() via validateOnParse = true",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "low",
+      "file": "owasp-asi/CVE-2026-45071.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-45133",
+      "cwes": [
+        "CWE-1333",
+        "CWE-674",
+        "CWE-776"
+      ],
+      "title": "Symfony hardened the parser when handling untrusted input",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "low",
+      "file": "owasp-asi/CVE-2026-45133.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-45725",
+      "cwes": [
+        "CWE-73"
+      ],
+      "title": "compliance-trestle Remote Fetching Mechanism has an Arbitrary File Write via Cache Path Traversal",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2026-45725.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-47103",
+      "cwes": [
+        "CWE-95"
+      ],
+      "title": "python-statemachine SCXML <data expr> Eval Injection",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "critical",
+      "file": "owasp-asi/CVE-2026-47103.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-47201",
+      "cwes": [
+        "CWE-20",
+        "CWE-287",
+        "CWE-347"
+      ],
+      "title": "authentik's XML Signature Wrapping in SAML Source ACS allows authentication as arbitrary federated user",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2026-47201.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-47211",
+      "cwes": [
+        "CWE-426"
+      ],
+      "title": "ouroboros-ai Vulnerable to Remote Code Execution via Untrusted Project-Directory .env",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2026-47211.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-48061",
+      "cwes": [
+        "CWE-348",
+        "CWE-807"
+      ],
+      "title": "Litestar: AllowedHostsMiddleware bypasses host validation via client-controlled X-Forwarded-Host header",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "medium",
+      "file": "owasp-asi/CVE-2026-48061.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-48107",
+      "cwes": [
+        "CWE-20"
+      ],
+      "title": "Russh: Unchecked keyboard-interactive prompt count in client auth path",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "medium",
+      "file": "owasp-asi/CVE-2026-48107.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-48108",
+      "cwes": [
+        "CWE-20"
+      ],
+      "title": "Russh: SSH identification parsing accepted non-canonical client banners and did not bound pre-banner input",
+      "proposedTactic": "ATD-TA4",
+      "category": "privilege-escalation",
+      "severity": "medium",
+      "file": "owasp-asi/CVE-2026-48108.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-48110",
+      "cwes": [
+        "CWE-20"
+      ],
+      "title": "Russh SSH message fields were decoded through allocation-first parsers before field-specific bounds",
+      "proposedTactic": "ATD-TA4",
+      "category": "privilege-escalation",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2026-48110.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-48496",
+      "cwes": [
+        "CWE-770"
+      ],
+      "title": "opentelemetry-ebpf-profiler: Unprivileged process can trigger a denial of service on the ebpf-profiler agent",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "medium",
+      "file": "owasp-asi/CVE-2026-48496.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-48704",
+      "cwes": [
+        "CWE-20"
+      ],
+      "title": "Warp — Vulnerability (CVE-2026-48704)",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2026-48704.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-48720",
+      "cwes": [
+        "CWE-20",
+        "CWE-73"
+      ],
+      "title": "Warp — Vulnerability (CVE-2026-48720)",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2026-48720.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-48755",
+      "cwes": [
+        "CWE-20"
+      ],
+      "title": "Incus has an argument injection in backup compression algorithm leading to AFW and ACE",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "critical",
+      "file": "owasp-asi/CVE-2026-48755.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-48769",
+      "cwes": [
+        "CWE-20"
+      ],
+      "title": "Incus has an arbitrary file write on its client due to trusted image hash",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "critical",
+      "file": "owasp-asi/CVE-2026-48769.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-48813",
+      "cwes": [
+        "CWE-74"
+      ],
+      "title": "Flawfinder output manipulation via untrusted filenames and source text",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "low",
+      "file": "owasp-asi/CVE-2026-48813.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-49444",
+      "cwes": [
+        "CWE-20"
+      ],
+      "title": "n8n — Sandbox Escape (CVE-2026-49444)",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2026-49444.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-50016",
+      "cwes": [
+        "CWE-23"
+      ],
+      "title": "pnpm: Transitive dependency alias path traversal allows project path override via symlink replacement",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2026-50016.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-50574",
+      "cwes": [
+        "CWE-74"
+      ],
+      "title": "yt-dlp: Arbitrary code execution via manifest downloads with aria2c",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2026-50574.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-53488",
+      "cwes": [
+        "CWE-74"
+      ],
+      "title": "containerd CRI — image-config `LABEL` flows to restart-monitor `binary://` logger: host-root command execution from an i",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2026-53488.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-53723",
+      "cwes": [
+        "CWE-20",
+        "CWE-91"
+      ],
+      "title": "guzzlehttp/guzzle-services' XML Request Serialization Vulnerable to XML Injection via CDATA Terminator",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "medium",
+      "file": "owasp-asi/CVE-2026-53723.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-53813",
+      "cwes": [
+        "CWE-427"
+      ],
+      "title": "OpenClaw before 2026.4.25 contains a path traversal vulnerability in memory-core artifact loading where workspace state ",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2026-53813.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-53819",
+      "cwes": [
+        "CWE-426"
+      ],
+      "title": "OpenClaw before 2026.5.27 contains an arbitrary code execution vulnerability in skill install flows where workspace .env",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2026-53819.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-53842",
+      "cwes": [
+        "CWE-426"
+      ],
+      "title": "OpenClaw before 2026.5.2 contains an environment variable injection vulnerability allowing workspace .env files to influ",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2026-53842.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-53846",
+      "cwes": [
+        "CWE-426"
+      ],
+      "title": "OpenClaw before 2026.4.29 contains a path traversal vulnerability in the install helper that allows workspace .env files",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2026-53846.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-53865",
+      "cwes": [
+        "CWE-426"
+      ],
+      "title": "OpenClaw before 2026.5.2 contains a path traversal vulnerability in maintenance task execution that allows workspace-der",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2026-53865.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-53875",
+      "cwes": [
+        "CWE-95"
+      ],
+      "title": "picklescan before 1.0.3 contains a scanning bypass vulnerability in the scan_pytorch function that allows attackers to e",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2026-53875.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-54513",
+      "cwes": [
+        "CWE-184"
+      ],
+      "title": "jackson-databind has an array subtype allowlist bypass in BasicPolymorphicTypeValidator (allowIfSubTypeIsArray)",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2026-54513.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-54516",
+      "cwes": [
+        "CWE-915"
+      ],
+      "title": "jackson-databind's renamed @JsonIgnore'd setters can deserialize via private fields",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "medium",
+      "file": "owasp-asi/CVE-2026-54516.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-55185",
+      "cwes": [
+        "CWE-601"
+      ],
+      "title": "Open Redirect Bypass in miniflux-v2",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "medium",
+      "file": "owasp-asi/CVE-2026-55185.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-55237",
+      "cwes": [
+        "CWE-601",
+        "CWE-87"
+      ],
+      "title": "AutoGPT — Xss (CVE-2026-55237)",
+      "proposedTactic": "ATD-TA4",
+      "category": "privilege-escalation",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2026-55237.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-55471",
+      "cwes": [
+        "CWE-611"
+      ],
+      "title": "HAPI FHIR: XXE in XsltUtilities.saxonTransform via unhardened Saxon TransformerFactory",
+      "proposedTactic": "ATD-TA4",
+      "category": "privilege-escalation",
+      "severity": "critical",
+      "file": "owasp-asi/CVE-2026-55471.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-55887",
+      "cwes": [
+        "CWE-88"
+      ],
+      "title": "Docker MCP Gateway: Argument injection via OCI image label YAML",
+      "proposedTactic": "ATD-TA4",
+      "category": "privilege-escalation",
+      "severity": "high",
+      "file": "owasp-asi/CVE-2026-55887.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-5741",
+      "cwes": [],
+      "title": "Docker MCP Server OS Command Injection (CVE-2026-5741)",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "medium",
+      "file": "owasp-asi/CVE-2026-5741.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-7803",
+      "cwes": [
+        "CWE-20"
+      ],
+      "title": "IBM Langflow OSS 1.0.0 through 1.10.0 could allow arbitrary code execution due to improper validation of flow nodes with",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "critical",
+      "file": "owasp-asi/CVE-2026-7803.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-8178",
+      "cwes": [
+        "CWE-470"
+      ],
+      "title": "Amazon Redshift Vulnerable to Remote Code Execution via Unsafe Class Loading",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "critical",
+      "file": "owasp-asi/CVE-2026-8178.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-10193",
+      "cwes": [],
+      "title": "Neo4j MCP Cypher Server DNS Rebinding / Database Takeover",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "vulnerablemcp/CVE-2025-10193.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-11445",
+      "cwes": [],
+      "title": "Kilo Code AI Agent Supply Chain Attack",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "vulnerablemcp/CVE-2025-11445.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-53372",
+      "cwes": [],
+      "title": "Docker Sandbox Escape in node-code-sandbox-mcp (CVE-2025-53372)",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "vulnerablemcp/CVE-2025-53372.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-59163",
+      "cwes": [],
+      "title": "Vet MCP Server DNS Rebinding (CVE-2025-59163)",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "vulnerablemcp/CVE-2025-59163.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-59944",
+      "cwes": [],
+      "title": "Cursor Case-Sensitivity File Protection Bypass (CVE-2025-59944)",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "vulnerablemcp/CVE-2025-59944.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-59956",
+      "cwes": [],
+      "title": "Coder Agent API Chat History Exposure via DNS Rebinding",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "medium",
+      "file": "vulnerablemcp/CVE-2025-59956.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-65513",
+      "cwes": [],
+      "title": "Fetch MCP Server SSRF (CVE-2025-65513)",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "critical",
+      "file": "vulnerablemcp/CVE-2025-65513.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2025-67366",
+      "cwes": [],
+      "title": "filesystem-mcp Path Traversal (CVE-2025-67366)",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "high",
+      "file": "vulnerablemcp/CVE-2025-67366.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-0755",
+      "cwes": [],
+      "title": "gemini-mcp-tool Command Injection (CVE-2026-0755)",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "critical",
+      "file": "vulnerablemcp/CVE-2026-0755.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-0756",
+      "cwes": [],
+      "title": "GitHub Kanban MCP Server RCE (CVE-2026-0756)",
+      "proposedTactic": "ATD-TA5",
+      "category": "tool-poisoning",
+      "severity": "critical",
+      "file": "vulnerablemcp/CVE-2026-0756.proposal.yaml"
+    },
+    {
+      "cve": "CVE-2026-23744",
+      "cwes": [],
+      "title": "MCPJam Inspector RCE (CVE-2026-23744)",
+      "proposedTactic": "ATD-TA4",
+      "category": "privilege-escalation",
+      "severity": "critical",
+      "file": "vulnerablemcp/CVE-2026-23744.proposal.yaml"
+    }
+  ]
+}

--- a/data/atd-ingest/new-technique-drafts-2026-08-13.json
+++ b/data/atd-ingest/new-technique-drafts-2026-08-13.json
@@ -1,0 +1,49 @@
+{
+  "generated": "2026-08-13T07:21:59.994Z",
+  "model": "claude-sonnet-5",
+  "minEvidence": 2,
+  "note": "LLM-drafted candidate ATD technique entries, schema-validated but NEVER auto-merged. atd_id is provisional — re-verify it is still the next free id at merge time (concurrent PRs may also claim it). A human must confirm tactic/mappings before pasting into website/public/atd/atd-techniques.json.",
+  "drafted": [],
+  "dropped": [
+    {
+      "cwe": "CWE-20",
+      "reason": "400 {\"type\":\"error\",\"error\":{\"type\":\"invalid_request_error\",\"message\":\"Your credit balance is too low to access the Anthropic API. Please go to Plans & Billing to upgrade or purchase credits.\"},\"request_id\":\"req_011CdzLx4i921Rzo5bGtxKhT\"}"
+    },
+    {
+      "cwe": "CWE-611",
+      "reason": "400 {\"type\":\"error\",\"error\":{\"type\":\"invalid_request_error\",\"message\":\"Your credit balance is too low to access the Anthropic API. Please go to Plans & Billing to upgrade or purchase credits.\"},\"request_id\":\"req_011CdzLx5RoC4jSpB323z9Za\"}"
+    },
+    {
+      "cwe": "CWE-74",
+      "reason": "400 {\"type\":\"error\",\"error\":{\"type\":\"invalid_request_error\",\"message\":\"Your credit balance is too low to access the Anthropic API. Please go to Plans & Billing to upgrade or purchase credits.\"},\"request_id\":\"req_011CdzLx5v4fzWSzCbRJPE5f\"}"
+    },
+    {
+      "cwe": "CWE-601",
+      "reason": "400 {\"type\":\"error\",\"error\":{\"type\":\"invalid_request_error\",\"message\":\"Your credit balance is too low to access the Anthropic API. Please go to Plans & Billing to upgrade or purchase credits.\"},\"request_id\":\"req_011CdzLx6T4QYSdKYjmKvKRM\"}"
+    },
+    {
+      "cwe": "CWE-1321",
+      "reason": "400 {\"type\":\"error\",\"error\":{\"type\":\"invalid_request_error\",\"message\":\"Your credit balance is too low to access the Anthropic API. Please go to Plans & Billing to upgrade or purchase credits.\"},\"request_id\":\"req_011CdzLx751nXRHcrCvwfiVb\"}"
+    },
+    {
+      "cwe": "CWE-95",
+      "reason": "400 {\"type\":\"error\",\"error\":{\"type\":\"invalid_request_error\",\"message\":\"Your credit balance is too low to access the Anthropic API. Please go to Plans & Billing to upgrade or purchase credits.\"},\"request_id\":\"req_011CdzLx7bWupveRRThpHJ9D\"}"
+    },
+    {
+      "cwe": "CWE-23",
+      "reason": "400 {\"type\":\"error\",\"error\":{\"type\":\"invalid_request_error\",\"message\":\"Your credit balance is too low to access the Anthropic API. Please go to Plans & Billing to upgrade or purchase credits.\"},\"request_id\":\"req_011CdzLx8FhiX6FdR3MWfcYN\"}"
+    },
+    {
+      "cwe": "CWE-434",
+      "reason": "400 {\"type\":\"error\",\"error\":{\"type\":\"invalid_request_error\",\"message\":\"Your credit balance is too low to access the Anthropic API. Please go to Plans & Billing to upgrade or purchase credits.\"},\"request_id\":\"req_011CdzLx8w8t67tYc46MQG2J\"}"
+    },
+    {
+      "cwe": "CWE-352",
+      "reason": "400 {\"type\":\"error\",\"error\":{\"type\":\"invalid_request_error\",\"message\":\"Your credit balance is too low to access the Anthropic API. Please go to Plans & Billing to upgrade or purchase credits.\"},\"request_id\":\"req_011CdzLx9QQzZPqtzJ9KvM2V\"}"
+    },
+    {
+      "cwe": "CWE-1336",
+      "reason": "400 {\"type\":\"error\",\"error\":{\"type\":\"invalid_request_error\",\"message\":\"Your credit balance is too low to access the Anthropic API. Please go to Plans & Billing to upgrade or purchase credits.\"},\"request_id\":\"req_011CdzLx9vfNN5ZySSg5hvii\"}"
+    }
+  ]
+}

--- a/website/public/atd/atd-techniques.json
+++ b/website/public/atd/atd-techniques.json
@@ -7,7 +7,7 @@
   "stats": {
     "techniques": 81,
     "withLiveRule": 47,
-    "withCve": 30,
+    "withCve": 33,
     "tactics": 9
   },
   "tactics": [
@@ -262,6 +262,202 @@
         {
           "type": "cve",
           "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-54449"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-19263"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-16133"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-19039"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-19041"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-19268"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-19279"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-19329"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-19334"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-72904"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2015-20108"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2019-6689"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2019-7537"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-21129"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-35954"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-36633"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-42906"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-21808"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-26128"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-26145"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-28935"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-36457"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-38286"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-39523"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-5752"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-1540"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-22197"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-34347"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-34352"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-4078"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-41815"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-43497"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-53526"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-27423"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-43714"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-43858"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-49833"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-53774"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-54377"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-59252"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-64671"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-65946"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-66032"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-67511"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-32052"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-32063"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-40068"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-41304"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-53822"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-7687"
         }
       ],
       "atr_rule": "ATR-2026-01927"
@@ -564,6 +760,370 @@
         {
           "type": "cve",
           "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-62312"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-17566"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-17625"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-12940"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-17623"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-58195"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-63732"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2017-1000502"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2019-0335"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-3291"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-0557"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-33891"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-39321"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-25313"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-38207"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-1879"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-2029"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-20716"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-24426"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-29189"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-3121"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-34073"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-40641"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-41111"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-4253"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-43405"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-43649"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-51092"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-52587"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-56137"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-6091"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-15060"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-30370"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-31693"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-49141"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-54123"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-54430"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-54795"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-57771"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-58370"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-58371"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-62354"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-64755"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-67637"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-0765"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-21893"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-22169"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-22176"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-22179"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-23500"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-24844"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-24887"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-25044"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-25053"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-25130"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-25143"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-25244"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-25722"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-25723"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-26279"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-26318"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-27806"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-28279"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-28292"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-31861"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-31994"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-31995"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-31996"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-31999"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-32003"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-32034"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-32056"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-32917"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-32949"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-33310"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-33319"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-33533"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-33648"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-34779"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-34940"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-35582"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-44723"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-44724"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-45136"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-45152"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-45578"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-46420"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-48703"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-54051"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-54686"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-55441"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-55448"
         }
       ],
       "atr_rule": "ATR-2026-00577"
@@ -631,6 +1191,14 @@
         {
           "type": "research",
           "url": "https://github.com/invariantlabs-ai/mcp-injection-experiments"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2011-4104"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-28850"
         }
       ],
       "atr_rule": "ATR-2026-00581"
@@ -742,6 +1310,70 @@
         {
           "type": "cve",
           "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-54446"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-47769"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-68578"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-8446"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2020-36245"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-38540"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-63390"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-27595"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-28391"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-28468"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-31240"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-32041"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-34162"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-39858"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-43575"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-44326"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-44329"
         }
       ]
     },
@@ -824,6 +1456,30 @@
         {
           "type": "cve",
           "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-24477"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-9680"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-31818"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-32046"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-43527"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-46517"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-47668"
         }
       ]
     },
@@ -1010,6 +1666,346 @@
         {
           "type": "cve",
           "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-54499"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-24232"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2016-8744"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2017-0903"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2017-16616"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2018-1000074"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2018-1000167"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2020-1947"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2020-1964"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2020-2137"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2020-2163"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2020-2178"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2020-2185"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2020-2211"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2020-8441"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-37678"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-4118"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-43853"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-43859"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-46364"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-1471"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-28948"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-31115"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-31605"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-32224"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-41678"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-41966"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-21538"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-24162"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-24620"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-25194"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-26153"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-2800"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-28115"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-28754"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-31890"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-38647"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-40195"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-46302"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-47204"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-49297"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-25117"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-27281"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-28859"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-31224"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-34072"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-45758"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-47836"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-48063"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-49375"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-52803"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-6960"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-7804"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-8502"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-10155"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-11157"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-14920"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-14921"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-14922"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-14924"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-14925"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-14929"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-14930"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-14931"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-47277"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-50460"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-53002"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-58756"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-8747"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-0760"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-0772"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-10566"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-21531"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-24009"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-28805"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-31214"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-31221"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-31238"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-31249"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-3357"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-35171"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-39832"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-41486"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-44795"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-7871"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-9291"
         }
       ]
     },
@@ -1253,6 +2249,454 @@
         {
           "type": "cve",
           "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-59216"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-71433"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-67357"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2008-6507"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2009-2475"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2011-3744"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2012-5657"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2013-4295"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2014-6439"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2015-9231"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2016-0792"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2017-1000393"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2017-10261"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2017-12623"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2017-13761"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2017-16355"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2017-5647"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2018-1000142"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2019-19499"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-21712"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-23469"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-23504"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-24348"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-29241"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-31051"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-31066"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-37783"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-39222"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-0845"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-28444"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-30841"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-33979"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-34093"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-34094"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-35391"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-35625"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-43791"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-45809"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-46315"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-49292"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-51527"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-10874"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-21501"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-24825"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-28188"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-29199"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-34711"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-39683"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-40633"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-43610"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-43779"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-45043"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-47197"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-55875"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-7038"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-8072"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-12732"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-21620"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-30694"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-31491"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-31494"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-49651"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-50708"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-52467"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-54380"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-54584"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-55008"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-55009"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-5690"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-58059"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-59434"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-61780"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-61917"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-64324"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-66303"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-66623"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-9039"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-12203"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-1669"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-25523"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-26273"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-27892"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-30847"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-32002"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-32609"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-33761"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-34839"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-35449"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-39943"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-40293"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-41323"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-41368"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-41389"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-41520"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-42092"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-42220"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-43942"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-44115"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-44738"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-44848"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-45553"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-45676"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-45720"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-47124"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-47395"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-47743"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-49336"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-54304"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-54305"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-55180"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-55447"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-55450"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-8028"
         }
       ]
     },
@@ -1285,6 +2729,22 @@
         {
           "type": "cve",
           "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-27124"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-48710"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-40175"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-53931"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-53999"
         }
       ]
     },
@@ -1703,6 +3163,998 @@
         {
           "type": "cve",
           "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-53598"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-67429"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-54785"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-54561"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-19270"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-44192"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-46555"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-62663"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-66004"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-73079"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-7646"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-9856"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-47487"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2017-15712"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2018-1000175"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2019-15952"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2019-25075"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2019-6111"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2020-12827"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2020-2259"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2020-35370"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2020-3715"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2020-8568"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2020-9689"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-21284"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-21395"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-21604"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-21683"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-35958"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-41127"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-42556"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-42767"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-43775"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-1850"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-22821"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-23620"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-24730"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-25842"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-28140"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-30947"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-31194"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-34171"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-41226"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-2315"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-27562"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-28382"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-28458"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-30172"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-30620"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-32309"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-32315"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-38337"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-38708"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-40587"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-41057"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-43800"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-46654"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-48299"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-49735"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-5245"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-10707"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-10902"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-11037"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-12065"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-21799"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-2221"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-23827"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-24590"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-27081"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-27317"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-27921"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-28149"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-31457"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-31462"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-32022"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-3429"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-35186"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-37902"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-38816"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-41121"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-41703"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-43044"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-4315"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-45188"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-45291"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-47169"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-47170"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-47171"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-47883"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-5182"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-52292"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-5452"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-5824"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-6085"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-6281"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-6971"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-7034"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-7037"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-8060"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-8438"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-8537"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-0851"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-1022"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-11849"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-12060"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-15514"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-24786"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-27098"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-32950"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-45691"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-49554"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-53513"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-54293"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-54794"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-55526"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-58755"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-61784"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-62449"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-64433"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-65346"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-66295"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-67818"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-8406"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-8917"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-12821"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-21726"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-21851"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-21861"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-22171"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-24049"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-24053"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-25055"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-25059"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-25152"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-25161"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-25524"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-25732"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-25797"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-27018"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-27483"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-27522"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-27523"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-27734"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-28208"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-28457"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-28786"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-28791"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-28792"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-28795"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-29780"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-31886"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-32007"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-32020"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-32026"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-32033"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-32036"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-32055"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-32061"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-32629"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-32711"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-32731"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-32885"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-33236"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-33292"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-33344"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-3345"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-33493"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-33497"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-33528"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-33529"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-33581"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-33681"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-33686"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-33949"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-34371"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-34522"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-34730"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-35050"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-35397"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-35483"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-35484"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-35485"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-35487"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-39378"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-39981"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-40037"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-40086"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-40090"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-40163"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-40611"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-40876"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-40909"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-40923"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-41383"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-41433"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-41589"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-41656"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-41691"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-42315"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-42549"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-42600"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-42605"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-42882"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-43624"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-44016"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-44111"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-44298"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-44340"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-44565"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-44566"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-44641"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-44650"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-44705"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-44788"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-4502"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-45224"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-45571"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-45711"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-45731"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-45774"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-46338"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-46345"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-46607"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-47121"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-47144"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-47253"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-47731"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-48126"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-48777"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-49119"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-49342"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-49406"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-49465"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-52798"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-52844"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-53519"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-53825"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-54014"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-54017"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-54094"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-54293"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-55699"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-55700"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-55828"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-55832"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-6590"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-6591"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-7524"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-8756"
         }
       ],
       "atr_rule": "ATR-2026-00578"
@@ -1744,6 +4196,22 @@
         {
           "type": "cve",
           "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-34452"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-24904"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-31036"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-41326"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-45491"
         }
       ]
     },
@@ -2093,6 +4561,462 @@
         {
           "type": "cve",
           "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-53597"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-70477"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-44632"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-46621"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-8056"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-50517"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-69251"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-61536"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-66065"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-67531"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-69255"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-73032"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-9135"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-9196"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2008-3167"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2009-1392"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2017-14077"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2017-6920"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2019-8230"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-30180"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-32649"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-43811"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-43837"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-0895"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-2099"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-23465"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-24512"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-24817"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-36036"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-36099"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-41089"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-45907"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-2583"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-30537"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-34251"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-35926"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-37273"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-39661"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-43661"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-46242"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-46243"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-48699"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-10252"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-12471"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-21576"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-21577"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-21650"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-23750"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-28424"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-31984"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-31996"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-3660"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-37014"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-39205"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-39236"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-3924"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-45053"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-46489"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-47879"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-48050"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-48061"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-49048"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-49362"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-56373"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-57000"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-6982"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-6983"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-0185"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-14926"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-14927"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-14928"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-26260"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-32383"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-5120"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-54550"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-58764"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-59041"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-62348"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-65026"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-65099"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-67489"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-0761"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-0766"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-0768"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-0771"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-0863"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-10134"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-10561"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-12822"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-21877"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-22771"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-23733"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-25153"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-26056"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-27498"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-27702"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-33057"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-33479"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-33943"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-39842"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-40911"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-40967"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-41246"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-41249"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-42234"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-4276"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-44244"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-44513"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-47117"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-47252"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-54074"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-5584"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-5760"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-6543"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-7700"
         }
       ]
     },
@@ -2136,6 +5060,18 @@
         {
           "type": "cve",
           "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-41087"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-48238"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-31991"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-33232"
         }
       ]
     },
@@ -2913,6 +5849,426 @@
         {
           "type": "cve",
           "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-52870"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-62830"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-68979"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-15015"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-66012"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2017-15680"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2018-1000008"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-41937"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-1782"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-22728"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-35148"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-37942"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-49654"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-50766"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-12473"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-13698"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-13816"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-2035"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-23752"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-38002"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-42470"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-4858"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-52383"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-6845"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-7043"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-7045"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-7046"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-12156"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-13378"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-31678"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-31720"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-31843"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-46348"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-49747"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-5018"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-52554"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-54378"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-59474"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-62116"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-62154"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-62256"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-64131"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-23632"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-25083"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-25338"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-28685"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-29070"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-30950"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-32905"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-33685"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-33950"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-34245"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-34369"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-35179"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-35621"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-35630"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-39360"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-39397"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-41298"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-41394"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-41498"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-42226"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-42228"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-42433"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-42439"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-43568"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-43572"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-43579"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-43583"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-44550"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-44555"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-44558"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-44559"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-44560"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-44569"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-44571"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-44585"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-44794"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-44994"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-45007"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-45625"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-45730"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-47120"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-47233"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-47349"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-47721"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-47724"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-48012"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-48119"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-48151"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-48592"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-50137"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-53633"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-53815"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-53816"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-53821"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-53844"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-53850"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-53851"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-53866"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-54019"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-54027"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-54029"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-55542"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-6589"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-9132"
         }
       ],
       "atr_rule": "ATR-2026-00549"
@@ -2971,6 +6327,74 @@
         {
           "type": "cve",
           "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-39888"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-21701"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-25186"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-25080"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-41319"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-68668"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-69264"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-22686"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-25056"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-26956"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-43577"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-47139"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-48721"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-48807"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-49458"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-49459"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-53853"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-54013"
         }
       ],
       "atr_rule": "ATR-2026-00436"
@@ -3038,6 +6462,18 @@
         {
           "type": "research",
           "url": "https://atlas.mitre.org/techniques/AML.T0034"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-23221"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-25533"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-33116"
         }
       ],
       "atr_rule": "ATR-2026-00050"
@@ -3373,6 +6809,3274 @@
         {
           "type": "cve",
           "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-58500"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-12496"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-70486"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-67333"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2005-4644"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2006-1548"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2006-4067"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2007-1405"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2007-3498"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2007-5059"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2007-5613"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2007-6570"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2008-1285"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2008-2302"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2008-2525"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2008-3381"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2008-4725"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2009-1938"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2009-2959"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2009-4343"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2010-2422"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2010-3659"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2010-5005"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2011-4630"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2012-4015"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2012-5490"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2013-4249"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2013-4714"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2013-6289"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2013-6429"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2013-7062"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2013-7074"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2014-2260"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2014-3146"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2014-3579"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2014-3994"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2014-4036"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2014-4301"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2015-0265"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2015-1039"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2015-1864"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2015-2241"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2015-3219"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2015-3296"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2015-7536"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2015-7562"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2015-8310"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2015-8606"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2015-8756"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2015-8759"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2015-8766"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2015-8796"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2016-0711"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2016-10516"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2016-10744"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2016-11077"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2016-1912"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2016-20054"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2016-2040"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2016-2163"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2016-2559"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2016-3101"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2016-3670"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2016-4056"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2016-4316"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2016-4567"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2016-4855"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2016-4880"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2016-4988"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2016-5733"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2016-7138"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2016-7147"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2016-7571"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2016-9188"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2017-1000088"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2017-1000102"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2017-1000386"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2017-1000425"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2017-10795"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2017-12630"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2017-12882"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2017-14239"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2017-14740"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2017-14920"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2017-15278"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2017-15279"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2017-5870"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2017-6099"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2017-6484"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2017-6589"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2017-6927"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2017-7204"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2017-7251"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2017-7271"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2017-7390"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2017-7391"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2018-0499"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2018-0570"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2018-1000106"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2018-1000129"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2018-1000162"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2018-1000407"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2018-10095"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2018-12104"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2018-13339"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2018-14840"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2018-17031"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2018-18478"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2018-19787"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2018-1999021"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2018-19992"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2018-19993"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2018-20583"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2018-3771"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2018-5233"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2018-6333"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2018-7198"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2018-7260"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2019-10047"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2019-10226"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2019-10335"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2019-10346"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2019-10432"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2019-10905"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2019-12823"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2019-13068"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2019-13127"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2019-14315"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2019-15481"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2019-16685"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2019-16687"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2019-17223"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2019-18656"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2019-19040"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2019-19935"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2019-20634"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2019-20903"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2019-25225"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2019-7168"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2019-7863"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2020-13239"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2020-13668"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2020-13973"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2020-15881"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2020-20589"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2020-2172"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2020-2220"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2020-2245"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2020-25815"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2020-25817"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2020-27388"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2020-27850"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2020-27851"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2020-27852"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2020-28957"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2020-29653"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2020-36395"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2020-36397"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2020-7934"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2020-9664"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-24323"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-25975"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-27131"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-27907"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-32244"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-32609"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-32856"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-32862"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-33326"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-33328"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-33332"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-33336"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-33337"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-33339"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-35463"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-37504"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-38267"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-38269"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-41134"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-41502"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-43818"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-43862"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-44791"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-45394"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-46871"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-0776"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-0928"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-0963"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-1091"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-1555"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-1566"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-1811"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-2036"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-21690"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-21702"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-22293"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-23474"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-23494"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-23499"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-23598"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-23638"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-23647"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-23808"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-24728"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-24746"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-24749"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-24814"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-24833"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-2523"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-25303"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-26593"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-26594"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-26597"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-28366"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-28368"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-28803"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-29172"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-29362"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-29540"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-29648"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-30110"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-30429"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-31035"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-31049"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-31108"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-31109"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-31127"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-31160"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-31175"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-31191"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-31290"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-3149"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-32065"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-32173"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-3242"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-3245"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-3255"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-33113"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-33154"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-33156"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-34140"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-35278"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-36020"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-36033"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-36037"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-36096"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-36527"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-36573"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-37721"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-38639"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-39348"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-39350"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-40044"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-40373"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-40487"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-4105"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-41938"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-42111"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-43120"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-43983"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-43996"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-46165"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-46181"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-46682"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-48345"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-0109"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-0871"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-1410"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-1756"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-2121"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-22461"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-22462"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-22491"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-23627"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-23913"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-24230"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-24769"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-24814"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-25571"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-25572"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-25727"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-2591"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-26046"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-26120"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-26480"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-26487"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-27075"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-27474"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-27489"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-28426"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-28604"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-28836"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-29201"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-29202"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-29205"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-29207"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-29528"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-29641"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-30609"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-30614"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-30838"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-31045"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-31126"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-31285"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-31506"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-31508"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-31544"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-3193"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-32070"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-32325"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-33194"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-33495"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-33736"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-33937"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-33962"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-34103"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-34464"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-3481"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-36471"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-36809"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-36823"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-36828"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-37280"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-37901"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-37940"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-38490"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-38500"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-38687"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-3978"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-40191"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-40809"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-41167"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-4145"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-41933"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-4196"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-42497"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-42498"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-42627"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-4303"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-43643"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-43828"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-43830"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-43884"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-44309"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-44310"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-44311"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-44390"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-45137"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-45280"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-45683"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-45815"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-45818"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-46998"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-47114"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-47125"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-47265"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-47322"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-47795"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-47797"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-48094"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-48219"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-48701"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-49293"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-49657"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-49781"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-50717"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-51445"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-51447"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-51652"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-6571"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-6717"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-11718"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-11993"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-12374"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-12852"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-1647"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-1648"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-20758"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-21485"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-21504"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-21515"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-21627"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-21628"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-2171"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-22075"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-22191"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-22195"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-2238"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-23341"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-23349"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-23635"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-23640"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-23642"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-23643"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-23817"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-23818"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-23819"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-23821"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-24558"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-24570"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-24815"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-25145"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-25151"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-25152"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-25601"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-25602"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-25603"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-25637"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-25874"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-26151"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-26269"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-26483"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-27095"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-27285"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-27287"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-27290"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-27300"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-28106"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-28108"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-28175"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-28199"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-28237"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-28593"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-28855"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-29179"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-29217"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-29881"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-29891"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-30248"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-31868"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-32464"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-32468"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-32472"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-32489"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-32877"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-32966"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-33670"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-34349"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-34355"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-34707"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-34899"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-35621"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-36110"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-36115"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-37031"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-37160"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-37166"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-37297"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-38356"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-38364"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-38503"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-38527"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-39123"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-39272"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-39308"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-39910"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-40101"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-41446"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-41447"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-41656"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-41676"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-41677"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-41810"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-41953"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-42816"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-43396"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-43788"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-43805"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-45047"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-45292"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-45613"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-45793"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-45812"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-45846"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-47058"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-47061"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-47067"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-47068"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-47075"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-47186"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-47523"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-47527"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-47605"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-47765"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-47882"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-47885"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-48057"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-49038"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-49377"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-5062"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-51135"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-51495"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-51497"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-5165"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-52595"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-52812"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-53257"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-53277"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-53382"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-53386"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-53457"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-53843"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-53999"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-5478"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-55227"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-55488"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-56199"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-56366"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-56410"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-56510"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-6581"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-6706"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-6722"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-6843"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-7044"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-7053"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-7398"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-7990"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-8556"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-9148"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-9440"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-9526"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-11966"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-13704"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-15056"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-1512"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-15599"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-21621"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-22131"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-23026"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-23200"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-23210"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-23668"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-24012"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-24017"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-24803"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-24981"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-26159"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-26210"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-27108"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-27109"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-27145"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-27155"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-27400"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-28254"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-29049"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-30081"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-30083"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-30148"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-30223"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-32426"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-43791"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-43954"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-45406"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-46343"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-46349"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-46571"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-46719"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-46734"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-46827"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-47828"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-47933"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-47946"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-48495"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-48958"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-49126"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-49137"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-49575"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-50183"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-50481"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-51487"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-51863"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-52478"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-52552"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-52902"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-53093"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-53354"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-53368"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-53369"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-53528"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-53626"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-53835"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-54075"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-54263"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-54384"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-55742"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-56265"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-59428"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-59526"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-59539"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-59545"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-59546"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-59839"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-61788"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-61914"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-62264"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-62267"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-62412"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-62414"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-62415"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-62508"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-62780"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-62796"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-62798"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-63872"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-64049"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-64501"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-64711"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-64745"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-64747"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-64758"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-66024"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-66040"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-66420"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-66452"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-66470"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-66648"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-68457"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-68614"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-68942"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-68951"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-69236"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-70959"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-8082"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-9910"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-0858"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-1115"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-13323"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-21871"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-22256"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-23476"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-23695"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-23829"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-23847"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-23997"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-24399"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-24490"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-24907"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-25051"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-25054"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-25478"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-25500"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-25516"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-25578"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-25581"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-26028"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-26192"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-26193"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-26989"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-27013"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-27099"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-27116"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-27120"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-2728"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-27469"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-27599"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-27607"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-27612"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-27614"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-27964"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-27970"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-28338"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-28343"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-28445"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-28509"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-28737"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-29191"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-30934"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-30974"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-31313"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-31823"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-31833"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-31938"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-32040"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-32109"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-32308"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-32722"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-32755"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-33066"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-33080"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-33244"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-33311"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-33331"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-33499"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-33500"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-33683"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-33749"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-33865"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-33883"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-33889"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-33916"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-33979"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-34231"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-34375"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-34396"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-34405"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-34448"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-34529"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-34557"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-34558"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-34716"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-34725"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-34727"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-34739"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-35539"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-35565"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-35569"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-35571"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-36766"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-39367"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-39390"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-39846"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-40186"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-40262"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-40296"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-40302"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-40479"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-41043"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-41061"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-41067"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-41147"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-41238"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-41241"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-41305"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-41426"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-41591"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-41683"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-41692"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-42086"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-42150"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-42524"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-42794"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-42877"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-43644"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-43876"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-43937"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-43979"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-43980"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-44175"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-44203"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-44212"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-44245"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-44311"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-44549"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-44568"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-44580"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-44644"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-44651"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-44708"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-44742"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-44896"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-44903"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-44990"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-45011"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-45028"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-45072"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-45106"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-45138"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-45249"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-45303"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-45348"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-45375"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-45580"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-45627"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-45753"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-46360"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-46361"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-46363"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-46367"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-46426"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-47090"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-47344"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-47348"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-47376"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-47423"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-47428"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-47694"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-47730"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-48157"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-48167"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-48527"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-48591"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-48788"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-49210"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-49216"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-49276"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-49279"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-49864"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-49978"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-50133"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-50146"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-50182"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-50183"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-50556"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-5160"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-54011"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-54025"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-54267"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-54298"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-54301"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-54303"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-54458"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-54527"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-5468"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-55409"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-55650"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-55690"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-55742"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-55847"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-56326"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-56358"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-56761"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-6592"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-6593"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-6600"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-6619"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-6658"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-7814"
         }
       ],
       "atr_rule": "ATR-2026-00259"
@@ -3803,6 +10507,610 @@
         {
           "type": "cve",
           "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-62240"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-17534"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-19339"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-54549"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-69257"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-56167"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-14540"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-19040"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-19337"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-19516"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-54249"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-65056"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-67428"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-72768"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-9081"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2017-5661"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-0671"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-24739"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-27193"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-36551"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-38398"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-42890"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-47950"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-27586"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-30444"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-40017"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-43654"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-45822"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-46124"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-46725"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-47635"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-48240"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-49198"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-6570"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-11030"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-11031"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-12775"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-27565"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-27927"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-29028"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-29090"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-29190"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-29198"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-38206"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-38514"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-39687"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-39699"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-40441"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-4642"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-56800"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-6095"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-7959"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-22603"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-25194"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-27600"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-29720"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-30220"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-31490"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-53767"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-58175"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-58829"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-62612"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-62615"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-62616"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-67743"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-68477"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-68696"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-8341"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-9821"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-10129"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-12566"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-22181"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-26286"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-27730"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-27808"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-30834"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-31943"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-31959"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-31989"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-32019"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-32037"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-32301"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-33039"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-33226"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-33294"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-3340"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-33401"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-3341"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-33486"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-33626"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-34225"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-34360"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-35036"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-35037"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-35486"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-35527"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-35540"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-35587"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-40072"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-40346"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-41297"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-41361"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-41366"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-42140"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-42181"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-42345"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-42591"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-42596"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-42597"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-42860"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-43526"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-43576"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-43879"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-43884"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-44116"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-44117"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-44502"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-44589"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-44652"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-44936"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-45298"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-45347"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-45548"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-45709"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-46372"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-47260"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-47268"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-47390"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-48051"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-48053"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-48128"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-48146"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-48148"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-50168"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-53812"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-53859"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-53927"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-53930"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-54008"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-54018"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-54353"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-54514"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-55187"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-55229"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-5530"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-55671"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-56348"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-5803"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-6617"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-6618"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-7177"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-7223"
         }
       ],
       "atr_rule": "ATR-2026-00013"
@@ -3963,6 +11271,38 @@
         {
           "type": "cve",
           "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-61592"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-57860"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-62726"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-65964"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-0770"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-22217"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-41295"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-42089"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-53810"
         }
       ],
       "atr_rule": "ATR-2026-00151"
@@ -3997,6 +11337,54 @@
         {
           "type": "cve",
           "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-8719"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2017-15051"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2018-1000865"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2020-2023"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-41032"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-7039"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-57760"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-27802"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-27899"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-33509"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-34989"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-44543"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-45715"
         }
       ],
       "atr_rule": "ATR-2026-00122"
@@ -4031,6 +11419,38 @@
         {
           "type": "research",
           "url": "https://github.com/Agent-Threat-Rule/agent-threat-rules"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-55550"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-1025"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-0242"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-12534"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-35671"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-47411"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-47412"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-47416"
         }
       ],
       "atr_rule": "ATR-2026-00040"
@@ -4079,6 +11499,70 @@
         {
           "type": "cve",
           "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-62208"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-67425"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2019-1003035"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2019-10309"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2019-10343"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2019-10374"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2019-10459"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2019-16549"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2020-2092"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2020-2304"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-27201"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-29047"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-34786"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-45384"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-22172"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-25631"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-32897"
         }
       ],
       "atr_rule": "ATR-2026-00113"
@@ -4942,6 +12426,750 @@
         {
           "type": "cve",
           "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-52869"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-65594"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-65015"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-62209"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-62219"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-68980"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-59118"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-14537"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-14538"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-18394"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-18954"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-19111"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-19244"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-55544"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-65975"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-67431"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-70472"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-72771"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-40616"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-1631"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-24450"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-24721"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-24748"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-31669"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-31670"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-34253"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-35689"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-22247"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-22487"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-23947"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-26366"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-26484"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-30840"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-3431"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-3574"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-40573"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-40610"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-40611"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-50732"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-0451"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-11045"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-26016"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-27086"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-27139"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-27288"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-27933"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-28098"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-29834"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-34102"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-37154"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-39323"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-45037"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-47616"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-55633"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-0928"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-27188"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-27206"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-27427"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-27507"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-49825"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-62506"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-64746"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-65098"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-66423"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-68153"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-69207"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-69220"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-22170"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-22555"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-22872"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-24055"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-24134"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-24780"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-24791"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-25889"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-26308"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-27183"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-28363"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-28466"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-28473"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-28699"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-28790"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-29183"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-29194"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-29607"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-29794"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-30926"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-30944"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-31998"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-32005"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-32023"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-32028"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-32035"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-32042"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-32050"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-32058"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-32811"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-32817"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-32895"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-32906"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-33026"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-33318"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-33326"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-33484"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-33576"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-33577"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-33578"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-33650"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-33720"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-33722"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-33764"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-34040"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-34506"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-34507"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-34512"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-35619"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-35625"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-35636"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-35645"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-35657"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-35673"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-39852"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-40071"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-40213"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-40353"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-41283"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-41296"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-41299"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-41303"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-41344"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-41353"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-41360"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-41908"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-41909"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-41948"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-42438"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-42569"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-42607"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-42843"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-43530"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-43948"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-44007"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-44110"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-44557"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-44561"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-44564"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-44567"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-44654"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-44935"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-44991"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-44993"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-45002"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-45075"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-45672"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-45692"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-45703"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-45732"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-45831"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-46362"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-46366"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-46717"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-47227"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-47231"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-47383"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-47405"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-48169"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-48508"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-53521"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-53721"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-53807"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-53809"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-53828"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-53834"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-53854"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-53855"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-53860"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-54010"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-54012"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-54021"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-54022"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-54307"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-54517"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-54518"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-54761"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-55162"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-55411"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-55636"
         }
       ]
     },
@@ -5114,6 +13342,302 @@
         {
           "type": "cve",
           "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-62390"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-17346"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-34191"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-60137"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-15829"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-17351"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2010-0139"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2017-7681"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2017-9246"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2018-17232"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2019-8130"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2020-7939"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-26986"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-31197"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-0620"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-30848"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-30849"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-30850"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-33945"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-47128"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-11958"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-27299"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-28107"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-32872"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-35181"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-37906"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-4215"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-43406"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-45794"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-6847"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-29189"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-31564"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-41233"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-62519"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-62617"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-64519"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-65093"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-65103"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-66396"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-8264"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-22242"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-22729"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-22743"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-26980"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-26990"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-29080"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-32714"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-32813"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-33142"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-33352"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-33442"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-3346"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-33468"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-33545"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-33660"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-33713"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-34747"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-34825"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-40978"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-41490"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-41496"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-42229"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-42233"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-42237"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-44337"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-44739"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-44792"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-46359"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-46670"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-5394"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-54310"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-54313"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-56062"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-56221"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-8462"
         }
       ]
     },
@@ -5192,6 +13716,22 @@
         {
           "type": "cve",
           "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-25536"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2019-8114"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-24686"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-32477"
+        },
+        {
+          "type": "cve",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-38229"
         }
       ]
     },


### PR DESCRIPTION
Daily CVE -> ATD ingest for 2026-08-13.

Summary: {proposalsConsidered:3968,enrichments:2135,techniquesTouched:24,newTechniqueCandidatesRaw:1164,eligibleClusters:57,newTechniqueDraftsGenerated:0,newTechniqueDraftsDropped:10}

Enrichments add real CVE evidence onto existing techniques (matched by CWE) — automatic, schema-validated, low risk.
New-technique DRAFTS (data/atd-ingest/new-technique-drafts-*.json) are Claude-authored candidate ATD entries for CWEs with no covering technique, corroborated by 2+ independent CVEs, and schema-validated against atd-technique.schema.json. Never auto-merged: a new technique is a claim about the threat taxonomy. Confirm tactic/mappings/atd_id (provisional — re-check it is still free) before pasting into website/public/atd/atd-techniques.json.
The flat candidates dump (data/atd-ingest/candidates-*.json) is everything else — no CWE at all, or a CWE seen only once — for human triage, not auto-drafted.
