### PR TITLE
docs: fix broken star history chart in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -781,6 +781,6 @@ The 96,096-skill ecosystem scan was made possible by the maintainers of OpenClaw
 
 <div align="center">
 
-[![Star History Chart](https://api.star-history.com/svg?repos=Agent-Threat-Rule/agent-threat-rules&type=Date)](https://star-history.com/#Agent-Threat-Rule/agent-threat-rules&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=Agent-Threat-Rule/agent-threat-rules&type=Date)](https://star-history.dera.page/#Agent-Threat-Rule/agent-threat-rules&Date)
 
 </div>


### PR DESCRIPTION
The star history chart in the README is currently broken: the upstream endpoint that renders it stopped working due to GitHub stargazer API restrictions, so the image no longer loads for visitors. This change points the chart at a working mirror of star history so the graph renders correctly again.

The chart repo and owner are unchanged, so no links will 404.