### PR TITLE
docs(status): the rule count in the standards doc was 357 rules out of date

### DIFF
--- a/STANDARDIZATION-STATUS.md
+++ b/STANDARDIZATION-STATUS.md
@@ -24,7 +24,7 @@ of those interfaces have changed**. Continue as before.
 
 | Layer | Artifact | Status | What this means for you |
 |---|---|---|---|
-| **Rule corpus** | `rules/*` (427 rules) | **STABLE — IN PRODUCTION** | Unchanged. Continues to be the canonical source. |
+| **Rule corpus** | `rules/*` (777 effective rules, 784 files) | **STABLE — IN PRODUCTION** | Unchanged. Continues to be the canonical source. |
 | **Rule format** | `spec/atr-schema.yaml` | **STABLE — IN PRODUCTION** | Unchanged. Rule YAML files still parse against this. |
 | **TS production engine** | `src/`, npm `agent-threat-rules` v2.1.3 | **STABLE — IN PRODUCTION** | Unchanged. No API breakage. |
 | **Existing ecosystem integrations** | Microsoft AGT, Cisco AI Defense, MISP CIRCL, OWASP A-S-R-H, precize, Sage, OpenHands, garak (in review) | **UNAFFECTED** | All continue to work without modification. |
@@ -66,8 +66,8 @@ Three external pressures converged in 2026-Q2:
 3. **F500 procurement questionnaires.** Microsoft AGT integration matured
    to the point that F500 procurement teams started asking "what does
    the governance look like, what does the conformance test look like,
-   what does the audit evidence look like?" — questions that a 427-rule
-   YAML corpus alone cannot answer.
+   what does the audit evidence look like?" — questions that a
+   YAML rule corpus alone cannot answer, at any size.
 
 The work was done as **proposal scaffolding** because:
 


### PR DESCRIPTION
STANDARDIZATION-STATUS.md is the document whose entire job is to tell outside
readers which parts of ATR are real and which are proposals. It said the rule
corpus was 427 rules, in two places. The disk says 784 files / 777 effective,
and data/stats.json agrees.

That is the one number in this repo that must never be stale, because standards
bodies and procurement teams read this file specifically to check whether the
project's claims about itself hold up.

Line 27 now carries both figures with the distinction that matters: 777
effective is what the engine loads and can fire; 784 is the file count, which
includes 7 inert rules. Outward citations use effective.

Line 70 had 427 embedded in a narrative sentence about F500 procurement
questions. A specific count there earns nothing and rots on a schedule, so it
now reads "a YAML rule corpus alone cannot answer, at any size" - the point
being made was never about the size.

Found while auditing this file ahead of adding a correlation-layer section to
it. Adding a new claim next to a known-false number would have inherited its
credibility problem.
