### PR TITLE
chore(author-semantic): surface API-exhausted runs as a warning, not silent green

### DIFF
--- a/scripts/author-semantic-rules.ts
+++ b/scripts/author-semantic-rules.ts
@@ -760,6 +760,31 @@ async function main(): Promise<void> {
     });
   }
 
+  // Visibility for a silent-green run: per-cluster LLM failures are caught above
+  // (non-fatal by design — the T2 lane must not red the CI on a transient API
+  // blip), but that means an exhausted ANTHROPIC_API_KEY account produces zero
+  // rules while every step stays green and the only trace is buried in the JSON.
+  // Surface it as a GitHub warning annotation (yellow, non-failing) so the
+  // rule-authoring line being starved is visible in the run summary. Classify
+  // API-availability errors (credit/quota/rate-limit/overload) distinctly, since
+  // those are an account/billing signal rather than a code bug.
+  if (summary.errors > 0) {
+    const reasons = summary.results
+      .filter((r) => r.status === "error")
+      .map((r) => String(r.reason ?? ""));
+    const apiUnavailable = reasons.some((r) =>
+      /credit balance is too low|rate.?limit|\bquota\b|overloaded|insufficient|billing|\b(429|529)\b/i.test(r),
+    );
+    const kind = apiUnavailable
+      ? "Anthropic API unavailable (credit/quota/rate-limit/overload)"
+      : "authoring errors";
+    console.log(
+      `::warning::author-semantic-rules: ${summary.errors} cluster(s) errored (${kind}); ` +
+        `${summary.promoted} rule(s) produced this run. CI stays green (non-fatal by design), but ` +
+        `the T2 rule-authoring line is degraded — check the ANTHROPIC_API_KEY account balance if this recurs.`,
+    );
+  }
+
   if (REPORT_PATH) {
     const abs = resolve(REPO_ROOT, REPORT_PATH);
     mkdirSync(dirname(abs), { recursive: true });


### PR DESCRIPTION
## What

`scripts/author-semantic-rules.ts` now emits a GitHub `::warning::` annotation when one or more clusters errored during authoring, so a degraded run is visible in the CI run summary. API-availability errors (credit balance / quota / rate-limit / overload) are classified distinctly from code errors.

## Why

The T2 lane already treats per-cluster LLM failures as non-fatal — they are caught, counted, and the script exits 0 so a transient API blip never reds the CI. That is the right call. The side effect is that an **exhausted `ANTHROPIC_API_KEY` account is a silent no-op**: zero rules are authored, every step stays green, and the only trace is buried in the summary JSON. The rule-authoring line can starve unnoticed — which is what happened on the daily runs from 2026-07-14 to 2026-07-27 (all failing on `credit balance is too low`), before the balance was topped up.

This makes that state visible without failing the build: a yellow warning in the run summary that names the likely cause and points at the account balance.

## Scope

- No change to exit codes or the non-fatal behaviour.
- Additive: one `::warning::` line after the authoring loop when `summary.errors > 0`.
- `npm run build` (tsc) passes.
