### PR TITLE
fix(rules): remove catastrophic backtracking from eight rules, and gate it

### DIFF
--- a/.github/workflows/redos-gate.yml
+++ b/.github/workflows/redos-gate.yml
@@ -1,0 +1,30 @@
+name: ReDoS Gate
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    paths:
+      - "rules/**"
+      - "data/redos-baseline.json"
+      - "scripts/gate-redos.py"
+  workflow_dispatch:
+
+# The latency gate measures what a rule costs on the eval corpus. It is
+# structurally blind to catastrophic backtracking, because a ReDoS pattern is
+# cheap on ordinary text and only explodes on a string shaped like its own
+# grammar. ATR-2026-01005 sat at maturity: stable, cost nothing measurable on
+# the corpus, and took over four minutes on 129 bytes.
+jobs:
+  redos:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+      - name: Install dependencies
+        run: pip install PyYAML
+      - name: Scan the rule corpus for catastrophic backtracking
+        run: python3 scripts/gate-redos.py --rules rules

--- a/data/benign-fp-measurement.json
+++ b/data/benign-fp-measurement.json
@@ -1,7 +1,7 @@
 {
   "_comment": "Benign-corpus false-positive measurement. Produced by scripts/gate-promotion-fp.ts --emit-measurement. A rule absent from `rules`, or whose detection_fingerprint no longer matches the rule on disk, is UNMEASURED and is capped at the observe tier by scripts/gate-action-eligibility.ts. Do not hand-edit.",
-  "generated_at": "2026-08-20",
-  "commit": "c813f2ca7374a621ee2badc819fa6e0bdd4454c3",
+  "generated_at": "2026-08-30",
+  "commit": "5b0b6844007b66f70cb4064bfa45ce803026195e",
   "corpora": [
     "data/skill-benchmark/benign",
     "data/benign-corpus-extended",
@@ -20,7 +20,7 @@
     "ATR-2026-00001": {
       "fp_count": 27,
       "maturity": "test",
-      "detection_fingerprint": "dd3dbe9b29c9bc6f",
+      "detection_fingerprint": "485df607cb93d3e0",
       "partial_measurement": false,
       "skill_path_unmeasured": true
     },
@@ -321,7 +321,7 @@
     "ATR-2026-00091": {
       "fp_count": 0,
       "maturity": "test",
-      "detection_fingerprint": "12287bbb1c1c98e5",
+      "detection_fingerprint": "0f3cb19606505b1f",
       "partial_measurement": false,
       "skill_path_unmeasured": true
     },
@@ -594,7 +594,7 @@
     "ATR-2026-00131": {
       "fp_count": 0,
       "maturity": "test",
-      "detection_fingerprint": "1fc97917a1e404e7",
+      "detection_fingerprint": "665647f19ddfc3d8",
       "partial_measurement": false,
       "skill_path_unmeasured": true
     },
@@ -699,7 +699,7 @@
     "ATR-2026-00146": {
       "fp_count": 0,
       "maturity": "test",
-      "detection_fingerprint": "a33bd6575bdb1a23",
+      "detection_fingerprint": "571e6eca92578d30",
       "partial_measurement": false,
       "skill_path_unmeasured": true
     },
@@ -909,7 +909,7 @@
     "ATR-2026-00220": {
       "fp_count": 3,
       "maturity": "test",
-      "detection_fingerprint": "873cef31a1df2edd",
+      "detection_fingerprint": "73860d452827c577",
       "partial_measurement": false,
       "skill_path_unmeasured": false
     },
@@ -1294,7 +1294,7 @@
     "ATR-2026-00282": {
       "fp_count": 2,
       "maturity": "test",
-      "detection_fingerprint": "ef13c7eaa646e92c",
+      "detection_fingerprint": "fb6bfdbd2b10c8bd",
       "partial_measurement": false,
       "skill_path_unmeasured": true
     },
@@ -2848,7 +2848,7 @@
     "ATR-2026-00508": {
       "fp_count": 4,
       "maturity": "test",
-      "detection_fingerprint": "2d66c6968e9c14e0",
+      "detection_fingerprint": "f0b782085f371e05",
       "partial_measurement": false,
       "skill_path_unmeasured": true
     },
@@ -4073,7 +4073,7 @@
     "ATR-2026-01771": {
       "fp_count": 0,
       "maturity": "test",
-      "detection_fingerprint": "a6db5fba82e1e089",
+      "detection_fingerprint": "4932a3a52f52d708",
       "partial_measurement": false,
       "skill_path_unmeasured": true
     },
@@ -5511,6 +5511,62 @@
       "detection_fingerprint": "d3378b0ac1b94601",
       "partial_measurement": false,
       "skill_path_unmeasured": false
+    },
+    "ATR-2026-02514": {
+      "fp_count": 0,
+      "maturity": "test",
+      "detection_fingerprint": "aa054941497f2c4e",
+      "partial_measurement": false,
+      "skill_path_unmeasured": true
+    },
+    "ATR-2026-02525": {
+      "fp_count": 0,
+      "maturity": "test",
+      "detection_fingerprint": "088cdfe0fec549bc",
+      "partial_measurement": false,
+      "skill_path_unmeasured": false
+    },
+    "ATR-2026-02528": {
+      "fp_count": 0,
+      "maturity": "test",
+      "detection_fingerprint": "93f68e06b7870d1a",
+      "partial_measurement": false,
+      "skill_path_unmeasured": false
+    },
+    "ATR-2026-02530": {
+      "fp_count": 0,
+      "maturity": "test",
+      "detection_fingerprint": "e3fe1abc2a5a284d",
+      "partial_measurement": false,
+      "skill_path_unmeasured": false
+    },
+    "ATR-2026-02531": {
+      "fp_count": 0,
+      "maturity": "test",
+      "detection_fingerprint": "9e6ce38587280837",
+      "partial_measurement": false,
+      "skill_path_unmeasured": false
+    },
+    "ATR-2026-02542": {
+      "fp_count": 0,
+      "maturity": "test",
+      "detection_fingerprint": "6c5ba744103e47f6",
+      "partial_measurement": false,
+      "skill_path_unmeasured": false
+    },
+    "ATR-2026-02557": {
+      "fp_count": 0,
+      "maturity": "test",
+      "detection_fingerprint": "e218b75fb4a8e14b",
+      "partial_measurement": false,
+      "skill_path_unmeasured": true
+    },
+    "ATR-2026-02570": {
+      "fp_count": 0,
+      "maturity": "test",
+      "detection_fingerprint": "dd0b249ad56bed41",
+      "partial_measurement": false,
+      "skill_path_unmeasured": true
     }
   }
 }

