### PR TITLE
The event shape follows hook_event_name too, not only the dispatch

### DIFF
--- a/src/hook-handler.ts
+++ b/src/hook-handler.ts
@@ -84,7 +84,13 @@ function allowOutput(reason?: string): HookOutput {
  * Convert a HookInput into an AgentEvent for engine evaluation.
  */
 function hookInputToEvent(input: HookInput): AgentEvent {
-  const isPreTool = input.hook === 'PreToolUse';
+  // hookEventOf, not input.hook. #483 fixed the dispatch switch and the stdio
+  // loop but left this one, so a real Claude Code event -- which names the field
+  // hook_event_name -- resolved isPreTool to false and was built as a
+  // tool_response. Measured: the same PreToolUse payload produced event.type
+  // tool_response under hook_event_name and tool_call under ATR's own `hook`.
+  // Rules admitted only on tool_call could not fire on any real event.
+  const isPreTool = hookEventOf(input) === 'PreToolUse';
   const type = isPreTool ? 'tool_call' : 'tool_response';
 
   const toolInput = input.tool_input ?? {};
@@ -376,7 +382,7 @@ export class HookHandler {
       case 'PostToolUse':
         return this.handlePostToolUse(input);
       default:
-        return allowOutput(`Unknown hook type: ${String((input as unknown as Record<string, unknown>).hook)}`);
+        return allowOutput(`Unknown hook type: ${String(hookEventOf(input))}`);
     }
   }
 

--- a/tests/hook-event-field.test.ts
+++ b/tests/hook-event-field.test.ts
@@ -69,3 +69,48 @@ describe('the hook event is read under the spelling the host actually sends', ()
     expect(out.reason ?? '').not.toContain('Unknown hook type');
   });
 });
+
+describe('the event SHAPE follows the same spelling, not just the dispatch', () => {
+  /**
+   * #483 fixed the dispatch switch and the stdio loop and stopped there.
+   * hookInputToEvent kept reading `input.hook`, so a real Claude Code event
+   * resolved isPreTool to false and was constructed as a tool_response. The
+   * dispatch was right and the shape was wrong, which is worse than the
+   * original bug in one way: it produced a plausible verdict instead of an
+   * obvious "Unknown hook type".
+   *
+   * Rules are admitted per agent_source, so a rule that only fires on tool_call
+   * could not fire on any real PreToolUse event.
+   */
+  it('a real PreToolUse builds a tool_call event, same as the ATR spelling', async () => {
+    const { ATREngine } = await import('../src/engine.js');
+    const { HookHandler } = await import('../src/hook-handler.js');
+    const engine = new ATREngine({ rulesDir: 'rules' });
+    const loaded = await engine.loadRules();
+    expect(loaded).toBeGreaterThan(100); // control: the engine really has rules
+
+    const seen: (string | undefined)[] = [];
+    const e = engine as unknown as {
+      evaluateWithVerdict: (ev: { type?: string }, ex?: unknown) => unknown;
+    };
+    const orig = e.evaluateWithVerdict.bind(engine);
+    e.evaluateWithVerdict = (ev, ex) => {
+      seen.push(ev?.type);
+      return orig(ev, ex);
+    };
+
+    const handler = new HookHandler({ engine }) as unknown as {
+      handlePreToolUse: (i: unknown) => Promise<unknown>;
+    };
+    const payload = (key: string) => ({
+      [key]: 'PreToolUse',
+      tool_name: 'Bash',
+      tool_input: { command: 'ls -la' },
+    });
+    await handler.handlePreToolUse(payload('hook_event_name'));
+    await handler.handlePreToolUse(payload('hook'));
+
+    expect(seen[0]).toBe('tool_call');
+    expect(seen[0]).toBe(seen[1]);
+  });
+});


### PR DESCRIPTION
#483 fixed the dispatch switch and the stdio loop and stopped there.
`hookInputToEvent` kept reading `input.hook`, so a real Claude Code event -- which
names the field `hook_event_name` -- resolved `isPreTool` to false and was built
as a `tool_response`. Measured on the result of that PR:

    hook_event_name (what the host sends)  ->  event.type = tool_response
    hook            (ATR's own fixtures)   ->  event.type = tool_call

Rules are admitted per `agent_source`, so anything keyed on `tool_call` could not
fire on a real PreToolUse event. An independent audit of wild-scan drift, run
against this same tree, put that at 81 live rules excluded and named
ATR-2026-00119 -- one of only 24 rules with recorded real-world hits -- among
the casualties.

This is worse than the bug it followed in one respect. The dispatch was right, so
the guard returned a plausible verdict instead of an obvious "Unknown hook type".
Nothing looked wrong.

Both remaining readers of `input.hook` are now `hookEventOf`; a grep over `src/`
finds no others, which is the check that should have been run the first time.

The regression test asserts the constructed event's `type`, not the dispatch, and
was mutation-verified: putting `hookEventOf` back to `input.hook` turns it red,
restoring it turns it green. Full suite, typecheck and build are exit 0.