### PR TITLE
fix(avid): enumerate all reports beyond API limit

### DIFF
--- a/scripts/sync-avid-db.ts
+++ b/scripts/sync-avid-db.ts
@@ -279,19 +279,42 @@ _avid_sync:
 
 // --- main -----------------------------------------------------------------
 
-async function listReports(year: string): Promise<string[]> {
-  // GitHub Contents API returns max 1000 entries per page. AVID 2026
-  // currently has 1000 -- if it grows past that we'll need to paginate.
-  const url = `https://api.github.com/repos/${AVID_OWNER}/${AVID_REPO}/contents/reports/${year}`;
+interface GitTreeResponse {
+  truncated: boolean;
+  tree: Array<{ path: string; type: string }>;
+}
+
+export function reportNamesForYear(response: GitTreeResponse, year: string): string[] {
+  if (response.truncated) {
+    throw new Error('AVID Git tree response was truncated');
+  }
+  const prefix = `reports/${year}/`;
+  return response.tree
+    .filter((entry) => entry.type === 'blob' && entry.path.startsWith(prefix))
+    .map((entry) => entry.path.slice(prefix.length))
+    .filter((name) => name.endsWith('.json') && !name.includes('/'))
+    .sort();
+}
+
+let reportTreePromise: Promise<GitTreeResponse> | undefined;
+
+async function loadReportTree(): Promise<GitTreeResponse> {
+  if (reportTreePromise) return reportTreePromise;
+  const url = `https://api.github.com/repos/${AVID_OWNER}/${AVID_REPO}/git/trees/main?recursive=1`;
   const ghToken = process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
   const headers: Record<string, string> = {
     Accept: 'application/vnd.github+json',
   };
   if (ghToken) headers.Authorization = `Bearer ${ghToken}`;
-  const res = await fetch(url, { headers });
-  if (!res.ok) throw new Error(`AVID listing failed for ${year}: ${res.status}`);
-  const entries = (await res.json()) as Array<{ name: string; type: string; download_url: string }>;
-  return entries.filter((e) => e.type === 'file' && e.name.endsWith('.json')).map((e) => e.name);
+  reportTreePromise = fetch(url, { headers }).then(async (res) => {
+    if (!res.ok) throw new Error(`AVID tree listing failed: ${res.status}`);
+    return (await res.json()) as GitTreeResponse;
+  });
+  return reportTreePromise;
+}
+
+async function listReports(year: string): Promise<string[]> {
+  return reportNamesForYear(await loadReportTree(), year);
 }
 
 async function fetchReport(year: string, name: string): Promise<AvidReport> {
@@ -388,7 +411,10 @@ async function main() {
   console.log(`${WRITE ? 'written' : 'would-write'}: ${written}`);
 }
 
-main().catch((err) => {
-  console.error(err);
-  process.exit(1);
-});
+const isMainModule = import.meta.url === `file://${process.argv[1]}`;
+if (isMainModule) {
+  main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/tests/sync-avid-db.test.ts
+++ b/tests/sync-avid-db.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { reportNamesForYear } from '../scripts/sync-avid-db.js';
+
+describe('reportNamesForYear', () => {
+  it('returns every report when a year contains more than 1,000 files', () => {
+    const reports = Array.from({ length: 1005 }, (_, index) => ({
+      path: `reports/2026/AVID-2026-R${String(index + 1).padStart(4, '0')}.json`,
+      type: 'blob',
+    }));
+    const tree = [
+      ...reports,
+      { path: 'reports/2025/AVID-2025-R0001.json', type: 'blob' },
+      { path: 'reports/2026/README.md', type: 'blob' },
+      { path: 'reports/2026/archive/old.json', type: 'blob' },
+    ];
+
+    const names = reportNamesForYear({ truncated: false, tree }, '2026');
+
+    expect(names).toHaveLength(1005);
+    expect(names[0]).toBe('AVID-2026-R0001.json');
+    expect(names.at(-1)).toBe('AVID-2026-R1005.json');
+  });
+
+  it('rejects a truncated tree instead of silently missing reports', () => {
+    expect(() => reportNamesForYear({ truncated: true, tree: [] }, '2026')).toThrow(
+      'AVID Git tree response was truncated',
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- replace the GitHub Contents API directory listing, capped at 1,000 entries, with one recursive Git tree request
- filter the complete tree by AVID report year and reject truncated responses instead of silently missing reports
- add regression coverage with 1,005 reports plus unrelated paths

AVID currently has 1,712 reports under `reports/2026`, while the previous listing returned only 1,000. This PR addresses that enumeration gap only.

Refs #379. The upstream AVID feed has also stopped publishing new report commits, so this does not claim to resolve or close the freshness issue.

## Verification

- `npm test -- tests/sync-avid-db.test.ts` (2 passed)
- `npm run typecheck:scripts`
- `npm run build`
- `npx tsx scripts/sync-avid-db.ts --year 2026 --limit 1` (dry-run listed 1,712 reports and wrote nothing)
- `git diff --check`