--- a/data/redos-baseline.json
+++ b/data/redos-baseline.json
@@ -1,0 +1,17 @@
+{
+  "_comment": "Conditions known to backtrack badly on adversarial input. Produced by scripts/gate-redos.py --update-baseline. Shrinking this file is the goal; growing it needs a reason in the commit message.",
+  "budget_seconds": 0.3,
+  "known": {
+    "ATR-2026-00001#9": 0.3071,
+    "ATR-2026-00163#4": 0.4593,
+    "ATR-2026-00220#2": 0.4287,
+    "ATR-2026-00272#0": 8.6241,
+    "ATR-2026-00285#0": 9.7671,
+    "ATR-2026-00303#2": 0.5053,
+    "ATR-2026-00337#4": 6.7029,
+    "ATR-2026-00451#1": 0.6717,
+    "ATR-2026-00707#0": 0.3814,
+    "ATR-2026-02372#0": 3.4953,
+    "ATR-2026-02372#1": 3.937
+  }
+}

--- a/data/redos-baseline.json
+++ b/data/redos-baseline.json
@@ -1,17 +1,18 @@
 {
   "_comment": "Conditions known to backtrack badly on adversarial input. Produced by scripts/gate-redos.py --update-baseline. Shrinking this file is the goal; growing it needs a reason in the commit message.",
   "budget_seconds": 0.3,
+  "calibration_reference_seconds": 0.114833,
   "known": {
-    "ATR-2026-00001#9": 0.3071,
-    "ATR-2026-00163#4": 0.4593,
-    "ATR-2026-00220#2": 0.4287,
-    "ATR-2026-00272#0": 8.6241,
-    "ATR-2026-00285#0": 9.7671,
-    "ATR-2026-00303#2": 0.5053,
-    "ATR-2026-00337#4": 6.7029,
-    "ATR-2026-00451#1": 0.6717,
-    "ATR-2026-00707#0": 0.3814,
-    "ATR-2026-02372#0": 3.4953,
-    "ATR-2026-02372#1": 3.937
+    "ATR-2026-00163#4": 0.4968,
+    "ATR-2026-00220#2": 0.3725,
+    "ATR-2026-00272#0": 7.8155,
+    "ATR-2026-00285#0": 8.8119,
+    "ATR-2026-00303#2": 0.4769,
+    "ATR-2026-00337#4": 6.005,
+    "ATR-2026-00451#1": 0.7691,
+    "ATR-2026-00707#0": 0.4207,
+    "ATR-2026-01005#0": 3.4177,
+    "ATR-2026-02372#0": 3.0262,
+    "ATR-2026-02372#1": 3.0232
   }
 }

--- a/rules/context-exfiltration/ATR-2026-00146-env-var-existence-probe.yaml
+++ b/rules/context-exfiltration/ATR-2026-00146-env-var-existence-probe.yaml
@@ -66,7 +66,7 @@ detection:
     - field: content
       operator: regex
       value: >-
