### PR TITLE
pyatr 0.3.0 — refresh the bundle, and unpin the behaviour that blocked it

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyatr"
-version = "0.2.7"
+version = "0.3.0"
 description = "Python engine for Agent Threat Rules (ATR) -- the open detection standard for AI agents (like Sigma, but for prompt injection, tool poisoning, MCP attacks, and skill compromise). Bundles the ATR rule set."
 requires-python = ">=3.10"
 license = {text = "MIT"}

--- a/python/tests/test_engine.py
+++ b/python/tests/test_engine.py
@@ -235,14 +235,39 @@ class TestATR2026013ToolSSRF:
         rule_ids = [m.rule_id for m in matches]
         assert "ATR-2026-00013" in rule_ids, f"Expected ATR-2026-00013 in {rule_ids}"
 
-    def test_fires_on_localhost(self, engine: ATREngine) -> None:
+    def test_does_not_fire_on_dev_localhost(self, engine: ATREngine) -> None:
+        """Bare localhost is a developer address, not SSRF.
+
+        This assertion used to be the reverse. ATR-2026-00013 was narrowed in
+        #296 ("narrow ATR-2026-00013 to real SSRF, stop flagging dev-localhost")
+        precisely because http://localhost:PORT is what every local dev server
+        looks like, and the rule now carries http://localhost:3000/health in its
+        own true_negatives. The loopback forms that ARE evidence of SSRF -- the
+        obfuscated ones a human would not type by hand, 0x7f000001, ::ffff:127.0.0.1,
+        decimal 2130706433 -- are still matched, and are covered below.
+
+        Leaving the old assertion in place is why this suite could not be run
+        against a current rule set: it pinned behaviour the rules had deliberately
+        abandoned, so refreshing the bundle broke the build.
+        """
         event = AgentEvent(
             content="http://localhost:8080/admin/config",
             event_type="tool_call",
         )
         matches = engine.evaluate(event)
         rule_ids = [m.rule_id for m in matches]
-        assert "ATR-2026-00013" in rule_ids
+        assert "ATR-2026-00013" not in rule_ids
+
+    def test_fires_on_obfuscated_loopback(self, engine: ATREngine) -> None:
+        """The loopback forms that survive the narrowing: encoded, not typed."""
+        event = AgentEvent(
+            content="http://0x7f000001/admin",
+            event_type="tool_call",
+            fields={"tool_args": "http://0x7f000001/admin"},
+        )
+        matches = engine.evaluate(event)
+        rule_ids = [m.rule_id for m in matches]
+        assert "ATR-2026-00013" in rule_ids, f"Expected ATR-2026-00013 in {rule_ids}"
 
     def test_does_not_fire_on_public_url(self, engine: ATREngine) -> None:
         event = AgentEvent(


### PR DESCRIPTION
pyatr 0.2.7 went out on 2026-07-10 and bundles 713 rules. `main` is at 785 files
and 778 effective, with 72 rule IDs that exist only in `main`. Six weeks and a
major version behind.

The cause turned out to be mechanical rather than neglect, which is the part
worth recording.

`tests/test_engine.py` asserted that ATR-2026-00013 fires on
`http://localhost:8080/admin/config`. It does not, and that is deliberate: #296
narrowed that rule to real SSRF for the express purpose of not flagging
dev-localhost, and the rule now carries `http://localhost:3000/health` in its own
`true_negatives`. The test pinned behaviour the rule set had abandoned, so
regenerating the bundle broke the build — and a broken build is why the wheel
stopped moving. The Python channel was not stale because nobody published it; it
was stale because it could not be published.

The assertion is reversed, with the reason and the PR number beside it, and a
companion test covers the obfuscated loopback forms (`0x7f000001`) that the
narrowing kept. Full suite green at 785 rules: 52 passed.

The version bump lands here rather than in the release because the tag path takes
the version from the tag and does not touch `pyproject.toml` — the same shape as
the npm workflow, where publishing from a tag ships whatever the manifest already
says.

After this merges, `pyatr-v0.3.0` publishes it.