### PR TITLE
fix(sigma): preserve ATR regex case semantics

### DIFF
--- a/docs/sigma-export/README.md
+++ b/docs/sigma-export/README.md
@@ -50,7 +50,7 @@ key the crosswalk established.
 | `references.owasp_llm: LLMnn` | `tags: owasp-llm.llmnn` | custom namespace | additive, non-standard |
 | `tags.category` | `tags: atr.category.<cat>` | custom namespace | additive, non-standard |
 | detection `field` (content, tool_response, ...) | Sigma detection field name | verbatim; drives `logsource.category` (see below) | field name exact; logsource custom |
-| detection `operator: regex` + `value` | `field\|re` or `field\|re\|i` | leading inline `(?i)` is stripped and re-expressed as the Sigma `re\|i` case-insensitive sub-flag; the rest of the pattern is passed through verbatim | see caveat below |
+| detection `operator: regex` + `value` | `field\|re\|i` by default; `field\|re` when `case_sensitive: true` | ATR regexes are case-insensitive by default. A leading inline `(?i)` is stripped and normalised into Sigma's `i` modifier; the rest of the pattern is passed through verbatim. | see caveat below |
 | detection `condition: any` | `condition: 1 of sel_*` | | yes |
 | detection `condition: all` | `condition: all of sel_*` | | yes |
 | detection `false_positives` | `falsepositives` | verbatim | yes |
@@ -77,12 +77,13 @@ field (custom values, all under `product: ai_agent`):
    will not know these field names until you map them to your agent telemetry.
    This is the single biggest caveat.
 
-2. **Case-insensitivity relies on `re|i` backend support.** ATR regexes almost
-   universally open with inline `(?i)`. The converter strips that and emits the
-   Sigma `re|i` sub-flag, which is the portable way. A handful of patterns with
-   other combined inline flags (`(?is)` etc.) keep the remaining flag inline;
-   inline-flag support varies by backend. Patterns with no leading `(?i)` are
-   emitted as case-sensitive `re` exactly as ATR wrote them.
+2. **Case-insensitivity relies on `re|i` backend support.** ATR regex matching is
+   case-insensitive by default, whether or not a source pattern carries inline
+   `(?i)`. The converter therefore emits Sigma's `re|i` sub-flag unless the ATR
+   condition explicitly sets `case_sensitive: true`. A leading inline `(?i)` is
+   stripped as a normalisation step, not treated as the source of ATR's runtime
+   semantics. A handful of patterns with other combined inline flags (`(?is)`
+   etc.) keep the remaining flag inline; inline-flag support varies by backend.
 
 3. **Regex flavor.** ATR patterns are Python `re`. Sigma `re` is documented as
    PCRE-ish but the effective flavor is the *target backend's* regex engine

--- a/scripts/generate-sigma.py
+++ b/scripts/generate-sigma.py
@@ -21,12 +21,12 @@ its known limitations):
     map those fields to their own agent-telemetry pipeline. This is approximate
     by nature and is called out, not hidden.
 
-  * ATR regexes are Python `re` with a near-universal leading inline `(?i)`.
-    Sigma's `re` modifier is case-sensitive by default but supports `re|i`.
-    Where an ATR pattern starts with `(?i)`, we strip it and emit `field|re|i`;
-    otherwise `field|re`. Remaining inline flags (rare) are preserved verbatim
-    inside the pattern -- backend support for inline flags varies, which is a
-    documented limitation, not a silent one.
+  * ATR regexes are case-insensitive by default unless a condition explicitly
+    sets `case_sensitive: true`. Sigma's `re` modifier is case-sensitive by
+    default, so the emitter uses `field|re|i` for the ATR default and `field|re`
+    for the explicit opt-out. A leading inline `(?i)` is normalised into the
+    Sigma modifier; other inline flags are preserved verbatim inside the
+    pattern, subject to backend support.
 
   * ATR's non-regex operators are rare. `operator: gt` (numeric behavioral
     threshold) has no clean Sigma string-match equivalent, so those single
@@ -435,11 +435,18 @@ def convert_conditions(atr_detection: dict, regex_dialect: str = "pcre") -> tupl
             if value is None:
                 warnings.append(f"condition #{idx} has no value; skipped")
                 continue
-            pattern, use_i = strip_leading_i_flag(str(value))
+            pattern, had_inline_i = strip_leading_i_flag(str(value))
+            case_sensitive = cond.get("case_sensitive") is True
+            if case_sensitive and had_inline_i:
+                warnings.append(
+                    f"condition #{idx} sets case_sensitive: true but its pattern "
+                    "has an inline i flag; case_sensitive takes precedence and "
+                    "the inline i flag was removed"
+                )
             pattern, blockers = emit_for_dialect(pattern, regex_dialect)
             for blocker in blockers:
                 warnings.append(f"condition #{idx} RE2-INCOMPATIBLE: {blocker}")
