### PR TITLE
Re-derive the benign false-positive evidence at 785 rules

### DIFF
--- a/data/benign-fp-measurement.json
+++ b/data/benign-fp-measurement.json
@@ -1,7 +1,7 @@
 {
   "_comment": "Benign-corpus false-positive measurement. Produced by scripts/gate-promotion-fp.ts --emit-measurement. A rule absent from `rules`, or whose detection_fingerprint no longer matches the rule on disk, is UNMEASURED and is capped at the observe tier by scripts/gate-action-eligibility.ts. Do not hand-edit.",
-  "generated_at": "2026-08-14",
-  "commit": "5b8d0de53ffcd95e5a52ef67cfaff661c812de99",
+  "generated_at": "2026-08-20",
+  "commit": "c813f2ca7374a621ee2badc819fa6e0bdd4454c3",
   "corpora": [
     "data/skill-benchmark/benign",
     "data/benign-corpus-extended",
@@ -284,9 +284,9 @@
       "skill_path_unmeasured": true
     },
     "ATR-2026-00086": {
-      "fp_count": 2,
+      "fp_count": 1,
       "maturity": "test",
-      "detection_fingerprint": "bf90df64b58905ed",
+      "detection_fingerprint": "f0354f85237a5ff3",
       "partial_measurement": false,
       "skill_path_unmeasured": true
     },
@@ -5495,6 +5495,13 @@
       "fp_count": 0,
       "maturity": "test",
       "detection_fingerprint": "19b86586eab5ff4f",
+      "partial_measurement": false,
+      "skill_path_unmeasured": false
+    },
+    "ATR-2026-02500": {
+      "fp_count": 0,
+      "maturity": "experimental",
+      "detection_fingerprint": "52b4c426ed03dab6",
       "partial_measurement": false,
       "skill_path_unmeasured": false
     },

--- a/rules/prompt-injection/ATR-2026-00086-visual-spoofing.yaml
+++ b/rules/prompt-injection/ATR-2026-00086-visual-spoofing.yaml
@@ -119,12 +119,24 @@ detection:
       (for example a Markdown or API term embedded in a Chinese sentence) - normal bilingual writing, which is why
       condition 4 is scoped to CJK COMPATIBILITY ideographs only
 response:
-  # block_input is gone. Changing the detection changes the fingerprint, so the
-  # false-positive figure recorded for this rule no longer describes it and the
-  # eligibility gate reads it as unmeasured -- ceiling observe. That is the gate
-  # working: the rule that fired on 94.9% of Cyrillic descriptions was declaring
-  # the authority to interrupt on evidence it no longer had. It can earn the tier
-  # back by being re-measured, not by asserting it here.
+  # block_input is gone, and it stays gone through a re-measurement that would
+  # allow it back.
+  #
+  # After the narrowing, this rule measures 1 false positive across the 12,060
+  # benign samples: 0.0083%, which the eligibility ladder grades DEGRADE, above
+  # the INTERRUPT tier block_input needs. The gate passes either way; this was
+  # checked rather than assumed.
+  #
+  # It stays at observe because that corpus is English. The failure this rule just
+  # had -- firing on 94.9% of the skill descriptions written in Cyrillic -- is
+  # structurally invisible to it, so 1-in-12,060 says nothing about the behaviour
+  # that lost the tier in the first place. The ladder's own reasoning is that a
+  # gate which cannot read the relevant measurement must refuse rather than pass,
+  # and a measurement blind to the axis in question is the same situation.
+  #
+  # What would earn it back: a clean run against a corpus with non-Latin scripts
+  # in it. data/measurements/clawhub-benign has 39 such samples and this rule now
+  # scores 0 on them, which is the right direction and too small a denominator.
   actions:
     - alert
     - escalate


### PR DESCRIPTION
The committed measurement was taken at 5b8d0de5 and stopped describing the ruleset
the moment ATR-2026-00086's detection changed. A changed fingerprint means the
recorded number is about a rule that no longer exists, and the eligibility gate
correctly reads that as unmeasured.

Full re-run: 785 rules against the same 12,060 benign samples. Exactly one number
moved, which is how you tell a clean re-run from a noisy one.

    ATR-2026-00086    2 -> 1
    ATR-2026-02500    new, 0 FP
    the other 783     identical
    total FP          15,299 -> 15,298
    dirty rules       191 -> 191

That 2-to-1 is also the honest size of what #489 bought on this corpus. The real
change was 37 to 0 across the 36,394 ClawHub skill descriptions. This gate is
English, so it never saw the problem and cannot show the repair — which is the
argument for the second half of this PR.

ATR-2026-00086 STAYS AT OBSERVE

At 1 in 12,060 the ladder grades it 0.0083%, DEGRADE, above the INTERRUPT tier
that block_input needs. The gate was run with the action restored to confirm it
would pass, then reverted; this is a decision, not a limitation.

It stays at observe because the corpus that grades it cannot see the failure that
cost it the tier. A rule that fires on 94.9% of one writing system and 0.2% of
everything else scores 1-in-12,060 on an English corpus, and that number is not
about the behaviour in question. The ladder already reasons that a gate unable to
read the relevant measurement must refuse rather than pass; a measurement blind to
the relevant axis is the same situation wearing a number.

The rule file records what would actually earn it back: a clean run against a
corpus containing non-Latin scripts. `data/measurements/clawhub-benign` has 39
such samples and this rule now scores 0 on them — right direction, denominator far
too small.

Unblocks the 4.0.0 release, which should not ship while the evidence file
describes a rule the repository no longer contains.