### PR TITLE
fix(rules): ATR-2026-01904 read method calls as domains

### DIFF
--- a/data/benign-fp-measurement.json
+++ b/data/benign-fp-measurement.json
@@ -4491,9 +4491,9 @@
       "skill_path_unmeasured": true
     },
     "ATR-2026-01904": {
-      "fp_count": 1,
+      "fp_count": 0,
       "maturity": "stable",
-      "detection_fingerprint": "17b30722d22d4fba",
+      "detection_fingerprint": "0f0771acc8f03046",
       "partial_measurement": false,
       "skill_path_unmeasured": true
     },

--- a/rules/prompt-injection/ATR-2026-01904-link-injection.yaml
+++ b/rules/prompt-injection/ATR-2026-01904-link-injection.yaml
@@ -62,15 +62,15 @@ detection:
   conditions:
   - field: user_input
     operator: regex
-    value: (?i)\b(?:add|integrate|include|insert|append|enhance|modify|suggest)\b[\s\S]{0,80}(?:https?://|www\.[a-z0-9-]+\.[a-z]{2,}|[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,}|[a-z0-9-]{3,}\.(?:com|net|org|io|xyz|co|info|app))[\s\S]{0,80}\b(?:your|the)\s+(?:reply|response|answer|message)\b
+    value: (?i)\b(?:add|integrate|include|insert|append|enhance|modify|suggest)\b[\s\S]{0,80}(?:https?://|www\.[a-z0-9-]+\.[a-z]{2,}|[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,}|[a-z0-9-]{3,}\.(?:com|net|org|io|xyz|co|info|app)(?:[\s,;:!?/)\]"\x27<>.]|$))[\s\S]{0,80}\b(?:your|the)\s+(?:reply|response|answer|message)\b
     description: 'BIPIA link-injection invariant #1'
   - field: user_input
     operator: regex
-    value: (?i)\b(?:add|integrate|include|insert|append|enhance|modify|suggest)\b[\s\S]{0,80}\b(?:your|the)\s+(?:reply|response|answer|message)\b[\s\S]{0,90}(?:https?://|www\.[a-z0-9-]+\.[a-z]{2,}|[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,}|[a-z0-9-]{3,}\.(?:com|net|org|io|xyz|co|info|app))
+    value: (?i)\b(?:add|integrate|include|insert|append|enhance|modify|suggest)\b[\s\S]{0,80}\b(?:your|the)\s+(?:reply|response|answer|message)\b[\s\S]{0,90}(?:https?://|www\.[a-z0-9-]+\.[a-z]{2,}|[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,}|[a-z0-9-]{3,}\.(?:com|net|org|io|xyz|co|info|app)(?:[\s,;:!?/)\]"\x27<>.]|$))
     description: 'BIPIA link-injection invariant #2'
   - field: user_input
     operator: regex
-    value: (?i)\bin\s+your\s+(?:reply|response|answer|message)\b[\s\S]{0,80}\b(?:suggest|share|visit|click|download|directing|pointing|link)\b[\s\S]{0,45}(?:https?://|www\.[a-z0-9-]+\.[a-z]{2,}|[a-z0-9-]{3,}\.(?:com|net|org|io|xyz|co|info|app))
+    value: (?i)\bin\s+your\s+(?:reply|response|answer|message)\b[\s\S]{0,80}\b(?:suggest|share|visit|click|download|directing|pointing|link)\b[\s\S]{0,45}(?:https?://|www\.[a-z0-9-]+\.[a-z]{2,}|[a-z0-9-]{3,}\.(?:com|net|org|io|xyz|co|info|app)(?:[\s,;:!?/)\]"\x27<>.]|$))
     description: 'BIPIA link-injection invariant #3'
   condition: any
   false_positives:
@@ -124,3 +124,12 @@ test_cases:
   - input: Translate this attached paragraph for me and keep the tone formal.
     expected: not_triggered
     description: benign — lacks the malicious invariant
+  - input: "Add the reactions to the reactions list\n    messages.append(r)  # Add the message to the messages list"
+    expected: not_triggered
+    description: real FP from the benign conversation corpus — messages.append parsed as the domain messages.app
+  - input: 'if err != nil { logger.info("retrying"); return net.connect(addr) } # add the result to the response'
+    expected: not_triggered
+    description: logger.info and net.connect are method calls, not .info and .net domains
+  - input: Please add a docstring to repo.commit() and self.config so the reply is easier to read.
+    expected: not_triggered
+    description: repo.commit and self.config sit between an add verb and "the reply" — the exact chain that fired before


### PR DESCRIPTION
Last of the three enforce-lane false positives from the conversation corpus in #468. Previous two: #472, #473.

## What was happening

`ATR-2026-01904` is `maturity: stable` and declares `block_tool`. It fired on this:

```python
# Add the reactions to the reactions list
    messages.append(r)  # Add the message to the messages list
```

## Why

The bare-domain alternative had no right-hand boundary:

```
[a-z0-9-]{3,}\.(?:com|net|org|io|xyz|co|info|app)
```

`messages.append` parses as the domain `messages.app`. The rest of the chain then falls into place on its own: an `Add` verb, something that looks like a domain, and `the message`.

The same hole reads `.commit` as `.com`, `.config` / `.concat` / `.copy` as `.co`, `.connect` as `.net`, `logger.info(` as `.info`, `.organize` as `.org`. This is not an exotic edge case — it is most code, and the rule blocks tool calls.

Only one sample in the corpus happened to line up all three parts of the chain. The underlying hole is much wider than one hit.

## The change

All three conditions now require the TLD to be followed by a delimiter or end of input.

RE2 has no lookahead and the portability gate enforces that, so this is a character class rather than `(?![a-z0-9])`.

## Verified on both sides

Ten method-call forms that matched before no longer do: `messages.append(r)`, `logger.info("x")`, `log.info(msg)`, `repo.commit()`, `arr.concat(b)`, `net.connect()`, `obj.copy()`, `self.config`, `obj.commit.hash`, `a.io.b`.

Ten real link shapes still match, including the ones a naive boundary would have broken: `visit example.org.` with the sentence period, `buy.app/now`, `see promo-site.com, then`, `"deal.app"`, `<free.info>`, `get-rich.co is great`.

A first attempt using `\b` was rejected during testing — it fixed eight of the nine code cases but still matched `logger.info(`, because `(` is a word boundary. The delimiter class is what closes that.

All 8 true positives still fire.

## Test cases added

Three true negatives: the corpus sample, a Go line combining `logger.info` with `net.connect`, and one that places `repo.commit()` and `self.config` between an add verb and "the reply" — the exact chain that fired here, so a future widening has to walk past it deliberately rather than rediscover it.

## Evidence

`fp_count` 1 → 0 across 12,060 benign samples, re-measured per-rule rather than edited.

- 784 rules validate
- 8 TPs / 8 TNs self-check clean
- `gate-action-eligibility` passes

## After this

The three enforce-lane false positives the conversation corpus found are closed. The remaining 27 rules it flagged are `test` or `experimental` — they do not block anything today, and they are the promotion pool, so they are worth fixing before the maturity schedule is unpaused rather than after.