-            modifier = "re|i" if use_i else "re"
+            modifier = "re" if case_sensitive else "re|i"
             selections[sel_name] = {f"{field}|{modifier}": pattern}
         elif operator in ("gt", "lt", "gte", "lte", "eq"):
             # Numeric behavioral threshold. Sigma has no portable numeric

--- a/scripts/test_generate_sigma.py
+++ b/scripts/test_generate_sigma.py
@@ -12,8 +12,8 @@ What it checks (the load-bearing conversion guarantees):
   3. The ATT&CK join key round-trips: every enterprise ATT&CK id in the source
      ATR rule's references.mitre_attack appears as `attack.txxxx` in Sigma tags,
      and no bogus attack.* tag is minted from an ATLAS id.
-  4. The near-universal leading `(?i)` in ATR regexes is turned into the Sigma
-     `re|i` modifier, not left inline.
+  4. ATR's default case-insensitive regex semantics become Sigma's `re|i`, while
+     the explicit `case_sensitive: true` opt-out remains case-sensitive.
   5. The detection field names survive verbatim (no data loss on the surface).
 """
 from __future__ import annotations
@@ -173,6 +173,37 @@ def test_case_insensitive_flag_becomes_re_i_modifier():
                     f"{rel} sel_{idx}: regex condition not emitted with re modifier: '{key}'"
                 )
     assert saw_re_i, "sample did not exercise the (?i) -> re|i path; sample is unrepresentative"
+
+
+def test_implicit_case_insensitivity_becomes_re_i_modifier():
+    """A real rule without (?i) must retain ATR's default case semantics."""
+    rel = "rules/prompt-injection/ATR-2026-02005-actor-never-breaks-character-roleplay-dan-style-.yaml"
+    atr, _, s, _, _ = _convert(rel)
+    source = atr["detection"]["conditions"][0]["value"]
+    assert not source.startswith("(?i)"), "regression fixture unexpectedly gained inline (?i)"
+    assert list(s["detection"]["sel_1"]) == ["content|re|i"]
+
+
+def test_case_sensitive_opt_out_stays_case_sensitive():
+    detection = {
+        "conditions": [
+            {"field": "content", "operator": "regex", "value": "Secret", "case_sensitive": True}
+        ]
+    }
+    selections, _, warnings = CONV.convert_conditions(detection)
+    assert selections["sel_1"] == {"content|re": "Secret"}
+    assert not warnings
+
+
+def test_case_sensitive_opt_out_overrides_inline_i_with_warning():
+    detection = {
+        "conditions": [
+            {"field": "content", "operator": "regex", "value": "(?is)Secret", "case_sensitive": True}
+        ]
+    }
+    selections, _, warnings = CONV.convert_conditions(detection)
+    assert selections["sel_1"] == {"content|re": "(?s)Secret"}
+    assert any("case_sensitive: true" in warning for warning in warnings)
 
 
 def test_detection_field_names_survive():


### PR DESCRIPTION
## Summary

- preserve ATR's default case-insensitive regex semantics in Sigma exports by emitting `field|re|i` even when the source pattern has no inline `(?i)`
- respect the schema's explicit `case_sensitive: true` opt-out by emitting `field|re`
- make conflicting `case_sensitive: true` plus inline `i` deterministic: the schema field wins, the inline `i` is removed, and conversion emits a warning
- document the mapping and add regression coverage using the real ATR-2026-02005 case from #331

Refs #331. This intentionally does not close the issue: pyATR's silent regex compile failures and the remaining variable-width-lookbehind rules are separate follow-ups.

## Context and scope

#509 fixed the JavaScript-only Unicode escapes. #510 and #511 preserve case semantics in the PyRIT digest, but do not change `generate-sigma.py`; this PR addresses only the Sigma-export subsection of #331.

The repository's rule-writing guide still recommends adding inline `(?i)`, while the schema and runtime define regex matching as case-insensitive by default unless `case_sensitive: true`. This PR does not change that broader authoring guidance.

No rules, pyATR code, workflows, generated examples, or dependency files are changed.

## Verification

- `python -m pytest scripts/test_generate_sigma.py -q -k 'not test_re2_dialect_rewrites_unicode_escapes'`: **18 passed, 1 deselected**
- full suite on this branch: **18 passed, 1 pre-existing failure**
- full suite on untouched `upstream/main`: **15 passed, the same 1 failure**
  - the existing RE2 Unicode test still expects `\\u{...}` after #509 replaced those escapes with literals
- regenerated the five tracked Sigma examples with both the upstream and changed exporters against the same rules: **zero output diff**
- ATR-2026-02005 before/after: the only output change is `content|re` to `content|re|i`
- `git diff --check`

The standalone Python converter suite is not currently wired into PR GitHub Actions; adding that CI integration is outside this focused change.