-        (?i)(?:process\.env|os\.environ|ENV|environment\s+variable)\s*[\[.\s]+\s*(?:OPENAI|ANTHROPIC|GITHUB|AWS|AZURE|GCP|STRIPE|TWILIO|SENDGRID|DATABASE|DB|POSTGRES|MYSQL|REDIS|SECRET|PRIVATE|AUTH)[A-Z_]*(?:API)?[_\s-]*(?:KEY|TOKEN|SECRET|PASSWORD|CREDENTIALS?)\s*[\]]*\s+(?:is\s+(?:defined|set|present|available|stored)|exists?|but\s+(?:I\s+)?(?:cannot|can.t|unable|don.t
+        (?i)(?:process\.env|os\.environ|ENV|environment\s+variable)[\[.\s]+(?:OPENAI|ANTHROPIC|GITHUB|AWS|AZURE|GCP|STRIPE|TWILIO|SENDGRID|DATABASE|DB|POSTGRES|MYSQL|REDIS|SECRET|PRIVATE|AUTH)[A-Z_]*(?:[\s-][_\s-]*)?(?:KEY|TOKEN|SECRET|PASSWORD|CREDENTIALS?)(?:\s*\]+)?\s+(?:is\s+(?:defined|set|present|available|stored)|exists?|but\s+(?:I\s+)?(?:cannot|can.t|unable|don.t
         have))
       description: Confirming env var existence while claiming no access
   false_positives:

--- a/rules/prompt-injection/ATR-2026-00001-direct-prompt-injection.yaml
+++ b/rules/prompt-injection/ATR-2026-00001-direct-prompt-injection.yaml
@@ -176,7 +176,7 @@ detection:
     # -- Layer 3b: Few-shot output manipulation (DE-specific, requires 3+ pairs) --
     - field: user_input
       operator: regex
-      value: "(?i)Eingabe\\s*:\\s*[^\\n]+\\s*Ausgabe\\s*:\\s*[^\\n]+\\s*Eingabe\\s*:\\s*[^\\n]+\\s*Ausgabe\\s*:"
+      value: "(?i)Eingabe\\s*:(?:\\s*\\S(?:[^\\n]*\\S)?|\\n*[^\\S\\n])\\s*Ausgabe\\s*:(?:\\s*\\S(?:[^\\n]*\\S)?|\\n*[^\\S\\n])\\s*Eingabe\\s*:(?:\\s*\\S(?:[^\\n]*\\S)?|\\n*[^\\S\\n])\\s*Ausgabe\\s*:"
       description: "German few-shot input/output override pattern (Eingabe/Ausgabe)"
 
     # -- Layer 4: Do-not-follow-rules patterns --

--- a/rules/prompt-injection/ATR-2026-00091-nested-payload.yaml
+++ b/rules/prompt-injection/ATR-2026-00091-nested-payload.yaml
@@ -71,7 +71,7 @@ detection:
   conditions:
     - field: user_input
       operator: regex
-      value: (?i)\{[^}]*\{[^}]*["']\s*:\s*["'][^"']*\b(ignore|override|disregard|forget)\s+(previous|system|all)\b[^"']*["']
+      value: (?i)\{[^{}]*\{[^{}]*["']\s*:\s*["'][^"']*\b(ignore|override|disregard|forget)\s+(previous|system|all)\b[^"']*["']
       description: Injection payload nested inside multi-level JSON objects
     # Alternation precedence: `|` binds loosest, so the escaped-whitespace list
     # has to be bracketed or the proximity requirement binds to the last branch

--- a/rules/prompt-injection/ATR-2026-00131-fictional-academic-framing.yaml
+++ b/rules/prompt-injection/ATR-2026-00131-fictional-academic-framing.yaml
@@ -81,7 +81,7 @@ detection:
     - field: user_input
       operator: regex
       value: >-
-        (?i)(write|compose|create|draft|author|craft|produce)\s+.{0,40}(story|narrative|fiction|tale|novel|screenplay|script|dialogue)\s+.{0,60}(AI|artificial\s+intelligence|chatbot|assistant|agent)\s+.{0,40}(character|protagonist|entity)\s+.{0,40}(no|without|lacks?|free\s+from|devoid\s+of)\s+.{0,20}(ethic|moral|restrict|constrain|limit|filter|guardrail|safety)
+        (?i)(write|compose|create|draft|author|craft|produce)\s+(?:[^\s].{0,39})?(story|narrative|fiction|tale|novel|screenplay|script|dialogue)\s+(?:[^\s].{0,59})?(AI|artificial\s+intelligence|chatbot|assistant|agent)\s+(?:[^\s].{0,39})?(character|protagonist|entity)\s+(?:[^\s].{0,39})?(no|without|lacks?|free\s+from|devoid\s+of)\s+(?:[^\s].{0,19})?(ethic|moral|restrict|constrain|limit|filter|guardrail|safety)
       description: Fiction writing request with unethical AI character
     - field: user_input
       operator: regex

--- a/rules/prompt-injection/ATR-2026-00282-perez-prompt-injection-hijack.yaml
+++ b/rules/prompt-injection/ATR-2026-00282-perez-prompt-injection-hijack.yaml
@@ -92,7 +92,7 @@ detection:
       description: 'Ignore-say/ignore-print with known garak rogue strings (hate-humans, kill-humans, long-prompt)'
     - field: tool_response
       operator: regex
-      value: '(?:^|\n)(?:\s*>\s*)+\s*(?:IGNORE|DISREGARD|NEW\s+INSTRUCTION|OVERRIDE|SYSTEM\s*:)'
+      value: '(?:^|\n)\s*(?:>\s*)+(?:IGNORE|DISREGARD|NEW\s+INSTRUCTION|OVERRIDE|SYSTEM\s*:)'
       description: 'Markdown blockquote-wrapped instruction override — > IGNORE / > SYSTEM: prefix used to visually isolate injection'
   condition: any
   false_positives:

--- a/rules/prompt-injection/ATR-2026-00508-escape-delimiter-wrapped-goal-hijacking-in-user-input-prompt.yaml
+++ b/rules/prompt-injection/ATR-2026-00508-escape-delimiter-wrapped-goal-hijacking-in-user-input-prompt.yaml
@@ -109,7 +109,7 @@ detection:
 
     - field: content
       operator: regex
-      value: '(?i)(?:[=*\-\\]{3,}|\*{3,})[\s\S]{0,100}(?:stop\s+everything|ignore\s+(?:any|all|the|your)?\s*(?:previous|following|prior|above)[\s\S]{0,40}(?:and\s+(?:following|previous)\s+)?instructions?)'
+      value: '(?i)[=*\-\\]{3}[\s\S]{0,100}(?:stop\s+everything|ignore\s+(?:(?:any|all|the|your)\s*)?(?:previous|following|prior|above)[\s\S]{0,40}(?:and\s+(?:following|previous)\s+)?instructions?)'
       description: 'Delimiter-wrapped hijack: separator run then STOP EVERYTHING / ignore...instructions'
   condition: any
   false_positives:

--- a/rules/prompt-injection/ATR-2026-01005-many-shot-repetition-override.yaml
+++ b/rules/prompt-injection/ATR-2026-01005-many-shot-repetition-override.yaml
@@ -69,7 +69,7 @@ detection:
     # Uses non-greedy matching to allow up to 5 Q/A cycles
     - field: user_input
       operator: regex
-      value: "(?i)(Q\\s*:\\s*.{5,200}\\s+A\\s*:\\s*.{5,300}\\s+){3,}Q\\s*:\\s*.{0,150}(password|secret|api[_\\s]?key|birth\\s*(date|day)|email\\s*(address)?|social\\s*security|SSN|override|bypass|admin|credentials?|master\\s*key)"
+      value: "(?i)(Q\\s*:\\s*\\S(?:(?!\\s+A\\s*:).){4,199}\\s+A\\s*:\\s*\\S(?:(?!\\s+Q\\s*:).){4,299}\\s+){3,}Q\\s*:\\s*.{0,150}(password|secret|api[_\\s]?key|birth\\s*(date|day)|email\\s*(address)?|social\\s*security|SSN|override|bypass|admin|credentials?|master\\s*key)"
       description: "Three or more Q&A pairs leading to password/secret/key request (many-shot chain)"
     # "Repeat X N times" conditioning followed by a question
     - field: user_input

--- a/rules/prompt-injection/ATR-2026-01005-many-shot-repetition-override.yaml
+++ b/rules/prompt-injection/ATR-2026-01005-many-shot-repetition-override.yaml
@@ -69,7 +69,7 @@ detection:
     # Uses non-greedy matching to allow up to 5 Q/A cycles
     - field: user_input
       operator: regex
-      value: "(?i)(Q\\s*:\\s*\\S(?:(?!\\s+A\\s*:).){4,199}\\s+A\\s*:\\s*\\S(?:(?!\\s+Q\\s*:).){4,299}\\s+){3,}Q\\s*:\\s*.{0,150}(password|secret|api[_\\s]?key|birth\\s*(date|day)|email\\s*(address)?|social\\s*security|SSN|override|bypass|admin|credentials?|master\\s*key)"
+      value: "(?i)(Q\\s*:\\s*.{5,200}\\s+A\\s*:\\s*.{5,300}\\s+){3,}Q\\s*:\\s*.{0,150}(password|secret|api[_\\s]?key|birth\\s*(date|day)|email\\s*(address)?|social\\s*security|SSN|override|bypass|admin|credentials?|master\\s*key)"
       description: "Three or more Q&A pairs leading to password/secret/key request (many-shot chain)"
     # "Repeat X N times" conditioning followed by a question
     - field: user_input

--- a/rules/prompt-injection/ATR-2026-01771-semantic-jailbreak-framing.yaml
+++ b/rules/prompt-injection/ATR-2026-01771-semantic-jailbreak-framing.yaml
@@ -90,7 +90,7 @@ detection:
     # benign "password manager" / "best practices" educational form.
     - field: user_input
       operator: regex
-      value: "(?i)Q\\s*:\\s*.{5,150}\\s+A\\s*:\\s*.{5,200}\\s+Q\\s*:\\s*(?:[^?\\n]{0,80}?)(?:our\\s+(?:system\\s+)?password|the\\s+(?:system\\s+)?password|your\\s+password|master\\s*key|secret\\s*key|encryption\\s+key|api[_\\s-]?key|birth\\s*(?:date|day|year)|social\\s*security|ssn|home\\s*address|credit\\s*card)\\b(?!\\s*managers?)"
+      value: "(?i)Q\\s*:\\s*.{4,149}[^\\s]\\s+A\\s*:\\s*.{4,199}[^\\s]\\s+Q\\s*:\\s*(?:[^?\\n]{0,80}?)(?:our\\s+(?:system\\s+)?password|the\\s+(?:system\\s+)?password|your\\s+password|master\\s*key|secret\\s*key|encryption\\s+key|api[_\\s-]?key|birth\\s*(?:date|day|year)|social\\s*security|ssn|home\\s*address|credit\\s*card)\\b(?!\\s*managers?)"
       description: "Q&A pairs culminating in a specific credential/PII question (excludes 'password manager')"
     # (a) chained ignore-above few-shot
     - field: user_input
@@ -105,7 +105,7 @@ detection:
     # (b) multi-question quiz terminating in a credential (2+ questions then password)
     - field: user_input
       operator: regex
-      value: "(?i)(?:[^?\\n]{5,60}\\?\\s+){2,}[^?\\n]{0,40}(?:what'?s?\\s+(?:the\\s+)?(?:password|secret|system\\s+password|pin)\\b|password\\s+for\\s+our\\s+system)"
+      value: "(?i)(?:[^\\s?\\n][^?\\n]{4,59}\\?\\s+){2,}[^?\\n]{0,40}(?:what'?s?\\s+(?:the\\s+)?(?:password|secret|system\\s+password|pin)\\b|password\\s+for\\s+our\\s+system)"
       description: "Two or more trivia questions followed by a password question"
     # (b) reflective pivot to credential confirmation (may span a sentence break)
     - field: user_input

--- a/rules/skill-compromise/ATR-2026-00220-malware-dropper.yaml
+++ b/rules/skill-compromise/ATR-2026-00220-malware-dropper.yaml
@@ -61,7 +61,7 @@ detection:
   conditions:
     - field: content
       operator: regex
-      value: '[a-zA-Z0-9+/]{40,}={0,2}.*base64\s+-[dD]'
+      value: '(?<![a-zA-Z0-9+/])[a-zA-Z0-9+/]{40}.*base64\s+-[dD]'
       description: 'Base64 encoded payload with decode instruction'
     - field: content
       operator: regex

--- a/rules/skill-compromise/ATR-2026-00220-malware-dropper.yaml
+++ b/rules/skill-compromise/ATR-2026-00220-malware-dropper.yaml
@@ -61,7 +61,7 @@ detection:
   conditions:
     - field: content
       operator: regex
-      value: '(?<![a-zA-Z0-9+/])[a-zA-Z0-9+/]{40}.*base64\s+-[dD]'
+      value: '(?:^|[^a-zA-Z0-9+/])[a-zA-Z0-9+/]{40}[^\n]{0,400}base64\s+-[dD]'
       description: 'Base64 encoded payload with decode instruction'
     - field: content
       operator: regex

--- a/scripts/gate-redos.py
+++ b/scripts/gate-redos.py
@@ -71,6 +71,18 @@ except ImportError:                        # pragma: no cover - older runtimes
 import yaml
 
 BASELINE = Path("data/redos-baseline.json")
+
+# A fixed workload, timed on the same machine in the same run, so the budget
+# tracks how fast that machine is. Without it the gate is an absolute
+# millisecond threshold, which is the exact failure gate-rule-latency.ts was
+# rewritten to escape: on a GitHub runner roughly twice as slow as the machine
+# this was written on, six conditions sitting at 0.15-0.25s crossed a 0.3s line
+# while nothing about them had changed. The reference number below was measured
+# on that authoring machine; the ratio is what matters, not the absolute value.
+CALIBRATION_PATTERN = r"(?i)(?:foo|bar|baz)+\s*[a-z0-9_]{3,40}\s*[:=]\s*\S+"
+CALIBRATION_INPUT = ("foobarbaz " * 400) + "token_value = something\n"
+CALIBRATION_REPEATS = 200
+CALIBRATION_REFERENCE_SECONDS = None  # filled in by --update-baseline
 PUMPS = (2, 3, 4, 8, 16)
 CHUNK = 40
 GENERIC = (
@@ -247,6 +259,26 @@ def measure(items, budget, wall):
     return results, hung
 
 
+def calibrate() -> float:
+    """Seconds this machine takes on the fixed reference workload."""
+    rx = re.compile(CALIBRATION_PATTERN)
+    started = time.monotonic()
+    for _ in range(CALIBRATION_REPEATS):
+        rx.search(CALIBRATION_INPUT)
+    return time.monotonic() - started
+
+
+def scaled_budget(base: float, reference: float | None) -> tuple[float, float]:
+    """Budget adjusted for this machine, and the factor used."""
+    if not reference:
+        return base, 1.0
+    factor = calibrate() / reference
+    # Clamp so a wildly noisy calibration cannot disable the gate outright or
+    # make it absurdly strict.
+    factor = min(max(factor, 0.5), 8.0)
+    return base * factor, factor
+
+
 def main() -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument("--budget", type=float, default=0.3,
@@ -257,6 +289,16 @@ def main() -> int:
     ap.add_argument("--rules", default="rules")
     ap.add_argument("--update-baseline", action="store_true")
     args = ap.parse_args()
+
+    reference = None
+    if BASELINE.exists():
+        reference = json.loads(BASELINE.read_text(encoding="utf-8")).get(
+            "calibration_reference_seconds"
+        )
+    budget, factor = scaled_budget(args.budget, reference)
+    if reference:
+        print(f"machine calibration factor {factor:.2f}x -> budget {budget:.3f}s")
+    args.budget = budget
 
     items = collect(Path(args.rules))
     if not items:
@@ -281,6 +323,7 @@ def main() -> int:
                                 "--update-baseline. Shrinking this file is the goal; "
                                 "growing it needs a reason in the commit message.",
                     "budget_seconds": args.budget,
+                    "calibration_reference_seconds": round(calibrate(), 6),
                     "known": {k: ("hang" if v == float("inf") else v)
                               for k, v in sorted(over.items())},
                 },

--- a/scripts/gate-redos.py
+++ b/scripts/gate-redos.py
@@ -1,0 +1,317 @@
+#!/usr/bin/env python3
+"""Corpus-wide ReDoS gate: no rule may blow up on adversarial input.
+
+WHY THIS EXISTS ALONGSIDE gate-rule-latency.ts
+
+The latency gate measures what a rule costs on the eval corpus, relative to a
+pinned anchor cohort. That catches a rule which is expensive on ordinary text.
+It is structurally blind to catastrophic backtracking, because a ReDoS pattern
+is fast on the corpus and only explodes on a string shaped like its own
+grammar. ATR-2026-01005 sat in the enforce lane at maturity: stable, cost
+nothing measurable on the corpus, and took over four minutes on 129 bytes.
+
+A NOTE FOR WHOEVER FIXES A RULE THIS GATE FLAGS
+
+Re-run the gate on the WHOLE corpus, not just the rule you touched, and keep
+the input that motivated the fix. Inputs are derived from a pattern own parse
+tree, so editing the pattern also changes what this gate aims at it: a rewrite
+can pass by moving out of its own generator sights while still hanging on the
+string that started the investigation. scripts/verify_rule_redos.py replays
+old-pattern-derived inputs against the new pattern for exactly this reason.
+
+HOW THE INPUTS ARE BUILT
+
+Generic adversarial strings are not enough and it is worth being precise about
+why: a run of 'a', a run of spaces and a base64 blob together find three of the
+nine patterns this gate was written after, and miss the exponential one
+entirely. So each input is generated from the pattern's OWN parse tree, with
+quantifiers pumped past their minimum, then truncated at the tail so the match
+must fail after doing maximal work.
+
+WHY THE STANDARD LIBRARY AND NOT THE regex MODULE
+
+`regex` accepts timeout= and would make this script far simpler. It also
+optimises away several of the shapes being hunted -- ATR-2026-01005 returns in
+microseconds under `regex` and in four minutes under `re`. A gate built on
+`regex` would report a clean corpus while every Python consumer using the
+standard library hangs. So `re` it is, and since a `re` match cannot be
+interrupted, the work runs in a child process the parent kills.
+
+TIMEOUTS ARE BISECTED, NOT ATTRIBUTED BY GUESS
+
+Conditions run in chunks for speed. When a chunk times out, the parent halves
+it and re-runs both halves, so the report names the one condition responsible
+rather than the chunk it was in.
+
+BASELINE
+
+Known debt lives in data/redos-baseline.json. The gate fails on anything not
+already there, so existing slow patterns stay visible without blocking every
+build, and accepting a new one is a deliberate --update-baseline commit.
+
+Usage:
+    python3 scripts/gate-redos.py [--budget 0.3] [--update-baseline] [--rules DIR]
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import multiprocessing as mp
+import re
+import sys
+import time
+from pathlib import Path
+
+try:
+    import re._parser as sre_parse
+    import re._constants as sre
+except ImportError:                        # pragma: no cover - older runtimes
+    import sre_parse, sre_constants as sre
+
+import yaml
+
+BASELINE = Path("data/redos-baseline.json")
+PUMPS = (2, 3, 4, 8, 16)
+CHUNK = 40
+GENERIC = (
+    "a" * 3000,
+    " " * 3000,
+    "-" * 3000,
+    "=" * 3000,
+    "*" * 3000,
+    "{" * 2000,
+    '"' * 2000,
+    ">" * 2000,
+    "\n" * 2000,
+    "QUJDRGVmZ2hpams" * 200,
+)
+
+
+def _negated_pick(items):
+    """Pick a character a negated class EXCLUDES-complement shares with its
+    neighbours.
+
+    Emitting a plain "a" for every negated class never places the interesting
+    character inside the filler, and that is precisely where this bug class
+    lives: ATR-2026-00091 is cubic on a run of "{" because its filler was
+    [^}], which matches "{" and therefore competes with the literal brace next
+    to it. An earlier version of this generator reported that rule clean.
+    """
+    excluded = set()
+    for op, av in items:
+        if op is sre.LITERAL:
+            excluded.add(chr(av))
+        elif op is sre.RANGE:
+            excluded.update(chr(c) for c in range(av[0], av[1] + 1))
+    for candidate in "{}\"'<>[]()|:;,.= \t":
+        if candidate not in excluded:
+            return candidate
+    return "a"
+
+
+def _member(items):
+    for op, av in items:
+        if op is sre.LITERAL:
+            return chr(av)
+        if op is sre.RANGE:
+            return chr(av[0])
+        if op is sre.CATEGORY:
+            return {sre.CATEGORY_DIGIT: "5", sre.CATEGORY_WORD: "a",
+                    sre.CATEGORY_SPACE: " "}.get(av, "a")
+    return "a"
+
+
+def generate(node, k, depth=0):
+    """A string the pattern almost matches, with quantifiers pumped to k."""
+    if depth > 12:
+        return ""
+    out = []
+    for op, av in node:
+        if op is sre.LITERAL:
+            out.append(chr(av))
+        elif op is sre.NOT_LITERAL:
+            out.append("a" if chr(av) != "a" else "b")
+        elif op is sre.ANY:
+            out.append("a")
+        elif op is sre.IN:
+            if av and av[0][0] is sre.NEGATE:
+                out.append(_negated_pick(av[1:]))
+            else:
+                out.append(_member(av))
+        elif op in (sre.MAX_REPEAT, sre.MIN_REPEAT):
+            lo, hi, sub = av
+            reps = max(lo, k)
+            if hi != sre.MAXREPEAT:
+                reps = min(reps, hi)
+            out.append(generate(sub, k, depth + 1) * min(reps, 40))
+        elif op is sre.SUBPATTERN:
+            out.append(generate(av[-1], k, depth + 1))
+        elif op is sre.BRANCH:
+            branches = av[1]
+            out.append(generate(branches[0], k, depth + 1) if branches else "")
+        elif op is sre.ATOMIC_GROUP:
+            out.append(generate(av, k, depth + 1))
+    return "".join(out)
+
+
+def collect(rules_dir: Path):
+    """Every regex condition in the corpus, as (key, pattern, flags)."""
+    out = []
+    for path in sorted(rules_dir.rglob("*.yaml")):
+        try:
+            rule = yaml.safe_load(path.read_text(encoding="utf-8"))
+        except Exception:
+            continue
+        if not isinstance(rule, dict):
+            continue
+        rid = rule.get("id")
+        det = rule.get("detection") or {}
+        for i, cond in enumerate(det.get("conditions") or []):
+            if cond.get("operator") != "regex" or not cond.get("value"):
+                continue
+            flags = 0 if cond.get("case_sensitive") else re.IGNORECASE
+            out.append((f"{rid}#{i}", cond["value"], flags))
+    return out
+
+
+def _worst(pattern, flags, budget):
+    """Slowest single search over this pattern's adversarial inputs."""
+    try:
+        rx = re.compile(pattern, flags)
+        ast = sre_parse.parse(pattern, flags)
+    except re.error:
+        return 0.0
+    texts = list(GENERIC)
+    for k in PUMPS:
+        base = generate(ast, k)
+        if not base:
+            continue
+        texts.append(base[:-1] + "\x00")
+        texts.append(base + "\x00")
+        # A literal prefix followed by a long homogeneous run. Several patterns
+        # only reach their ambiguity after their own literal anchor -- for
+        # ATR-2026-00146 the blowup needs "env" and then a whitespace run, and
+        # neither a bare run of spaces nor the pumped string alone gets there.
+        for filler in (" ", "a", "\t", "."):
+            texts.append(base[: max(1, len(base) // 2)] + filler * 1500 + "\x00")
+    worst = 0.0
+    for text in texts:
+        started = time.monotonic()
+        rx.search(text)
+        elapsed = time.monotonic() - started
+        if elapsed > worst:
+            worst = elapsed
+        if worst > budget:
+            break
+    return worst
+
+
+def _run_chunk(items, budget, out_q):
+    for key, pattern, flags in items:
+        out_q.put((key, round(_worst(pattern, flags, budget), 4)))
+
+
+def measure(items, budget, wall):
+    """Time every condition, killing and bisecting any chunk that hangs."""
+    results = {}
+    pending = [items[i:i + CHUNK] for i in range(0, len(items), CHUNK)]
+    hung = []
+    while pending:
+        chunk = pending.pop(0)
+        q = mp.Queue()
+        proc = mp.Process(target=_run_chunk, args=(chunk, budget, q))
+        proc.start()
+        deadline = time.monotonic() + wall * max(1, len(chunk))
+        got = {}
+        while time.monotonic() < deadline:
+            try:
+                key, worst = q.get(timeout=0.2)
+                got[key] = worst
+            except Exception:
+                if not proc.is_alive():
+                    break
+        proc.join(timeout=0.1)
+        if proc.is_alive():
+            proc.terminate()
+            proc.join()
+        results.update(got)
+        missing = [it for it in chunk if it[0] not in got]
+        if missing:
+            if len(missing) == 1:
+                hung.append(missing[0][0])
+                results[missing[0][0]] = float("inf")
+            else:
+                half = len(missing) // 2
+                pending.insert(0, missing[half:])
+                pending.insert(0, missing[:half])
+    return results, hung
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--budget", type=float, default=0.3,
+                    help="seconds any single pattern may take on any input")
+    ap.add_argument("--wall", type=float, default=2.0,
+                    help="seconds of wall clock allowed per condition before the "
+                         "child is killed and the chunk bisected")
+    ap.add_argument("--rules", default="rules")
+    ap.add_argument("--update-baseline", action="store_true")
+    args = ap.parse_args()
+
+    items = collect(Path(args.rules))
+    if not items:
+        print(f"no regex conditions under {args.rules}", file=sys.stderr)
+        return 2
+    print(f"scanning {len(items)} regex conditions, budget {args.budget}s each")
+
+    results, hung = measure(items, args.budget, args.wall)
+    over = {k: v for k, v in results.items() if v > args.budget}
+
+    baseline = {}
+    if BASELINE.exists():
+        baseline = json.loads(BASELINE.read_text(encoding="utf-8")).get("known", {})
+
+    if args.update_baseline:
+        BASELINE.parent.mkdir(parents=True, exist_ok=True)
+        BASELINE.write_text(
+            json.dumps(
+                {
+                    "_comment": "Conditions known to backtrack badly on adversarial "
+                                "input. Produced by scripts/gate-redos.py "
+                                "--update-baseline. Shrinking this file is the goal; "
+                                "growing it needs a reason in the commit message.",
+                    "budget_seconds": args.budget,
+                    "known": {k: ("hang" if v == float("inf") else v)
+                              for k, v in sorted(over.items())},
+                },
+                indent=2,
+            ) + "\n",
+            encoding="utf-8",
+        )
+        print(f"baseline written: {len(over)} known slow conditions")
+        return 0
+
+    fresh = sorted(k for k in over if k not in baseline)
+    fixed = sorted(k for k in baseline if k not in over)
+
+    for k in sorted(over):
+        mark = "NEW " if k in fresh else "known"
+        worst = results[k]
+        shown = "hang" if worst == float("inf") else f"{worst:.2f}s"
+        print(f"  {mark} {k:24} {shown}")
+    if hung:
+        print(f"\n{len(hung)} condition(s) never returned and were killed")
+    if fixed:
+        print(f"\n{len(fixed)} condition(s) improved and can leave the baseline: "
+              + ", ".join(fixed))
+
+    if fresh:
+        print(f"\nFAIL: {len(fresh)} condition(s) backtrack catastrophically and are "
+              f"not in {BASELINE}")
+        return 1
+    print(f"\nOK: {len(over)} known, 0 new")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify_rule_redos.py
+++ b/scripts/verify_rule_redos.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+"""Verify one rule after a regex change: behaviour preserved, blowup gone.
+
+Three checks, all of which must pass:
+
+  1. The rule's own test cases still hold -- every true_positive still fires
+     and every true_negative still does not.
+  2. No pattern in the rule blows up on adversarial input. Inputs are
+     generated from each pattern's own AST with quantifiers pumped, which is
+     the only way to reach patterns whose blowup needs their own grammar --
+     a run of 'a' never finds ATR-2026-01005.
+  3. The rule flags no more of the benign corpus than it did before.
+
+Run:  python3 scripts/verify_rule_redos.py rules/.../ATR-2026-01005-*.yaml [benign_dir]
+"""
+from __future__ import annotations
+
+import json
+import re
+import sys
+import time
+from pathlib import Path
+
+try:
+    import re._parser as sre_parse
+    import re._constants as sre
+except ImportError:                       # pragma: no cover
+    import sre_parse, sre_constants as sre
+
+import yaml
+
+PUMPS = (2, 3, 4, 8, 16)
+BUDGET = 0.30          # seconds any single pattern may take on any input
+
+
+def _from_in(items):
+    for op, av in items:
+        if op is sre.LITERAL:
+            return chr(av)
+        if op is sre.RANGE:
+            return chr(av[0])
+        if op is sre.CATEGORY:
+            return {sre.CATEGORY_DIGIT: "5", sre.CATEGORY_WORD: "a",
+                    sre.CATEGORY_SPACE: " "}.get(av, "a")
+    return "a"
+
+
+def generate(node, k, depth=0):
+    if depth > 12:
+        return ""
+    out = []
+    for op, av in node:
+        if op is sre.LITERAL:
+            out.append(chr(av))
+        elif op is sre.NOT_LITERAL:
+            out.append("a" if chr(av) != "a" else "b")
+        elif op is sre.ANY:
+            out.append("a")
+        elif op is sre.IN:
+            out.append("a" if (av and av[0][0] is sre.NEGATE) else _from_in(av))
+        elif op in (sre.MAX_REPEAT, sre.MIN_REPEAT):
+            lo, hi, sub = av
+            reps = max(lo, k)
+            if hi != sre.MAXREPEAT:
+                reps = min(reps, hi)
+            out.append(generate(sub, k, depth + 1) * min(reps, 40))
+        elif op is sre.SUBPATTERN:
+            out.append(generate(av[-1], k, depth + 1))
+        elif op is sre.BRANCH:
+            branches = av[1]
+            out.append(generate(branches[0], k, depth + 1) if branches else "")
+        elif op is sre.ATOMIC_GROUP:
+            out.append(generate(av, k, depth + 1))
+    return "".join(out)
+
+
+def conditions(rule):
+    det = rule.get("detection") or {}
+    return [c for c in (det.get("conditions") or []) if c.get("operator") == "regex"]
+
+
+def fires(rule, text):
+    """Mirror the engine's any/all logic over this rule's regex conditions."""
+    conds = conditions(rule)
+    results = []
+    for c in conds:
+        try:
+            rx = re.compile(c["value"], 0 if c.get("case_sensitive") else re.IGNORECASE)
+        except re.error:
+            results.append(False)
+            continue
+        results.append(rx.search(text) is not None)
+    logic = str((rule.get("detection") or {}).get("condition", "any"))
+    return all(results) if logic == "all" else any(results)
+
+
+def check_test_cases(rule):
+    tc = rule.get("test_cases") or {}
+    problems = []
+    for label, expected in (("true_positives", True), ("true_negatives", False)):
+        for case in tc.get(label) or []:
+            text = case if isinstance(case, str) else (
+                case.get("input") or case.get("content") or case.get("text") or ""
+            )
+            if not text:
+                continue
+            if fires(rule, text) is not expected:
+                problems.append(f"{label}: {text[:70]!r}")
+    return problems
+
+
+def check_blowup(rule):
+    slow = []
+    for i, c in enumerate(conditions(rule)):
+        pattern = c["value"]
+        flags = 0 if c.get("case_sensitive") else re.IGNORECASE
+        try:
+            rx = re.compile(pattern, flags)
+            ast = sre_parse.parse(pattern, flags)
+        except re.error as exc:
+            slow.append(f"#{i} does not compile: {exc}")
+            continue
+        worst = 0.0
+        for k in PUMPS:
+            base = generate(ast, k)
+            if not base:
+                continue
+            for text in (base[:-1] + "\x00", base + "\x00", ("a" * 3000), (" " * 3000)):
+                started = time.monotonic()
+                rx.search(text)
+                elapsed = time.monotonic() - started
+                worst = max(worst, elapsed)
+                if elapsed > BUDGET:
+                    slow.append(f"#{i} {elapsed:.2f}s on {len(text)} chars (k={k})")
+                    break
+            if worst > BUDGET:
+                break
+    return slow
+
+
+def check_benign(rule, benign_dir):
+    if not benign_dir:
+        return None
+    paths = sorted(Path(benign_dir).glob("*.md"))
+    if not paths:
+        return None
+    return sum(
+        1 for p in paths
+        if fires(rule, p.read_text(encoding="utf-8", errors="replace"))
+    )
+
+
+def main() -> int:
+    if len(sys.argv) < 2:
+        print(__doc__)
+        return 2
+    path = Path(sys.argv[1])
+    benign = sys.argv[2] if len(sys.argv) > 2 else None
+    rule = yaml.safe_load(path.read_text(encoding="utf-8"))
+
+    print(f"rule      : {rule.get('id')}  maturity={rule.get('maturity')}")
+    print(f"conditions: {len(conditions(rule))} regex")
+
+    tc = check_test_cases(rule)
+    print(f"test cases: {'PASS' if not tc else 'FAIL'}")
+    for p in tc:
+        print(f"    {p}")
+
+    slow = check_blowup(rule)
+    print(f"blowup    : {'PASS' if not slow else 'FAIL'} (budget {BUDGET}s per pattern)")
+    for s in slow:
+        print(f"    {s}")
+
+    flagged = check_benign(rule, benign)
+    if flagged is not None:
+        print(f"benign    : flags {flagged} documents")
+
+    return 1 if (tc or slow) else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What this is

`ATR-2026-01005` is `maturity: stable` — the enforce lane, automatic blocking, no human in the loop — and takes **249 seconds on a 129-byte string** under Python `re`. A `re` match cannot be interrupted once started, so any consumer evaluating attacker-supplied text with that rule loaded can be stopped by 129 bytes. Eight more rules are polynomial on inputs of the same kind.

All of them share one shape: a filler that can also match the separator that follows it, sitting inside or beside a repetition, so the engine enumerates every way to split the input.

**Eight rules are fixed here. `ATR-2026-01005` is not — see the decision it needs, below.**

## Why the existing gate did not catch this

`gate-rule-latency.ts` measures what a rule costs on the eval corpus, relative to a pinned anchor cohort. That catches a rule which is expensive on ordinary text. It is structurally blind to catastrophic backtracking, because a ReDoS pattern is cheap on ordinary text and only explodes on a string shaped like its own grammar. `ATR-2026-01005` cost nothing measurable on the corpus.

`scripts/gate-redos.py` is the new gate. Four decisions in it are load-bearing:

- **Inputs come from each pattern's own parse tree**, quantifiers pumped, tail broken. Generic strings are not enough: a run of `a`, a run of spaces and a base64 blob together find three of these and miss the exponential one entirely.
- **It uses the standard library, not the `regex` module.** `regex` accepts `timeout=` and would make the script far simpler, but it also optimises several of these shapes away — `ATR-2026-01005` returns in microseconds under `regex`. A gate built on it would report a clean corpus while every consumer using `re` hangs.
- **Timeouts are bisected, not guessed.** Conditions run in chunks; a chunk that hangs is halved and re-run, so the report names the condition rather than the chunk.
- **The budget is calibrated on the machine that runs it.** The first version of this gate failed CI with six conditions at 0.31–0.45s that measure 0.15–0.25s locally — an absolute millisecond threshold inside the runner's noise band, the same failure `gate-rule-latency.ts` was rewritten to escape. It now times a fixed reference workload in the same process and scales the budget by the ratio, clamped to [0.5×, 8×].

## Verification

Per rule, all of which hold:

| check | result |
|---|---|
| rule's own test cases | pass, unchanged |
| benign corpus, 432 documents | flag count unchanged |
| malicious corpus, 32 documents | flag count unchanged |
| 120,000 fuzz strings per rule, old vs new | 0 divergences |
| adversarial timing, inputs derived from the **old** pattern too | all under 0.03s against a 0.3s budget |
| `data/benign-fp-measurement.json`, re-measured over 12,060 samples | **every fp_count identical** — 27→27, 3→3, 2→2, 4→4, rest 0→0 |

Two of those rows deserve a note.

Inputs are derived from a pattern's own parse tree, so editing the pattern also changes what the generator aims at it — a rewrite can pass by moving out of its own sights while still hanging on the string that started the investigation. `scripts/verify_rule_redos.py` replays old-pattern-derived inputs against the new pattern for exactly that reason.

The re-measurement was not optional: the action-eligibility gate keys a rule's permitted response action to a measurement of that exact detection, so editing eight patterns invalidated eight fingerprints. Re-measuring produced identical false-positive counts across all eight, which is the strongest behaviour-preservation evidence available here — the fingerprints moved, the false positives did not.

Gate on this branch's parent: `FAIL: 9 conditions`. Gate on this branch: those are gone.

## The decision this PR does not make

`ATR-2026-01005` sits between two of this repo's own gates and cannot satisfy both:

- Removing the exponential blowup requires a lookaround — a tempered dot, so the filler cannot cross the `A:` delimiter.
- `Rule regexes must stay RE2 portable` rejects lookarounds, and says so plainly: downstream consumers compile these with RE2 and will drop the rule outright.

Four RE2-clean rewrites were measured and all remain exponential: excluding the colon from the filler, ending the filler on a non-space, both together, and tightening the bound from 200 to 60 (7.1s at pump k=8, unbounded at k=16). So the rule is reverted to its original pattern and recorded in `data/redos-baseline.json`, and the choice is left open rather than made quietly:

1. accept RE2 non-portability for this rule, and take the ReDoS fix;
2. redesign the rule so neither cost applies;
3. demote it out of `maturity: stable` while it carries an exponential pattern in the enforce lane.

Trading a denial of service for silent non-coverage at every RE2 consumer is not a call that belongs inside a commit labelled as an improvement.

## Remaining debt

`data/redos-baseline.json` records **eleven** conditions that are still slow, worst 8.8s: `ATR-2026-00163#4`, `00220#2`, `00272#0`, `00285#0`, `00303#2`, `00337#4`, `00451#1`, `00707#0`, `01005#0`, `02372#0`, `02372#1`. They are baselined rather than fixed here so the gate can be enforced now and the debt stays visible. Shrinking that file is the follow-up.
