### PR TITLE
fix(rules): quote the ATLAS T0110.000 title so the site can build again

### DIFF
--- a/docs/crosswalks/atr-attack-crosswalk.md
+++ b/docs/crosswalks/atr-attack-crosswalk.md
@@ -32,7 +32,7 @@ columns are still extracted from ATR metadata, not authored here.
 - Rules carrying an enterprise ATT&CK id (`references.mitre_attack` Txxxx): 197
 - Distinct enterprise ATT&CK techniques referenced: 80
 - Rules carrying a MITRE ATLAS id (`references.mitre_atlas`): 784
-- Distinct MITRE ATLAS techniques referenced: 44
+- Distinct MITRE ATLAS techniques referenced: 43
 - Rules carrying an OWASP Agentic id (`references.owasp_agentic`): 784
 - ATR categories (distinct `tags.category` values): 9
 
@@ -389,7 +389,7 @@ ATT&CK techniques (join key):
 | T1552 | Unsecured Credentials | `ATR-2026-00534`, `ATR-2026-01931` |
 | T1552.001 | Credentials In Files | `ATR-2026-00576` |
 
-ATLAS techniques ATR adds: AML.T0010, AML.T0010.005, AML.T0019, AML.T0024, AML.T0040, AML.T0049, AML.T0051, AML.T0051.001, AML.T0053, AML.T0056, AML.T0057, AML.T0069, AML.T0070, AML.T0104, AML.T0110.000, {'AML.T0110.000
+ATLAS techniques ATR adds: AML.T0010, AML.T0010.005, AML.T0019, AML.T0024, AML.T0040, AML.T0049, AML.T0051, AML.T0051.001, AML.T0053, AML.T0056, AML.T0057, AML.T0069, AML.T0070, AML.T0104, AML.T0110.000
 
 OWASP Agentic categories ATR adds: ASI01:2026, ASI02:2026, ASI03:2026, ASI04:2026, ASI05:2026, ASI06:2026, ASI07:2026, ASI08:2026, ASI09:2026
 

--- a/rules/tool-poisoning/ATR-2026-00103-hidden-safety-bypass-instruction.yaml
+++ b/rules/tool-poisoning/ATR-2026-00103-hidden-safety-bypass-instruction.yaml
@@ -23,7 +23,7 @@ references:
     - ASI01:2026
   mitre_atlas:
     - AML.T0051 - LLM Prompt Injection
-    - AML.T0110.000 - AI Agent Tool Poisoning: Definition and Instructions
+    - "AML.T0110.000 - AI Agent Tool Poisoning: Definition and Instructions"
 compliance:
   nist_ai_rmf:
     - subcategory: "MS.2.6"

--- a/tests/validate-rules.ts
+++ b/tests/validate-rules.ts
@@ -242,6 +242,26 @@ function validateRule(filePath: string): ValidationResult {
     // References (warning if missing)
     if (!rule['references']) {
       warnings.push('Missing references (OWASP LLM / MITRE ATLAS mapping recommended)');
+    } else {
+      // Every reference list must hold plain strings. spec/schema/rule.schema.json
+      // already says items: {type: string}, but nothing enforced it here, so an
+      // unquoted framework title containing ": " parsed as a YAML map instead of a
+      // string and shipped to main. The website renders these straight into JSX,
+      // where a map is not a valid React child, and every deploy after it failed
+      // at prerender for three days while validate stayed green. Error, not warning.
+      const references = rule['references'] as Record<string, unknown>;
+      for (const [field, value] of Object.entries(references)) {
+        if (!Array.isArray(value)) continue;
+        value.forEach((entry, i) => {
+          if (typeof entry !== 'string') {
+            errors.push(
+              `references.${field}[${i}] must be a string, got ${
+                Array.isArray(entry) ? 'array' : typeof entry
+              } (${JSON.stringify(entry)}). A value containing ": " needs quoting in YAML.`
+            );
+          }
+        });
+      }
     }
 
     // Validate regex patterns don't cause errors


### PR DESCRIPTION
agentthreatrule.org has not deployed since 2026-08-12. Every Deploy Website run
since then failed at the same place:

  Error occurred prerendering page "/en/rules/ATR-2026-00103"
  Error: Objects are not valid as a React child
  (found: object with keys {AML.T0110.000 - AI Agent Tool Poisoning})

The site did not go down, so this was not visible from outside: Cloudflare kept
serving the last successful build while nothing pushed to main reached the site.

Cause

One unquoted line in ATR-2026-00103:

  - AML.T0110.000 - AI Agent Tool Poisoning: Definition and Instructions

The ATLAS technique title contains ": ", so YAML read the entry as a map,
{"AML.T0110.000 - AI Agent Tool Poisoning": "Definition and Instructions"},
rather than a string. The rule page maps references.mitre_atlas straight into
JSX, and a plain object is not a renderable React child, so the export aborted
on that one page and took the whole deploy with it. Quoting the value restores
the intended string. It is the only entry in all 784 rules with this shape.

Why nothing caught it

spec/schema/rule.schema.json has always declared references.*.items as
{type: string}, but tests/validate-rules.ts never checked references beyond
"is it present", so npm run validate stayed green at 784/784 while main was
shipping a rule the website could not render. Reference list entries are now an
error, and the message says a value containing ": " needs quoting in YAML,
because that is the mistake anyone hits next.

Verification, both directions

- Bug reintroduced: validate reports 783 passed / 1 failed and names
  references.mitre_atlas[1].
- Fix applied: 784 passed / 0 failed.
- Full website build completes and emits all 784 rule pages, including the
  ATR-2026-00103 page that was aborting. The ATLAS title renders as
  "AML.T0110.000 - AI Agent Tool Poisoning: Definition and Instructions".
