### PR TITLE
fix(gate): check peer true negatives within the same PR

### DIFF
--- a/scripts/check-rules-safety.ts
+++ b/scripts/check-rules-safety.ts
@@ -272,25 +272,23 @@ function loadExtendedBenign(): ExtendedBenignSample[] {
   return out;
 }
 
-interface RuleTNSample {
+export interface RuleTNSample {
   ownerRuleId: string;
   ownerFile: string;
   text: string;
 }
 
 /**
- * Collect every existing rule's true_negatives, tagged with the rule
- * that authored them. Used for cross-rule conflict detection.
+ * Collect every rule's true_negatives, tagged with the rule that authored
+ * them. This includes new rules so peers added by the same PR are checked in
+ * both directions; self-conflicts are excluded by owner id at evaluation time.
  */
-function loadAllExistingTrueNegatives(
-  excludeFiles: Set<string>,
-): RuleTNSample[] {
+function loadAllTrueNegatives(): RuleTNSample[] {
   const out: RuleTNSample[] = [];
   for (const f of walkYamlFiles(RULES_DIR)) {
     const rel = f.startsWith(REPO_ROOT + "/")
       ? f.slice(REPO_ROOT.length + 1)
       : f;
-    if (excludeFiles.has(rel)) continue;
     let doc: unknown;
     try {
       doc = yamlLoad(readFileSync(f, "utf-8"));
@@ -520,26 +518,22 @@ async function checkResearchMentionFP(
 }
 
 /**
- * Check 5: cross-rule conflict. For each new rule, verify it does not
- * match any OTHER (existing) rule's true_negatives. If rule X starts
- * firing on rule Y's known-benign set, Y just regressed in precision
- * and we need a human to look at the overlap.
+ * Evaluate the directed cross-rule matrix. Only new rules can be offenders,
+ * while every other rule (including a peer added by the same PR) can own the
+ * true-negative sample. A rule's own TN is intentionally left to its own-rule
+ * validation rather than reported as a cross-rule conflict.
  *
  * Returns a map of newRuleId → list of "ownerRuleId:sample-snippet"
  * conflicts.
  */
-async function checkCrossRuleConflict(
-  engine: ATREngine,
-  newRuleIds: Set<string>,
-  newFiles: Set<string>,
-): Promise<Map<string, string[]>> {
+export function findCrossRuleConflicts(
+  newRuleIds: ReadonlySet<string>,
+  tnSamples: readonly RuleTNSample[],
+  matches: (text: string) => ReadonlySet<string>,
+): Map<string, string[]> {
   const fps = new Map<string, string[]>();
-  const tnSamples = loadAllExistingTrueNegatives(newFiles);
-  if (tnSamples.length === 0) {
-    return fps;
-  }
   for (const tn of tnSamples) {
-    for (const id of matchAllRuleIds(engine, tn.text)) {
+    for (const id of matches(tn.text)) {
       if (newRuleIds.has(id) && id !== tn.ownerRuleId) {
         if (!fps.has(id)) fps.set(id, []);
         const snippet = tn.text.slice(0, 60).replace(/\s+/g, " ");
@@ -550,6 +544,18 @@ async function checkCrossRuleConflict(
     }
   }
   return fps;
+}
+
+/** Check 5: run the directed matrix against the repository's TN corpus. */
+async function checkCrossRuleConflict(
+  engine: ATREngine,
+  newRuleIds: Set<string>,
+): Promise<Map<string, string[]>> {
+  return findCrossRuleConflicts(
+    newRuleIds,
+    loadAllTrueNegatives(),
+    (text) => matchAllRuleIds(engine, text),
+  );
 }
 
 /**
@@ -926,12 +932,8 @@ async function main(): Promise<void> {
       });
     }
 
-    // Check 5 — cross-rule conflict against existing TNs.
-    const conflictFps = await checkCrossRuleConflict(
-      engine,
-      newRuleIds,
-      new Set(newFiles),
-    );
+    // Check 5 — directed cross-rule conflict against existing and peer TNs.
+    const conflictFps = await checkCrossRuleConflict(engine, newRuleIds);
     for (const [id, conflicts] of conflictFps) {
       failures.push({
         file: fileToId.get(id) ?? id,

--- a/tests/check-rules-safety-cross-rule.test.ts
+++ b/tests/check-rules-safety-cross-rule.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import {
+  findCrossRuleConflicts,
+  type RuleTNSample,
+} from "../scripts/check-rules-safety.js";
+
+const tn = (ownerRuleId: string, text: string): RuleTNSample => ({
+  ownerRuleId,
+  ownerFile: `rules/${ownerRuleId}.yaml`,
+  text,
+});
+
+describe("findCrossRuleConflicts", () => {
+  it("checks peer true negatives in both directions", () => {
+    const samples = [tn("RULE-A", "safe for A"), tn("RULE-B", "safe for B")];
+    const matches = (text: string) =>
+      new Set(text === "safe for A" ? ["RULE-B"] : ["RULE-A"]);
+
+    expect([...findCrossRuleConflicts(new Set(["RULE-A", "RULE-B"]), samples, matches).keys()]).toEqual([
+      "RULE-B",
+      "RULE-A",
+    ]);
+  });
+
+  it("does not report a rule matching its own true negative as cross-rule", () => {
+    const conflicts = findCrossRuleConflicts(
+      new Set(["RULE-A"]),
+      [tn("RULE-A", "own sample")],
+      () => new Set(["RULE-A"]),
+    );
+    expect(conflicts.size).toBe(0);
+  });
+
+  it("passes when peer true negatives are silent", () => {
+    const conflicts = findCrossRuleConflicts(
+      new Set(["RULE-A", "RULE-B"]),
+      [tn("RULE-A", "safe for A"), tn("RULE-B", "safe for B")],
+      () => new Set(),
+    );
+    expect(conflicts.size).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

- close the Check 5 blind spot where all rule files added by the current PR were excluded from the true-negative corpus
- evaluate new rules against peer true negatives in both directed pairings
- preserve the existing self-match exclusion by rule owner ID

This is the first, independently reviewable follow-up discussed in #515. It does not add ruleset monotonicity or merge-group validation.

## Tests

- `npm test -- tests/check-rules-safety-cross-rule.test.ts tests/check-rules-safety-discovery.test.ts` (15 passed)
- `npm run typecheck:scripts`
- `npm run build`
- `npm test` (1100 passed, 3 skipped)